### PR TITLE
Use devcontainers CLI directly

### DIFF
--- a/.github/workflows/devcontainer-release.yml
+++ b/.github/workflows/devcontainer-release.yml
@@ -16,28 +16,11 @@ jobs:
         id: checkout
         uses: actions/checkout@v4
 
-      - name: Docker meta
+      - name: Compute tag for devcontainer image
         id: meta
-        uses: docker/metadata-action@v5
-        with:
-          # list of Docker images to use as base name for tags
-          images: |
-            name=ghcr.io/${{ github.repository }}/devcontainer
-          # generate Docker tags based on the following events/attributes
-          tags: |
-            type=match,pattern=devcontainer/v(.*),group=1
-          sep-tags: ","
-
-      - name: Update Tags to Fit into devcontainers/cli format
-        id: dcmeta
         run: |
-          prefix="ghcr.io/${{ github.repository }}/devcontainer"
-          input_list="$DOCKER_METADATA_OUTPUT_TAGS"
-          delimiter=","
-
-          result_list=$(echo "$input_list" | sed "s|${prefix}:||g")
-
-          echo "tags=$result_list" >> "$GITHUB_OUTPUT"
+          tag="${GITHUB_REF#refs/tags/devcontainer/v}"
+          echo "tag=$tag" >> "$GITHUB_OUTPUT"
 
       - name: Set up Depot CLI
         uses: depot/setup-action@v1
@@ -55,14 +38,14 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Build and release devcontainer Multi-Platform
-        uses: devcontainers/ci@v0.3
+        run: |
+          npm install -g @devcontainers/cli
+          devcontainer build \
+            --workspace-folder .github \
+            --image-name ghcr.io/${{ github.repository }}/devcontainer:${{ steps.meta.outputs.tag }} \
+            --image-name ghcr.io/${{ github.repository }}/devcontainer:latest \
+            --platform linux/amd64,linux/arm64 \
+            --push
         env:
           # see: https://github.com/devcontainers/ci/issues/191#issuecomment-1603857155
           BUILDX_NO_DEFAULT_ATTESTATIONS: true
-        with:
-          imageName: ghcr.io/${{ github.repository }}/devcontainer
-          imageTag: ${{ steps.dcmeta.outputs.tags }}
-          # cacheFrom: ghcr.io/${{ github.repository }}/devcontainer
-          platform: linux/amd64,linux/arm64
-          push: always
-          subFolder: .github


### PR DESCRIPTION
The `devcontainers/ci` action assumes that multi-platform image builds aren't possible and injects an `--output` flag to download the image as a tarball instead. This isn't the case with Depot, as it can build multi-platform images directly.

This PR adapts the workflow to call the `devcontainer` CLI directly, so that the build and push can function as expected.