### PR TITLE
set default ssl mode to disable

### DIFF
--- a/frontend/app/connections/[id]/components/PostgresForm.tsx
+++ b/frontend/app/connections/[id]/components/PostgresForm.tsx
@@ -7,9 +7,17 @@ import {
   FormDescription,
   FormField,
   FormItem,
+  FormLabel,
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   CheckConnectionConfigResponse,
   ConnectionConfig,
@@ -18,6 +26,7 @@ import {
   UpdateConnectionRequest,
   UpdateConnectionResponse,
 } from '@/neosync-api-client/mgmt/v1alpha1/connection_pb';
+import { SSL_MODES } from '@/yup-validations/connections';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ExclamationTriangleIcon, RocketIcon } from '@radix-ui/react-icons';
 import { ReactElement, useState } from 'react';
@@ -162,10 +171,28 @@ export default function PostgresForm(props: Props) {
           name="db.sslMode"
           render={({ field }) => (
             <FormItem>
+              <FormLabel>SSL Mode</FormLabel>
               <FormControl>
-                <Input placeholder="ssl mode" {...field} />
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SSL_MODES.map((mode) => (
+                      <SelectItem
+                        className="cursor-pointer"
+                        key={mode}
+                        value={mode}
+                      >
+                        {mode}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </FormControl>
-              <FormDescription>SSL Mode</FormDescription>
+              <FormDescription>
+                The location of the source data set.
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/frontend/app/new/connection/postgres/PostgresForm.tsx
+++ b/frontend/app/new/connection/postgres/PostgresForm.tsx
@@ -8,9 +8,17 @@ import {
   FormDescription,
   FormField,
   FormItem,
+  FormLabel,
   FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import {
+  Select,
+  SelectContent,
+  SelectItem,
+  SelectTrigger,
+  SelectValue,
+} from '@/components/ui/select';
 import {
   CheckConnectionConfigResponse,
   ConnectionConfig,
@@ -19,6 +27,7 @@ import {
   PostgresConnection,
   PostgresConnectionConfig,
 } from '@/neosync-api-client/mgmt/v1alpha1/connection_pb';
+import { SSL_MODES } from '@/yup-validations/connections';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { ExclamationTriangleIcon, RocketIcon } from '@radix-ui/react-icons';
 import { useRouter } from 'next/navigation';
@@ -53,6 +62,7 @@ export default function PostgresForm() {
         user: 'postgres',
         pass: 'postgres',
         port: 5432,
+        sslMode: 'disable',
       },
     },
   });
@@ -174,10 +184,28 @@ export default function PostgresForm() {
           name="db.sslMode"
           render={({ field }) => (
             <FormItem>
+              <FormLabel>SSL Mode</FormLabel>
               <FormControl>
-                <Input placeholder="ssl mode" {...field} />
+                <Select onValueChange={field.onChange} value={field.value}>
+                  <SelectTrigger>
+                    <SelectValue />
+                  </SelectTrigger>
+                  <SelectContent>
+                    {SSL_MODES.map((mode) => (
+                      <SelectItem
+                        className="cursor-pointer"
+                        key={mode}
+                        value={mode}
+                      >
+                        {mode}
+                      </SelectItem>
+                    ))}
+                  </SelectContent>
+                </Select>
               </FormControl>
-              <FormDescription>SSL Mode</FormDescription>
+              <FormDescription>
+                The location of the source data set.
+              </FormDescription>
               <FormMessage />
             </FormItem>
           )}

--- a/frontend/yup-validations/connections.ts
+++ b/frontend/yup-validations/connections.ts
@@ -28,3 +28,12 @@ export const EXISTING_POSTGRES_CONNECTION = Yup.object({
 export type YupExistingPostgresConnection = Yup.InferType<
   typeof EXISTING_POSTGRES_CONNECTION
 >;
+
+export const SSL_MODES = [
+  'disable',
+  'allow',
+  'prefer',
+  'require',
+  'verify-ca',
+  'verify-full',
+];


### PR DESCRIPTION
from benthos docs
`Please note that the postgres driver enforces SSL by default, you can override this with the parameter sslmode=disable if required.`