### PR TITLE
Nick/neos 396 destination connection options do not persist from new page

### DIFF
--- a/backend/gen/go/db/mock_DBTX.go
+++ b/backend/gen/go/db/mock_DBTX.go
@@ -28,6 +28,10 @@ func (_m *MockDBTX) EXPECT() *MockDBTX_Expecter {
 func (_m *MockDBTX) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
 	ret := _m.Called(ctx, tableName, columnNames, rowSrc)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CopyFrom")
+	}
+
 	var r0 int64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, pgx.Identifier, []string, pgx.CopyFromSource) (int64, error)); ok {
@@ -85,6 +89,10 @@ func (_m *MockDBTX) Exec(_a0 context.Context, _a1 string, _a2 ...interface{}) (p
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Exec")
+	}
 
 	var r0 pgconn.CommandTag
 	var r1 error
@@ -149,6 +157,10 @@ func (_m *MockDBTX) Query(_a0 context.Context, _a1 string, _a2 ...interface{}) (
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Query")
+	}
 
 	var r0 pgx.Rows
 	var r1 error
@@ -215,6 +227,10 @@ func (_m *MockDBTX) QueryRow(_a0 context.Context, _a1 string, _a2 ...interface{}
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryRow")
+	}
 
 	var r0 pgx.Row
 	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) pgx.Row); ok {

--- a/backend/gen/go/db/mock_Querier.go
+++ b/backend/gen/go/db/mock_Querier.go
@@ -28,6 +28,10 @@ func (_m *MockQuerier) EXPECT() *MockQuerier_Expecter {
 func (_m *MockQuerier) CreateAccountApiKey(ctx context.Context, db DBTX, arg CreateAccountApiKeyParams) (NeosyncApiAccountApiKey, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAccountApiKey")
+	}
+
 	var r0 NeosyncApiAccountApiKey
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, CreateAccountApiKeyParams) (NeosyncApiAccountApiKey, error)); ok {
@@ -81,6 +85,10 @@ func (_c *MockQuerier_CreateAccountApiKey_Call) RunAndReturn(run func(context.Co
 // CreateAccountInvite provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) CreateAccountInvite(ctx context.Context, db DBTX, arg CreateAccountInviteParams) (NeosyncApiAccountInvite, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAccountInvite")
+	}
 
 	var r0 NeosyncApiAccountInvite
 	var r1 error
@@ -136,6 +144,10 @@ func (_c *MockQuerier_CreateAccountInvite_Call) RunAndReturn(run func(context.Co
 func (_m *MockQuerier) CreateAccountUserAssociation(ctx context.Context, db DBTX, arg CreateAccountUserAssociationParams) (NeosyncApiAccountUserAssociation, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAccountUserAssociation")
+	}
+
 	var r0 NeosyncApiAccountUserAssociation
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, CreateAccountUserAssociationParams) (NeosyncApiAccountUserAssociation, error)); ok {
@@ -189,6 +201,10 @@ func (_c *MockQuerier_CreateAccountUserAssociation_Call) RunAndReturn(run func(c
 // CreateAuth0IdentityProviderAssociation provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) CreateAuth0IdentityProviderAssociation(ctx context.Context, db DBTX, arg CreateAuth0IdentityProviderAssociationParams) (NeosyncApiUserIdentityProviderAssociation, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateAuth0IdentityProviderAssociation")
+	}
 
 	var r0 NeosyncApiUserIdentityProviderAssociation
 	var r1 error
@@ -244,6 +260,10 @@ func (_c *MockQuerier_CreateAuth0IdentityProviderAssociation_Call) RunAndReturn(
 func (_m *MockQuerier) CreateConnection(ctx context.Context, db DBTX, arg CreateConnectionParams) (NeosyncApiConnection, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateConnection")
+	}
+
 	var r0 NeosyncApiConnection
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, CreateConnectionParams) (NeosyncApiConnection, error)); ok {
@@ -297,6 +317,10 @@ func (_c *MockQuerier_CreateConnection_Call) RunAndReturn(run func(context.Conte
 // CreateJob provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) CreateJob(ctx context.Context, db DBTX, arg CreateJobParams) (NeosyncApiJob, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateJob")
+	}
 
 	var r0 NeosyncApiJob
 	var r1 error
@@ -352,6 +376,10 @@ func (_c *MockQuerier_CreateJob_Call) RunAndReturn(run func(context.Context, DBT
 func (_m *MockQuerier) CreateJobConnectionDestination(ctx context.Context, db DBTX, arg CreateJobConnectionDestinationParams) (NeosyncApiJobDestinationConnectionAssociation, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateJobConnectionDestination")
+	}
+
 	var r0 NeosyncApiJobDestinationConnectionAssociation
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, CreateJobConnectionDestinationParams) (NeosyncApiJobDestinationConnectionAssociation, error)); ok {
@@ -405,6 +433,10 @@ func (_c *MockQuerier_CreateJobConnectionDestination_Call) RunAndReturn(run func
 // CreateJobConnectionDestinations provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) CreateJobConnectionDestinations(ctx context.Context, db DBTX, arg []CreateJobConnectionDestinationsParams) (int64, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateJobConnectionDestinations")
+	}
 
 	var r0 int64
 	var r1 error
@@ -460,6 +492,10 @@ func (_c *MockQuerier_CreateJobConnectionDestinations_Call) RunAndReturn(run fun
 func (_m *MockQuerier) CreateMachineUser(ctx context.Context, db DBTX) (NeosyncApiUser, error) {
 	ret := _m.Called(ctx, db)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateMachineUser")
+	}
+
 	var r0 NeosyncApiUser
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX) (NeosyncApiUser, error)); ok {
@@ -513,6 +549,10 @@ func (_c *MockQuerier_CreateMachineUser_Call) RunAndReturn(run func(context.Cont
 func (_m *MockQuerier) CreateNonMachineUser(ctx context.Context, db DBTX) (NeosyncApiUser, error) {
 	ret := _m.Called(ctx, db)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateNonMachineUser")
+	}
+
 	var r0 NeosyncApiUser
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX) (NeosyncApiUser, error)); ok {
@@ -565,6 +605,10 @@ func (_c *MockQuerier_CreateNonMachineUser_Call) RunAndReturn(run func(context.C
 // CreatePersonalAccount provides a mock function with given fields: ctx, db, accountSlug
 func (_m *MockQuerier) CreatePersonalAccount(ctx context.Context, db DBTX, accountSlug string) (NeosyncApiAccount, error) {
 	ret := _m.Called(ctx, db, accountSlug)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreatePersonalAccount")
+	}
 
 	var r0 NeosyncApiAccount
 	var r1 error
@@ -620,6 +664,10 @@ func (_c *MockQuerier_CreatePersonalAccount_Call) RunAndReturn(run func(context.
 func (_m *MockQuerier) CreateTeamAccount(ctx context.Context, db DBTX, accountSlug string) (NeosyncApiAccount, error) {
 	ret := _m.Called(ctx, db, accountSlug)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateTeamAccount")
+	}
+
 	var r0 NeosyncApiAccount
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, string) (NeosyncApiAccount, error)); ok {
@@ -673,6 +721,10 @@ func (_c *MockQuerier_CreateTeamAccount_Call) RunAndReturn(run func(context.Cont
 // CreateUserDefinedTransformer provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) CreateUserDefinedTransformer(ctx context.Context, db DBTX, arg CreateUserDefinedTransformerParams) (NeosyncApiTransformer, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateUserDefinedTransformer")
+	}
 
 	var r0 NeosyncApiTransformer
 	var r1 error
@@ -728,6 +780,10 @@ func (_c *MockQuerier_CreateUserDefinedTransformer_Call) RunAndReturn(run func(c
 func (_m *MockQuerier) DeleteJob(ctx context.Context, db DBTX, id pgtype.UUID) error {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteJob")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) error); ok {
 		r0 = rf(ctx, db, id)
@@ -772,6 +828,10 @@ func (_c *MockQuerier_DeleteJob_Call) RunAndReturn(run func(context.Context, DBT
 func (_m *MockQuerier) DeleteUserDefinedTransformerById(ctx context.Context, db DBTX, id pgtype.UUID) error {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteUserDefinedTransformerById")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) error); ok {
 		r0 = rf(ctx, db, id)
@@ -815,6 +875,10 @@ func (_c *MockQuerier_DeleteUserDefinedTransformerById_Call) RunAndReturn(run fu
 // GetAccount provides a mock function with given fields: ctx, db, id
 func (_m *MockQuerier) GetAccount(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiAccount, error) {
 	ret := _m.Called(ctx, db, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccount")
+	}
 
 	var r0 NeosyncApiAccount
 	var r1 error
@@ -870,6 +934,10 @@ func (_c *MockQuerier_GetAccount_Call) RunAndReturn(run func(context.Context, DB
 func (_m *MockQuerier) GetAccountApiKeyById(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiAccountApiKey, error) {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountApiKeyById")
+	}
+
 	var r0 NeosyncApiAccountApiKey
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (NeosyncApiAccountApiKey, error)); ok {
@@ -924,6 +992,10 @@ func (_c *MockQuerier_GetAccountApiKeyById_Call) RunAndReturn(run func(context.C
 func (_m *MockQuerier) GetAccountApiKeyByKeyValue(ctx context.Context, db DBTX, keyValue string) (NeosyncApiAccountApiKey, error) {
 	ret := _m.Called(ctx, db, keyValue)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountApiKeyByKeyValue")
+	}
+
 	var r0 NeosyncApiAccountApiKey
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, string) (NeosyncApiAccountApiKey, error)); ok {
@@ -977,6 +1049,10 @@ func (_c *MockQuerier_GetAccountApiKeyByKeyValue_Call) RunAndReturn(run func(con
 // GetAccountApiKeys provides a mock function with given fields: ctx, db, accountid
 func (_m *MockQuerier) GetAccountApiKeys(ctx context.Context, db DBTX, accountid pgtype.UUID) ([]NeosyncApiAccountApiKey, error) {
 	ret := _m.Called(ctx, db, accountid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountApiKeys")
+	}
 
 	var r0 []NeosyncApiAccountApiKey
 	var r1 error
@@ -1034,6 +1110,10 @@ func (_c *MockQuerier_GetAccountApiKeys_Call) RunAndReturn(run func(context.Cont
 func (_m *MockQuerier) GetAccountInvite(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiAccountInvite, error) {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountInvite")
+	}
+
 	var r0 NeosyncApiAccountInvite
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (NeosyncApiAccountInvite, error)); ok {
@@ -1087,6 +1167,10 @@ func (_c *MockQuerier_GetAccountInvite_Call) RunAndReturn(run func(context.Conte
 // GetAccountInviteByToken provides a mock function with given fields: ctx, db, token
 func (_m *MockQuerier) GetAccountInviteByToken(ctx context.Context, db DBTX, token string) (NeosyncApiAccountInvite, error) {
 	ret := _m.Called(ctx, db, token)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountInviteByToken")
+	}
 
 	var r0 NeosyncApiAccountInvite
 	var r1 error
@@ -1142,6 +1226,10 @@ func (_c *MockQuerier_GetAccountInviteByToken_Call) RunAndReturn(run func(contex
 func (_m *MockQuerier) GetAccountUserAssociation(ctx context.Context, db DBTX, arg GetAccountUserAssociationParams) (NeosyncApiAccountUserAssociation, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountUserAssociation")
+	}
+
 	var r0 NeosyncApiAccountUserAssociation
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, GetAccountUserAssociationParams) (NeosyncApiAccountUserAssociation, error)); ok {
@@ -1195,6 +1283,10 @@ func (_c *MockQuerier_GetAccountUserAssociation_Call) RunAndReturn(run func(cont
 // GetAccountsByUser provides a mock function with given fields: ctx, db, id
 func (_m *MockQuerier) GetAccountsByUser(ctx context.Context, db DBTX, id pgtype.UUID) ([]NeosyncApiAccount, error) {
 	ret := _m.Called(ctx, db, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountsByUser")
+	}
 
 	var r0 []NeosyncApiAccount
 	var r1 error
@@ -1252,6 +1344,10 @@ func (_c *MockQuerier_GetAccountsByUser_Call) RunAndReturn(run func(context.Cont
 func (_m *MockQuerier) GetActiveAccountInvites(ctx context.Context, db DBTX, accountid pgtype.UUID) ([]NeosyncApiAccountInvite, error) {
 	ret := _m.Called(ctx, db, accountid)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetActiveAccountInvites")
+	}
+
 	var r0 []NeosyncApiAccountInvite
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) ([]NeosyncApiAccountInvite, error)); ok {
@@ -1308,6 +1404,10 @@ func (_c *MockQuerier_GetActiveAccountInvites_Call) RunAndReturn(run func(contex
 func (_m *MockQuerier) GetAnonymousUser(ctx context.Context, db DBTX) (NeosyncApiUser, error) {
 	ret := _m.Called(ctx, db)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAnonymousUser")
+	}
+
 	var r0 NeosyncApiUser
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX) (NeosyncApiUser, error)); ok {
@@ -1360,6 +1460,10 @@ func (_c *MockQuerier_GetAnonymousUser_Call) RunAndReturn(run func(context.Conte
 // GetConnectionById provides a mock function with given fields: ctx, db, id
 func (_m *MockQuerier) GetConnectionById(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiConnection, error) {
 	ret := _m.Called(ctx, db, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConnectionById")
+	}
 
 	var r0 NeosyncApiConnection
 	var r1 error
@@ -1415,6 +1519,10 @@ func (_c *MockQuerier_GetConnectionById_Call) RunAndReturn(run func(context.Cont
 func (_m *MockQuerier) GetConnectionByNameAndAccount(ctx context.Context, db DBTX, arg GetConnectionByNameAndAccountParams) (NeosyncApiConnection, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetConnectionByNameAndAccount")
+	}
+
 	var r0 NeosyncApiConnection
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, GetConnectionByNameAndAccountParams) (NeosyncApiConnection, error)); ok {
@@ -1468,6 +1576,10 @@ func (_c *MockQuerier_GetConnectionByNameAndAccount_Call) RunAndReturn(run func(
 // GetConnectionsByAccount provides a mock function with given fields: ctx, db, accountid
 func (_m *MockQuerier) GetConnectionsByAccount(ctx context.Context, db DBTX, accountid pgtype.UUID) ([]NeosyncApiConnection, error) {
 	ret := _m.Called(ctx, db, accountid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConnectionsByAccount")
+	}
 
 	var r0 []NeosyncApiConnection
 	var r1 error
@@ -1525,6 +1637,10 @@ func (_c *MockQuerier_GetConnectionsByAccount_Call) RunAndReturn(run func(contex
 func (_m *MockQuerier) GetConnectionsByIds(ctx context.Context, db DBTX, dollar_1 []pgtype.UUID) ([]NeosyncApiConnection, error) {
 	ret := _m.Called(ctx, db, dollar_1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetConnectionsByIds")
+	}
+
 	var r0 []NeosyncApiConnection
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, []pgtype.UUID) ([]NeosyncApiConnection, error)); ok {
@@ -1581,6 +1697,10 @@ func (_c *MockQuerier_GetConnectionsByIds_Call) RunAndReturn(run func(context.Co
 func (_m *MockQuerier) GetJobById(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiJob, error) {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobById")
+	}
+
 	var r0 NeosyncApiJob
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (NeosyncApiJob, error)); ok {
@@ -1634,6 +1754,10 @@ func (_c *MockQuerier_GetJobById_Call) RunAndReturn(run func(context.Context, DB
 // GetJobByNameAndAccount provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) GetJobByNameAndAccount(ctx context.Context, db DBTX, arg GetJobByNameAndAccountParams) (NeosyncApiJob, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobByNameAndAccount")
+	}
 
 	var r0 NeosyncApiJob
 	var r1 error
@@ -1689,6 +1813,10 @@ func (_c *MockQuerier_GetJobByNameAndAccount_Call) RunAndReturn(run func(context
 func (_m *MockQuerier) GetJobConnectionDestination(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiJobDestinationConnectionAssociation, error) {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobConnectionDestination")
+	}
+
 	var r0 NeosyncApiJobDestinationConnectionAssociation
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (NeosyncApiJobDestinationConnectionAssociation, error)); ok {
@@ -1742,6 +1870,10 @@ func (_c *MockQuerier_GetJobConnectionDestination_Call) RunAndReturn(run func(co
 // GetJobConnectionDestinations provides a mock function with given fields: ctx, db, id
 func (_m *MockQuerier) GetJobConnectionDestinations(ctx context.Context, db DBTX, id pgtype.UUID) ([]NeosyncApiJobDestinationConnectionAssociation, error) {
 	ret := _m.Called(ctx, db, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobConnectionDestinations")
+	}
 
 	var r0 []NeosyncApiJobDestinationConnectionAssociation
 	var r1 error
@@ -1799,6 +1931,10 @@ func (_c *MockQuerier_GetJobConnectionDestinations_Call) RunAndReturn(run func(c
 func (_m *MockQuerier) GetJobConnectionDestinationsByJobIds(ctx context.Context, db DBTX, jobids []pgtype.UUID) ([]NeosyncApiJobDestinationConnectionAssociation, error) {
 	ret := _m.Called(ctx, db, jobids)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobConnectionDestinationsByJobIds")
+	}
+
 	var r0 []NeosyncApiJobDestinationConnectionAssociation
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, []pgtype.UUID) ([]NeosyncApiJobDestinationConnectionAssociation, error)); ok {
@@ -1854,6 +1990,10 @@ func (_c *MockQuerier_GetJobConnectionDestinationsByJobIds_Call) RunAndReturn(ru
 // GetJobsByAccount provides a mock function with given fields: ctx, db, accountid
 func (_m *MockQuerier) GetJobsByAccount(ctx context.Context, db DBTX, accountid pgtype.UUID) ([]NeosyncApiJob, error) {
 	ret := _m.Called(ctx, db, accountid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobsByAccount")
+	}
 
 	var r0 []NeosyncApiJob
 	var r1 error
@@ -1911,6 +2051,10 @@ func (_c *MockQuerier_GetJobsByAccount_Call) RunAndReturn(run func(context.Conte
 func (_m *MockQuerier) GetPersonalAccountByUserId(ctx context.Context, db DBTX, userid pgtype.UUID) (NeosyncApiAccount, error) {
 	ret := _m.Called(ctx, db, userid)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetPersonalAccountByUserId")
+	}
+
 	var r0 NeosyncApiAccount
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (NeosyncApiAccount, error)); ok {
@@ -1964,6 +2108,10 @@ func (_c *MockQuerier_GetPersonalAccountByUserId_Call) RunAndReturn(run func(con
 // GetTeamAccountsByUserId provides a mock function with given fields: ctx, db, userid
 func (_m *MockQuerier) GetTeamAccountsByUserId(ctx context.Context, db DBTX, userid pgtype.UUID) ([]NeosyncApiAccount, error) {
 	ret := _m.Called(ctx, db, userid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTeamAccountsByUserId")
+	}
 
 	var r0 []NeosyncApiAccount
 	var r1 error
@@ -2021,6 +2169,10 @@ func (_c *MockQuerier_GetTeamAccountsByUserId_Call) RunAndReturn(run func(contex
 func (_m *MockQuerier) GetTemporalConfigByAccount(ctx context.Context, db DBTX, id pgtype.UUID) (*pg_models.TemporalConfig, error) {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetTemporalConfigByAccount")
+	}
+
 	var r0 *pg_models.TemporalConfig
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (*pg_models.TemporalConfig, error)); ok {
@@ -2076,6 +2228,10 @@ func (_c *MockQuerier_GetTemporalConfigByAccount_Call) RunAndReturn(run func(con
 // GetTemporalConfigByUserAccount provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) GetTemporalConfigByUserAccount(ctx context.Context, db DBTX, arg GetTemporalConfigByUserAccountParams) (*pg_models.TemporalConfig, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTemporalConfigByUserAccount")
+	}
 
 	var r0 *pg_models.TemporalConfig
 	var r1 error
@@ -2133,6 +2289,10 @@ func (_c *MockQuerier_GetTemporalConfigByUserAccount_Call) RunAndReturn(run func
 func (_m *MockQuerier) GetUser(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiUser, error) {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUser")
+	}
+
 	var r0 NeosyncApiUser
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (NeosyncApiUser, error)); ok {
@@ -2186,6 +2346,10 @@ func (_c *MockQuerier_GetUser_Call) RunAndReturn(run func(context.Context, DBTX,
 // GetUserAssociationByAuth0Id provides a mock function with given fields: ctx, db, auth0ProviderID
 func (_m *MockQuerier) GetUserAssociationByAuth0Id(ctx context.Context, db DBTX, auth0ProviderID string) (NeosyncApiUserIdentityProviderAssociation, error) {
 	ret := _m.Called(ctx, db, auth0ProviderID)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserAssociationByAuth0Id")
+	}
 
 	var r0 NeosyncApiUserIdentityProviderAssociation
 	var r1 error
@@ -2241,6 +2405,10 @@ func (_c *MockQuerier_GetUserAssociationByAuth0Id_Call) RunAndReturn(run func(co
 func (_m *MockQuerier) GetUserByAuth0Id(ctx context.Context, db DBTX, auth0ProviderID string) (NeosyncApiUser, error) {
 	ret := _m.Called(ctx, db, auth0ProviderID)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserByAuth0Id")
+	}
+
 	var r0 NeosyncApiUser
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, string) (NeosyncApiUser, error)); ok {
@@ -2295,6 +2463,10 @@ func (_c *MockQuerier_GetUserByAuth0Id_Call) RunAndReturn(run func(context.Conte
 func (_m *MockQuerier) GetUserDefinedTransformerById(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiTransformer, error) {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserDefinedTransformerById")
+	}
+
 	var r0 NeosyncApiTransformer
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (NeosyncApiTransformer, error)); ok {
@@ -2348,6 +2520,10 @@ func (_c *MockQuerier_GetUserDefinedTransformerById_Call) RunAndReturn(run func(
 // GetUserDefinedTransformersByAccount provides a mock function with given fields: ctx, db, accountid
 func (_m *MockQuerier) GetUserDefinedTransformersByAccount(ctx context.Context, db DBTX, accountid pgtype.UUID) ([]NeosyncApiTransformer, error) {
 	ret := _m.Called(ctx, db, accountid)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserDefinedTransformersByAccount")
+	}
 
 	var r0 []NeosyncApiTransformer
 	var r1 error
@@ -2405,6 +2581,10 @@ func (_c *MockQuerier_GetUserDefinedTransformersByAccount_Call) RunAndReturn(run
 func (_m *MockQuerier) GetUserIdentitiesByTeamAccount(ctx context.Context, db DBTX, accountid pgtype.UUID) ([]NeosyncApiUserIdentityProviderAssociation, error) {
 	ret := _m.Called(ctx, db, accountid)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserIdentitiesByTeamAccount")
+	}
+
 	var r0 []NeosyncApiUserIdentityProviderAssociation
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) ([]NeosyncApiUserIdentityProviderAssociation, error)); ok {
@@ -2460,6 +2640,10 @@ func (_c *MockQuerier_GetUserIdentitiesByTeamAccount_Call) RunAndReturn(run func
 // GetUserIdentityAssociationsByUserIds provides a mock function with given fields: ctx, db, dollar_1
 func (_m *MockQuerier) GetUserIdentityAssociationsByUserIds(ctx context.Context, db DBTX, dollar_1 []pgtype.UUID) ([]NeosyncApiUserIdentityProviderAssociation, error) {
 	ret := _m.Called(ctx, db, dollar_1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserIdentityAssociationsByUserIds")
+	}
 
 	var r0 []NeosyncApiUserIdentityProviderAssociation
 	var r1 error
@@ -2517,6 +2701,10 @@ func (_c *MockQuerier_GetUserIdentityAssociationsByUserIds_Call) RunAndReturn(ru
 func (_m *MockQuerier) GetUserIdentityByUserId(ctx context.Context, db DBTX, userID pgtype.UUID) (NeosyncApiUserIdentityProviderAssociation, error) {
 	ret := _m.Called(ctx, db, userID)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserIdentityByUserId")
+	}
+
 	var r0 NeosyncApiUserIdentityProviderAssociation
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (NeosyncApiUserIdentityProviderAssociation, error)); ok {
@@ -2570,6 +2758,10 @@ func (_c *MockQuerier_GetUserIdentityByUserId_Call) RunAndReturn(run func(contex
 // IsConnectionInAccount provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) IsConnectionInAccount(ctx context.Context, db DBTX, arg IsConnectionInAccountParams) (int64, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsConnectionInAccount")
+	}
 
 	var r0 int64
 	var r1 error
@@ -2625,6 +2817,10 @@ func (_c *MockQuerier_IsConnectionInAccount_Call) RunAndReturn(run func(context.
 func (_m *MockQuerier) IsConnectionNameAvailable(ctx context.Context, db DBTX, arg IsConnectionNameAvailableParams) (int64, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for IsConnectionNameAvailable")
+	}
+
 	var r0 int64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, IsConnectionNameAvailableParams) (int64, error)); ok {
@@ -2678,6 +2874,10 @@ func (_c *MockQuerier_IsConnectionNameAvailable_Call) RunAndReturn(run func(cont
 // IsJobNameAvailable provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) IsJobNameAvailable(ctx context.Context, db DBTX, arg IsJobNameAvailableParams) (int64, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsJobNameAvailable")
+	}
 
 	var r0 int64
 	var r1 error
@@ -2733,6 +2933,10 @@ func (_c *MockQuerier_IsJobNameAvailable_Call) RunAndReturn(run func(context.Con
 func (_m *MockQuerier) IsTransformerNameAvailable(ctx context.Context, db DBTX, arg IsTransformerNameAvailableParams) (int64, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for IsTransformerNameAvailable")
+	}
+
 	var r0 int64
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, IsTransformerNameAvailableParams) (int64, error)); ok {
@@ -2786,6 +2990,10 @@ func (_c *MockQuerier_IsTransformerNameAvailable_Call) RunAndReturn(run func(con
 // IsUserInAccount provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) IsUserInAccount(ctx context.Context, db DBTX, arg IsUserInAccountParams) (int64, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsUserInAccount")
+	}
 
 	var r0 int64
 	var r1 error
@@ -2841,6 +3049,10 @@ func (_c *MockQuerier_IsUserInAccount_Call) RunAndReturn(run func(context.Contex
 func (_m *MockQuerier) RemoveAccountApiKey(ctx context.Context, db DBTX, id pgtype.UUID) error {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveAccountApiKey")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) error); ok {
 		r0 = rf(ctx, db, id)
@@ -2884,6 +3096,10 @@ func (_c *MockQuerier_RemoveAccountApiKey_Call) RunAndReturn(run func(context.Co
 // RemoveAccountInvite provides a mock function with given fields: ctx, db, id
 func (_m *MockQuerier) RemoveAccountInvite(ctx context.Context, db DBTX, id pgtype.UUID) error {
 	ret := _m.Called(ctx, db, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveAccountInvite")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) error); ok {
@@ -2929,6 +3145,10 @@ func (_c *MockQuerier_RemoveAccountInvite_Call) RunAndReturn(run func(context.Co
 func (_m *MockQuerier) RemoveAccountUser(ctx context.Context, db DBTX, arg RemoveAccountUserParams) error {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveAccountUser")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, RemoveAccountUserParams) error); ok {
 		r0 = rf(ctx, db, arg)
@@ -2972,6 +3192,10 @@ func (_c *MockQuerier_RemoveAccountUser_Call) RunAndReturn(run func(context.Cont
 // RemoveConnectionById provides a mock function with given fields: ctx, db, id
 func (_m *MockQuerier) RemoveConnectionById(ctx context.Context, db DBTX, id pgtype.UUID) error {
 	ret := _m.Called(ctx, db, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveConnectionById")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) error); ok {
@@ -3017,6 +3241,10 @@ func (_c *MockQuerier_RemoveConnectionById_Call) RunAndReturn(run func(context.C
 func (_m *MockQuerier) RemoveConnectionByNameAndAccount(ctx context.Context, db DBTX, arg RemoveConnectionByNameAndAccountParams) error {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveConnectionByNameAndAccount")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, RemoveConnectionByNameAndAccountParams) error); ok {
 		r0 = rf(ctx, db, arg)
@@ -3060,6 +3288,10 @@ func (_c *MockQuerier_RemoveConnectionByNameAndAccount_Call) RunAndReturn(run fu
 // RemoveJobById provides a mock function with given fields: ctx, db, id
 func (_m *MockQuerier) RemoveJobById(ctx context.Context, db DBTX, id pgtype.UUID) error {
 	ret := _m.Called(ctx, db, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveJobById")
+	}
 
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) error); ok {
@@ -3105,6 +3337,10 @@ func (_c *MockQuerier_RemoveJobById_Call) RunAndReturn(run func(context.Context,
 func (_m *MockQuerier) RemoveJobConnectionDestination(ctx context.Context, db DBTX, id pgtype.UUID) error {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveJobConnectionDestination")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) error); ok {
 		r0 = rf(ctx, db, id)
@@ -3149,6 +3385,10 @@ func (_c *MockQuerier_RemoveJobConnectionDestination_Call) RunAndReturn(run func
 func (_m *MockQuerier) RemoveJobConnectionDestinations(ctx context.Context, db DBTX, jobids []pgtype.UUID) error {
 	ret := _m.Called(ctx, db, jobids)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveJobConnectionDestinations")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, []pgtype.UUID) error); ok {
 		r0 = rf(ctx, db, jobids)
@@ -3192,6 +3432,10 @@ func (_c *MockQuerier_RemoveJobConnectionDestinations_Call) RunAndReturn(run fun
 // SetAnonymousUser provides a mock function with given fields: ctx, db
 func (_m *MockQuerier) SetAnonymousUser(ctx context.Context, db DBTX) (NeosyncApiUser, error) {
 	ret := _m.Called(ctx, db)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetAnonymousUser")
+	}
 
 	var r0 NeosyncApiUser
 	var r1 error
@@ -3245,6 +3489,10 @@ func (_c *MockQuerier_SetAnonymousUser_Call) RunAndReturn(run func(context.Conte
 // UpdateAccountApiKeyValue provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) UpdateAccountApiKeyValue(ctx context.Context, db DBTX, arg UpdateAccountApiKeyValueParams) (NeosyncApiAccountApiKey, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateAccountApiKeyValue")
+	}
 
 	var r0 NeosyncApiAccountApiKey
 	var r1 error
@@ -3300,6 +3548,10 @@ func (_c *MockQuerier_UpdateAccountApiKeyValue_Call) RunAndReturn(run func(conte
 func (_m *MockQuerier) UpdateAccountInviteToAccepted(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiAccountInvite, error) {
 	ret := _m.Called(ctx, db, id)
 
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateAccountInviteToAccepted")
+	}
+
 	var r0 NeosyncApiAccountInvite
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) (NeosyncApiAccountInvite, error)); ok {
@@ -3353,6 +3605,10 @@ func (_c *MockQuerier_UpdateAccountInviteToAccepted_Call) RunAndReturn(run func(
 // UpdateActiveAccountInvitesToExpired provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) UpdateActiveAccountInvitesToExpired(ctx context.Context, db DBTX, arg UpdateActiveAccountInvitesToExpiredParams) (NeosyncApiAccountInvite, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateActiveAccountInvitesToExpired")
+	}
 
 	var r0 NeosyncApiAccountInvite
 	var r1 error
@@ -3408,6 +3664,10 @@ func (_c *MockQuerier_UpdateActiveAccountInvitesToExpired_Call) RunAndReturn(run
 func (_m *MockQuerier) UpdateConnection(ctx context.Context, db DBTX, arg UpdateConnectionParams) (NeosyncApiConnection, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateConnection")
+	}
+
 	var r0 NeosyncApiConnection
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, UpdateConnectionParams) (NeosyncApiConnection, error)); ok {
@@ -3461,6 +3721,10 @@ func (_c *MockQuerier_UpdateConnection_Call) RunAndReturn(run func(context.Conte
 // UpdateJobConnectionDestination provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) UpdateJobConnectionDestination(ctx context.Context, db DBTX, arg UpdateJobConnectionDestinationParams) (NeosyncApiJobDestinationConnectionAssociation, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateJobConnectionDestination")
+	}
 
 	var r0 NeosyncApiJobDestinationConnectionAssociation
 	var r1 error
@@ -3516,6 +3780,10 @@ func (_c *MockQuerier_UpdateJobConnectionDestination_Call) RunAndReturn(run func
 func (_m *MockQuerier) UpdateJobMappings(ctx context.Context, db DBTX, arg UpdateJobMappingsParams) (NeosyncApiJob, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateJobMappings")
+	}
+
 	var r0 NeosyncApiJob
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, UpdateJobMappingsParams) (NeosyncApiJob, error)); ok {
@@ -3569,6 +3837,10 @@ func (_c *MockQuerier_UpdateJobMappings_Call) RunAndReturn(run func(context.Cont
 // UpdateJobSchedule provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) UpdateJobSchedule(ctx context.Context, db DBTX, arg UpdateJobScheduleParams) (NeosyncApiJob, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateJobSchedule")
+	}
 
 	var r0 NeosyncApiJob
 	var r1 error
@@ -3624,6 +3896,10 @@ func (_c *MockQuerier_UpdateJobSchedule_Call) RunAndReturn(run func(context.Cont
 func (_m *MockQuerier) UpdateJobSource(ctx context.Context, db DBTX, arg UpdateJobSourceParams) (NeosyncApiJob, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateJobSource")
+	}
+
 	var r0 NeosyncApiJob
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, UpdateJobSourceParams) (NeosyncApiJob, error)); ok {
@@ -3678,6 +3954,10 @@ func (_c *MockQuerier_UpdateJobSource_Call) RunAndReturn(run func(context.Contex
 func (_m *MockQuerier) UpdateTemporalConfigByAccount(ctx context.Context, db DBTX, arg UpdateTemporalConfigByAccountParams) (NeosyncApiAccount, error) {
 	ret := _m.Called(ctx, db, arg)
 
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateTemporalConfigByAccount")
+	}
+
 	var r0 NeosyncApiAccount
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, UpdateTemporalConfigByAccountParams) (NeosyncApiAccount, error)); ok {
@@ -3731,6 +4011,10 @@ func (_c *MockQuerier_UpdateTemporalConfigByAccount_Call) RunAndReturn(run func(
 // UpdateUserDefinedTransformer provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) UpdateUserDefinedTransformer(ctx context.Context, db DBTX, arg UpdateUserDefinedTransformerParams) (NeosyncApiTransformer, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUserDefinedTransformer")
+	}
 
 	var r0 NeosyncApiTransformer
 	var r1 error

--- a/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_AuthServiceClient.go
+++ b/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_AuthServiceClient.go
@@ -28,6 +28,10 @@ func (_m *MockAuthServiceClient) EXPECT() *MockAuthServiceClient_Expecter {
 func (_m *MockAuthServiceClient) GetAuthStatus(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetAuthStatusRequest]) (*connect.Response[mgmtv1alpha1.GetAuthStatusResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAuthStatus")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetAuthStatusResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetAuthStatusRequest]) (*connect.Response[mgmtv1alpha1.GetAuthStatusResponse], error)); ok {
@@ -82,6 +86,10 @@ func (_c *MockAuthServiceClient_GetAuthStatus_Call) RunAndReturn(run func(contex
 // GetAuthUser provides a mock function with given fields: _a0, _a1
 func (_m *MockAuthServiceClient) GetAuthUser(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetAuthUserRequest]) (*connect.Response[mgmtv1alpha1.GetAuthUserResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAuthUser")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetAuthUserResponse]
 	var r1 error
@@ -138,6 +146,10 @@ func (_c *MockAuthServiceClient_GetAuthUser_Call) RunAndReturn(run func(context.
 func (_m *MockAuthServiceClient) GetAuthorizeUrl(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetAuthorizeUrlRequest]) (*connect.Response[mgmtv1alpha1.GetAuthorizeUrlResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetAuthorizeUrl")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetAuthorizeUrlResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetAuthorizeUrlRequest]) (*connect.Response[mgmtv1alpha1.GetAuthorizeUrlResponse], error)); ok {
@@ -193,6 +205,10 @@ func (_c *MockAuthServiceClient_GetAuthorizeUrl_Call) RunAndReturn(run func(cont
 func (_m *MockAuthServiceClient) GetCliIssuer(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetCliIssuerRequest]) (*connect.Response[mgmtv1alpha1.GetCliIssuerResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetCliIssuer")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetCliIssuerResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetCliIssuerRequest]) (*connect.Response[mgmtv1alpha1.GetCliIssuerResponse], error)); ok {
@@ -247,6 +263,10 @@ func (_c *MockAuthServiceClient_GetCliIssuer_Call) RunAndReturn(run func(context
 // LoginCli provides a mock function with given fields: _a0, _a1
 func (_m *MockAuthServiceClient) LoginCli(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.LoginCliRequest]) (*connect.Response[mgmtv1alpha1.LoginCliResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for LoginCli")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.LoginCliResponse]
 	var r1 error

--- a/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_ConnectionServiceClient.go
+++ b/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_ConnectionServiceClient.go
@@ -28,6 +28,10 @@ func (_m *MockConnectionServiceClient) EXPECT() *MockConnectionServiceClient_Exp
 func (_m *MockConnectionServiceClient) CheckConnectionConfig(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.CheckConnectionConfigRequest]) (*connect.Response[mgmtv1alpha1.CheckConnectionConfigResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CheckConnectionConfig")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.CheckConnectionConfigResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.CheckConnectionConfigRequest]) (*connect.Response[mgmtv1alpha1.CheckConnectionConfigResponse], error)); ok {
@@ -82,6 +86,10 @@ func (_c *MockConnectionServiceClient_CheckConnectionConfig_Call) RunAndReturn(r
 // CheckSqlQuery provides a mock function with given fields: _a0, _a1
 func (_m *MockConnectionServiceClient) CheckSqlQuery(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.CheckSqlQueryRequest]) (*connect.Response[mgmtv1alpha1.CheckSqlQueryResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CheckSqlQuery")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.CheckSqlQueryResponse]
 	var r1 error
@@ -138,6 +146,10 @@ func (_c *MockConnectionServiceClient_CheckSqlQuery_Call) RunAndReturn(run func(
 func (_m *MockConnectionServiceClient) CreateConnection(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.CreateConnectionRequest]) (*connect.Response[mgmtv1alpha1.CreateConnectionResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateConnection")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.CreateConnectionResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.CreateConnectionRequest]) (*connect.Response[mgmtv1alpha1.CreateConnectionResponse], error)); ok {
@@ -192,6 +204,10 @@ func (_c *MockConnectionServiceClient_CreateConnection_Call) RunAndReturn(run fu
 // DeleteConnection provides a mock function with given fields: _a0, _a1
 func (_m *MockConnectionServiceClient) DeleteConnection(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.DeleteConnectionRequest]) (*connect.Response[mgmtv1alpha1.DeleteConnectionResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteConnection")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.DeleteConnectionResponse]
 	var r1 error
@@ -248,6 +264,10 @@ func (_c *MockConnectionServiceClient_DeleteConnection_Call) RunAndReturn(run fu
 func (_m *MockConnectionServiceClient) GetConnection(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetConnectionRequest]) (*connect.Response[mgmtv1alpha1.GetConnectionResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetConnection")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetConnectionResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetConnectionRequest]) (*connect.Response[mgmtv1alpha1.GetConnectionResponse], error)); ok {
@@ -302,6 +322,10 @@ func (_c *MockConnectionServiceClient_GetConnection_Call) RunAndReturn(run func(
 // GetConnectionSchema provides a mock function with given fields: _a0, _a1
 func (_m *MockConnectionServiceClient) GetConnectionSchema(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetConnectionSchemaRequest]) (*connect.Response[mgmtv1alpha1.GetConnectionSchemaResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetConnectionSchema")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetConnectionSchemaResponse]
 	var r1 error
@@ -358,6 +382,10 @@ func (_c *MockConnectionServiceClient_GetConnectionSchema_Call) RunAndReturn(run
 func (_m *MockConnectionServiceClient) GetConnections(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetConnectionsRequest]) (*connect.Response[mgmtv1alpha1.GetConnectionsResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetConnections")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetConnectionsResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetConnectionsRequest]) (*connect.Response[mgmtv1alpha1.GetConnectionsResponse], error)); ok {
@@ -413,6 +441,10 @@ func (_c *MockConnectionServiceClient_GetConnections_Call) RunAndReturn(run func
 func (_m *MockConnectionServiceClient) IsConnectionNameAvailable(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.IsConnectionNameAvailableRequest]) (*connect.Response[mgmtv1alpha1.IsConnectionNameAvailableResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for IsConnectionNameAvailable")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.IsConnectionNameAvailableResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.IsConnectionNameAvailableRequest]) (*connect.Response[mgmtv1alpha1.IsConnectionNameAvailableResponse], error)); ok {
@@ -467,6 +499,10 @@ func (_c *MockConnectionServiceClient_IsConnectionNameAvailable_Call) RunAndRetu
 // UpdateConnection provides a mock function with given fields: _a0, _a1
 func (_m *MockConnectionServiceClient) UpdateConnection(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.UpdateConnectionRequest]) (*connect.Response[mgmtv1alpha1.UpdateConnectionResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateConnection")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.UpdateConnectionResponse]
 	var r1 error

--- a/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_JobServiceClient.go
+++ b/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_JobServiceClient.go
@@ -28,6 +28,10 @@ func (_m *MockJobServiceClient) EXPECT() *MockJobServiceClient_Expecter {
 func (_m *MockJobServiceClient) CancelJobRun(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.CancelJobRunRequest]) (*connect.Response[mgmtv1alpha1.CancelJobRunResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CancelJobRun")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.CancelJobRunResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.CancelJobRunRequest]) (*connect.Response[mgmtv1alpha1.CancelJobRunResponse], error)); ok {
@@ -82,6 +86,10 @@ func (_c *MockJobServiceClient_CancelJobRun_Call) RunAndReturn(run func(context.
 // CreateJob provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) CreateJob(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.CreateJobRequest]) (*connect.Response[mgmtv1alpha1.CreateJobResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateJob")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.CreateJobResponse]
 	var r1 error
@@ -138,6 +146,10 @@ func (_c *MockJobServiceClient_CreateJob_Call) RunAndReturn(run func(context.Con
 func (_m *MockJobServiceClient) CreateJobDestinationConnections(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.CreateJobDestinationConnectionsRequest]) (*connect.Response[mgmtv1alpha1.CreateJobDestinationConnectionsResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateJobDestinationConnections")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.CreateJobDestinationConnectionsResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.CreateJobDestinationConnectionsRequest]) (*connect.Response[mgmtv1alpha1.CreateJobDestinationConnectionsResponse], error)); ok {
@@ -192,6 +204,10 @@ func (_c *MockJobServiceClient_CreateJobDestinationConnections_Call) RunAndRetur
 // CreateJobRun provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) CreateJobRun(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.CreateJobRunRequest]) (*connect.Response[mgmtv1alpha1.CreateJobRunResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CreateJobRun")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.CreateJobRunResponse]
 	var r1 error
@@ -248,6 +264,10 @@ func (_c *MockJobServiceClient_CreateJobRun_Call) RunAndReturn(run func(context.
 func (_m *MockJobServiceClient) DeleteJob(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.DeleteJobRequest]) (*connect.Response[mgmtv1alpha1.DeleteJobResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteJob")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.DeleteJobResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.DeleteJobRequest]) (*connect.Response[mgmtv1alpha1.DeleteJobResponse], error)); ok {
@@ -302,6 +322,10 @@ func (_c *MockJobServiceClient_DeleteJob_Call) RunAndReturn(run func(context.Con
 // DeleteJobDestinationConnection provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) DeleteJobDestinationConnection(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.DeleteJobDestinationConnectionRequest]) (*connect.Response[mgmtv1alpha1.DeleteJobDestinationConnectionResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteJobDestinationConnection")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.DeleteJobDestinationConnectionResponse]
 	var r1 error
@@ -358,6 +382,10 @@ func (_c *MockJobServiceClient_DeleteJobDestinationConnection_Call) RunAndReturn
 func (_m *MockJobServiceClient) DeleteJobRun(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.DeleteJobRunRequest]) (*connect.Response[mgmtv1alpha1.DeleteJobRunResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteJobRun")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.DeleteJobRunResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.DeleteJobRunRequest]) (*connect.Response[mgmtv1alpha1.DeleteJobRunResponse], error)); ok {
@@ -412,6 +440,10 @@ func (_c *MockJobServiceClient_DeleteJobRun_Call) RunAndReturn(run func(context.
 // GetJob provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) GetJob(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetJobRequest]) (*connect.Response[mgmtv1alpha1.GetJobResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetJob")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetJobResponse]
 	var r1 error
@@ -468,6 +500,10 @@ func (_c *MockJobServiceClient_GetJob_Call) RunAndReturn(run func(context.Contex
 func (_m *MockJobServiceClient) GetJobNextRuns(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetJobNextRunsRequest]) (*connect.Response[mgmtv1alpha1.GetJobNextRunsResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobNextRuns")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetJobNextRunsResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetJobNextRunsRequest]) (*connect.Response[mgmtv1alpha1.GetJobNextRunsResponse], error)); ok {
@@ -522,6 +558,10 @@ func (_c *MockJobServiceClient_GetJobNextRuns_Call) RunAndReturn(run func(contex
 // GetJobRecentRuns provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) GetJobRecentRuns(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetJobRecentRunsRequest]) (*connect.Response[mgmtv1alpha1.GetJobRecentRunsResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobRecentRuns")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetJobRecentRunsResponse]
 	var r1 error
@@ -578,6 +618,10 @@ func (_c *MockJobServiceClient_GetJobRecentRuns_Call) RunAndReturn(run func(cont
 func (_m *MockJobServiceClient) GetJobRun(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetJobRunRequest]) (*connect.Response[mgmtv1alpha1.GetJobRunResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobRun")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetJobRunResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetJobRunRequest]) (*connect.Response[mgmtv1alpha1.GetJobRunResponse], error)); ok {
@@ -632,6 +676,10 @@ func (_c *MockJobServiceClient_GetJobRun_Call) RunAndReturn(run func(context.Con
 // GetJobRunEvents provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) GetJobRunEvents(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetJobRunEventsRequest]) (*connect.Response[mgmtv1alpha1.GetJobRunEventsResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobRunEvents")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetJobRunEventsResponse]
 	var r1 error
@@ -688,6 +736,10 @@ func (_c *MockJobServiceClient_GetJobRunEvents_Call) RunAndReturn(run func(conte
 func (_m *MockJobServiceClient) GetJobRuns(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetJobRunsRequest]) (*connect.Response[mgmtv1alpha1.GetJobRunsResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobRuns")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetJobRunsResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetJobRunsRequest]) (*connect.Response[mgmtv1alpha1.GetJobRunsResponse], error)); ok {
@@ -742,6 +794,10 @@ func (_c *MockJobServiceClient_GetJobRuns_Call) RunAndReturn(run func(context.Co
 // GetJobStatus provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) GetJobStatus(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetJobStatusRequest]) (*connect.Response[mgmtv1alpha1.GetJobStatusResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobStatus")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetJobStatusResponse]
 	var r1 error
@@ -798,6 +854,10 @@ func (_c *MockJobServiceClient_GetJobStatus_Call) RunAndReturn(run func(context.
 func (_m *MockJobServiceClient) GetJobStatuses(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetJobStatusesRequest]) (*connect.Response[mgmtv1alpha1.GetJobStatusesResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobStatuses")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetJobStatusesResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetJobStatusesRequest]) (*connect.Response[mgmtv1alpha1.GetJobStatusesResponse], error)); ok {
@@ -852,6 +912,10 @@ func (_c *MockJobServiceClient_GetJobStatuses_Call) RunAndReturn(run func(contex
 // GetJobs provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) GetJobs(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetJobsRequest]) (*connect.Response[mgmtv1alpha1.GetJobsResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetJobs")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetJobsResponse]
 	var r1 error
@@ -908,6 +972,10 @@ func (_c *MockJobServiceClient_GetJobs_Call) RunAndReturn(run func(context.Conte
 func (_m *MockJobServiceClient) IsJobNameAvailable(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.IsJobNameAvailableRequest]) (*connect.Response[mgmtv1alpha1.IsJobNameAvailableResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for IsJobNameAvailable")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.IsJobNameAvailableResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.IsJobNameAvailableRequest]) (*connect.Response[mgmtv1alpha1.IsJobNameAvailableResponse], error)); ok {
@@ -962,6 +1030,10 @@ func (_c *MockJobServiceClient_IsJobNameAvailable_Call) RunAndReturn(run func(co
 // PauseJob provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) PauseJob(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.PauseJobRequest]) (*connect.Response[mgmtv1alpha1.PauseJobResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for PauseJob")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.PauseJobResponse]
 	var r1 error
@@ -1018,6 +1090,10 @@ func (_c *MockJobServiceClient_PauseJob_Call) RunAndReturn(run func(context.Cont
 func (_m *MockJobServiceClient) SetJobSourceSqlConnectionSubsets(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.SetJobSourceSqlConnectionSubsetsRequest]) (*connect.Response[mgmtv1alpha1.SetJobSourceSqlConnectionSubsetsResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for SetJobSourceSqlConnectionSubsets")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.SetJobSourceSqlConnectionSubsetsResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.SetJobSourceSqlConnectionSubsetsRequest]) (*connect.Response[mgmtv1alpha1.SetJobSourceSqlConnectionSubsetsResponse], error)); ok {
@@ -1072,6 +1148,10 @@ func (_c *MockJobServiceClient_SetJobSourceSqlConnectionSubsets_Call) RunAndRetu
 // UpdateJobDestinationConnection provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) UpdateJobDestinationConnection(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.UpdateJobDestinationConnectionRequest]) (*connect.Response[mgmtv1alpha1.UpdateJobDestinationConnectionResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateJobDestinationConnection")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.UpdateJobDestinationConnectionResponse]
 	var r1 error
@@ -1128,6 +1208,10 @@ func (_c *MockJobServiceClient_UpdateJobDestinationConnection_Call) RunAndReturn
 func (_m *MockJobServiceClient) UpdateJobSchedule(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.UpdateJobScheduleRequest]) (*connect.Response[mgmtv1alpha1.UpdateJobScheduleResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateJobSchedule")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.UpdateJobScheduleResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.UpdateJobScheduleRequest]) (*connect.Response[mgmtv1alpha1.UpdateJobScheduleResponse], error)); ok {
@@ -1182,6 +1266,10 @@ func (_c *MockJobServiceClient_UpdateJobSchedule_Call) RunAndReturn(run func(con
 // UpdateJobSourceConnection provides a mock function with given fields: _a0, _a1
 func (_m *MockJobServiceClient) UpdateJobSourceConnection(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.UpdateJobSourceConnectionRequest]) (*connect.Response[mgmtv1alpha1.UpdateJobSourceConnectionResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateJobSourceConnection")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.UpdateJobSourceConnectionResponse]
 	var r1 error

--- a/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_TransformersServiceClient.go
+++ b/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_TransformersServiceClient.go
@@ -28,6 +28,10 @@ func (_m *MockTransformersServiceClient) EXPECT() *MockTransformersServiceClient
 func (_m *MockTransformersServiceClient) CreateUserDefinedTransformer(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.CreateUserDefinedTransformerRequest]) (*connect.Response[mgmtv1alpha1.CreateUserDefinedTransformerResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateUserDefinedTransformer")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.CreateUserDefinedTransformerResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.CreateUserDefinedTransformerRequest]) (*connect.Response[mgmtv1alpha1.CreateUserDefinedTransformerResponse], error)); ok {
@@ -82,6 +86,10 @@ func (_c *MockTransformersServiceClient_CreateUserDefinedTransformer_Call) RunAn
 // DeleteUserDefinedTransformer provides a mock function with given fields: _a0, _a1
 func (_m *MockTransformersServiceClient) DeleteUserDefinedTransformer(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.DeleteUserDefinedTransformerRequest]) (*connect.Response[mgmtv1alpha1.DeleteUserDefinedTransformerResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DeleteUserDefinedTransformer")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.DeleteUserDefinedTransformerResponse]
 	var r1 error
@@ -138,6 +146,10 @@ func (_c *MockTransformersServiceClient_DeleteUserDefinedTransformer_Call) RunAn
 func (_m *MockTransformersServiceClient) GetSystemTransformers(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetSystemTransformersRequest]) (*connect.Response[mgmtv1alpha1.GetSystemTransformersResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetSystemTransformers")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetSystemTransformersResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetSystemTransformersRequest]) (*connect.Response[mgmtv1alpha1.GetSystemTransformersResponse], error)); ok {
@@ -192,6 +204,10 @@ func (_c *MockTransformersServiceClient_GetSystemTransformers_Call) RunAndReturn
 // GetUserDefinedTransformerById provides a mock function with given fields: _a0, _a1
 func (_m *MockTransformersServiceClient) GetUserDefinedTransformerById(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetUserDefinedTransformerByIdRequest]) (*connect.Response[mgmtv1alpha1.GetUserDefinedTransformerByIdResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserDefinedTransformerById")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetUserDefinedTransformerByIdResponse]
 	var r1 error
@@ -248,6 +264,10 @@ func (_c *MockTransformersServiceClient_GetUserDefinedTransformerById_Call) RunA
 func (_m *MockTransformersServiceClient) GetUserDefinedTransformers(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetUserDefinedTransformersRequest]) (*connect.Response[mgmtv1alpha1.GetUserDefinedTransformersResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserDefinedTransformers")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetUserDefinedTransformersResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetUserDefinedTransformersRequest]) (*connect.Response[mgmtv1alpha1.GetUserDefinedTransformersResponse], error)); ok {
@@ -303,6 +323,10 @@ func (_c *MockTransformersServiceClient_GetUserDefinedTransformers_Call) RunAndR
 func (_m *MockTransformersServiceClient) IsTransformerNameAvailable(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.IsTransformerNameAvailableRequest]) (*connect.Response[mgmtv1alpha1.IsTransformerNameAvailableResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for IsTransformerNameAvailable")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.IsTransformerNameAvailableResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.IsTransformerNameAvailableRequest]) (*connect.Response[mgmtv1alpha1.IsTransformerNameAvailableResponse], error)); ok {
@@ -357,6 +381,10 @@ func (_c *MockTransformersServiceClient_IsTransformerNameAvailable_Call) RunAndR
 // UpdateUserDefinedTransformer provides a mock function with given fields: _a0, _a1
 func (_m *MockTransformersServiceClient) UpdateUserDefinedTransformer(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.UpdateUserDefinedTransformerRequest]) (*connect.Response[mgmtv1alpha1.UpdateUserDefinedTransformerResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for UpdateUserDefinedTransformer")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.UpdateUserDefinedTransformerResponse]
 	var r1 error

--- a/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_UserAccountServiceClient.go
+++ b/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect/mock_UserAccountServiceClient.go
@@ -28,6 +28,10 @@ func (_m *MockUserAccountServiceClient) EXPECT() *MockUserAccountServiceClient_E
 func (_m *MockUserAccountServiceClient) AcceptTeamAccountInvite(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.AcceptTeamAccountInviteRequest]) (*connect.Response[mgmtv1alpha1.AcceptTeamAccountInviteResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for AcceptTeamAccountInvite")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.AcceptTeamAccountInviteResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.AcceptTeamAccountInviteRequest]) (*connect.Response[mgmtv1alpha1.AcceptTeamAccountInviteResponse], error)); ok {
@@ -82,6 +86,10 @@ func (_c *MockUserAccountServiceClient_AcceptTeamAccountInvite_Call) RunAndRetur
 // ConvertPersonalToTeamAccount provides a mock function with given fields: _a0, _a1
 func (_m *MockUserAccountServiceClient) ConvertPersonalToTeamAccount(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.ConvertPersonalToTeamAccountRequest]) (*connect.Response[mgmtv1alpha1.ConvertPersonalToTeamAccountResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for ConvertPersonalToTeamAccount")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.ConvertPersonalToTeamAccountResponse]
 	var r1 error
@@ -138,6 +146,10 @@ func (_c *MockUserAccountServiceClient_ConvertPersonalToTeamAccount_Call) RunAnd
 func (_m *MockUserAccountServiceClient) CreateTeamAccount(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.CreateTeamAccountRequest]) (*connect.Response[mgmtv1alpha1.CreateTeamAccountResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for CreateTeamAccount")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.CreateTeamAccountResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.CreateTeamAccountRequest]) (*connect.Response[mgmtv1alpha1.CreateTeamAccountResponse], error)); ok {
@@ -192,6 +204,10 @@ func (_c *MockUserAccountServiceClient_CreateTeamAccount_Call) RunAndReturn(run 
 // GetAccountTemporalConfig provides a mock function with given fields: _a0, _a1
 func (_m *MockUserAccountServiceClient) GetAccountTemporalConfig(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetAccountTemporalConfigRequest]) (*connect.Response[mgmtv1alpha1.GetAccountTemporalConfigResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountTemporalConfig")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetAccountTemporalConfigResponse]
 	var r1 error
@@ -248,6 +264,10 @@ func (_c *MockUserAccountServiceClient_GetAccountTemporalConfig_Call) RunAndRetu
 func (_m *MockUserAccountServiceClient) GetTeamAccountInvites(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetTeamAccountInvitesRequest]) (*connect.Response[mgmtv1alpha1.GetTeamAccountInvitesResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetTeamAccountInvites")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetTeamAccountInvitesResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetTeamAccountInvitesRequest]) (*connect.Response[mgmtv1alpha1.GetTeamAccountInvitesResponse], error)); ok {
@@ -302,6 +322,10 @@ func (_c *MockUserAccountServiceClient_GetTeamAccountInvites_Call) RunAndReturn(
 // GetTeamAccountMembers provides a mock function with given fields: _a0, _a1
 func (_m *MockUserAccountServiceClient) GetTeamAccountMembers(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetTeamAccountMembersRequest]) (*connect.Response[mgmtv1alpha1.GetTeamAccountMembersResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTeamAccountMembers")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetTeamAccountMembersResponse]
 	var r1 error
@@ -358,6 +382,10 @@ func (_c *MockUserAccountServiceClient_GetTeamAccountMembers_Call) RunAndReturn(
 func (_m *MockUserAccountServiceClient) GetUser(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetUserRequest]) (*connect.Response[mgmtv1alpha1.GetUserResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetUser")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.GetUserResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.GetUserRequest]) (*connect.Response[mgmtv1alpha1.GetUserResponse], error)); ok {
@@ -412,6 +440,10 @@ func (_c *MockUserAccountServiceClient_GetUser_Call) RunAndReturn(run func(conte
 // GetUserAccounts provides a mock function with given fields: _a0, _a1
 func (_m *MockUserAccountServiceClient) GetUserAccounts(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.GetUserAccountsRequest]) (*connect.Response[mgmtv1alpha1.GetUserAccountsResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetUserAccounts")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.GetUserAccountsResponse]
 	var r1 error
@@ -468,6 +500,10 @@ func (_c *MockUserAccountServiceClient_GetUserAccounts_Call) RunAndReturn(run fu
 func (_m *MockUserAccountServiceClient) InviteUserToTeamAccount(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.InviteUserToTeamAccountRequest]) (*connect.Response[mgmtv1alpha1.InviteUserToTeamAccountResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for InviteUserToTeamAccount")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.InviteUserToTeamAccountResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.InviteUserToTeamAccountRequest]) (*connect.Response[mgmtv1alpha1.InviteUserToTeamAccountResponse], error)); ok {
@@ -522,6 +558,10 @@ func (_c *MockUserAccountServiceClient_InviteUserToTeamAccount_Call) RunAndRetur
 // IsUserInAccount provides a mock function with given fields: _a0, _a1
 func (_m *MockUserAccountServiceClient) IsUserInAccount(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.IsUserInAccountRequest]) (*connect.Response[mgmtv1alpha1.IsUserInAccountResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for IsUserInAccount")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.IsUserInAccountResponse]
 	var r1 error
@@ -578,6 +618,10 @@ func (_c *MockUserAccountServiceClient_IsUserInAccount_Call) RunAndReturn(run fu
 func (_m *MockUserAccountServiceClient) RemoveTeamAccountInvite(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.RemoveTeamAccountInviteRequest]) (*connect.Response[mgmtv1alpha1.RemoveTeamAccountInviteResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveTeamAccountInvite")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.RemoveTeamAccountInviteResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.RemoveTeamAccountInviteRequest]) (*connect.Response[mgmtv1alpha1.RemoveTeamAccountInviteResponse], error)); ok {
@@ -632,6 +676,10 @@ func (_c *MockUserAccountServiceClient_RemoveTeamAccountInvite_Call) RunAndRetur
 // RemoveTeamAccountMember provides a mock function with given fields: _a0, _a1
 func (_m *MockUserAccountServiceClient) RemoveTeamAccountMember(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.RemoveTeamAccountMemberRequest]) (*connect.Response[mgmtv1alpha1.RemoveTeamAccountMemberResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for RemoveTeamAccountMember")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.RemoveTeamAccountMemberResponse]
 	var r1 error
@@ -688,6 +736,10 @@ func (_c *MockUserAccountServiceClient_RemoveTeamAccountMember_Call) RunAndRetur
 func (_m *MockUserAccountServiceClient) SetAccountTemporalConfig(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.SetAccountTemporalConfigRequest]) (*connect.Response[mgmtv1alpha1.SetAccountTemporalConfigResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for SetAccountTemporalConfig")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.SetAccountTemporalConfigResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.SetAccountTemporalConfigRequest]) (*connect.Response[mgmtv1alpha1.SetAccountTemporalConfigResponse], error)); ok {
@@ -743,6 +795,10 @@ func (_c *MockUserAccountServiceClient_SetAccountTemporalConfig_Call) RunAndRetu
 func (_m *MockUserAccountServiceClient) SetPersonalAccount(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.SetPersonalAccountRequest]) (*connect.Response[mgmtv1alpha1.SetPersonalAccountResponse], error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for SetPersonalAccount")
+	}
+
 	var r0 *connect.Response[mgmtv1alpha1.SetPersonalAccountResponse]
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, *connect.Request[mgmtv1alpha1.SetPersonalAccountRequest]) (*connect.Response[mgmtv1alpha1.SetPersonalAccountResponse], error)); ok {
@@ -797,6 +853,10 @@ func (_c *MockUserAccountServiceClient_SetPersonalAccount_Call) RunAndReturn(run
 // SetUser provides a mock function with given fields: _a0, _a1
 func (_m *MockUserAccountServiceClient) SetUser(_a0 context.Context, _a1 *connect.Request[mgmtv1alpha1.SetUserRequest]) (*connect.Response[mgmtv1alpha1.SetUserResponse], error) {
 	ret := _m.Called(_a0, _a1)
+
+	if len(ret) == 0 {
+		panic("no return value specified for SetUser")
+	}
 
 	var r0 *connect.Response[mgmtv1alpha1.SetUserResponse]
 	var r1 error

--- a/backend/internal/auth/authmw/mock_AuthClient.go
+++ b/backend/internal/auth/authmw/mock_AuthClient.go
@@ -26,6 +26,10 @@ func (_m *MockAuthClient) EXPECT() *MockAuthClient_Expecter {
 func (_m *MockAuthClient) InjectTokenCtx(ctx context.Context, header http.Header) (context.Context, error) {
 	ret := _m.Called(ctx, header)
 
+	if len(ret) == 0 {
+		panic("no return value specified for InjectTokenCtx")
+	}
+
 	var r0 context.Context
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, http.Header) (context.Context, error)); ok {

--- a/backend/internal/auth/jwt/mock_JwtValidator.go
+++ b/backend/internal/auth/jwt/mock_JwtValidator.go
@@ -25,6 +25,10 @@ func (_m *MockJwtValidator) EXPECT() *MockJwtValidator_Expecter {
 func (_m *MockJwtValidator) ValidateToken(ctx context.Context, tokenString string) (interface{}, error) {
 	ret := _m.Called(ctx, tokenString)
 
+	if len(ret) == 0 {
+		panic("no return value specified for ValidateToken")
+	}
+
 	var r0 interface{}
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (interface{}, error)); ok {

--- a/backend/internal/cmds/mgmt/serve/connect/cmd.go
+++ b/backend/internal/cmds/mgmt/serve/connect/cmd.go
@@ -243,6 +243,11 @@ func serve(ctx context.Context) error {
 	}
 	tfwfmgr := clientmanager.New(&clientmanager.Config{
 		AuthCertificates: authcerts,
+		DefaultTemporalConfig: &clientmanager.DefaultTemporalConfig{
+			Url:              getDefaultTemporalUrl(),
+			Namespace:        getDefaultTemporalNamespace(),
+			SyncJobQueueName: getDefaultTemporalSyncJobQueue(),
+		},
 	}, db.Q, db.Db)
 
 	jobServiceConfig := &v1alpha1_jobservice.Config{

--- a/backend/internal/cmds/mgmt/serve/connect/cmd.go
+++ b/backend/internal/cmds/mgmt/serve/connect/cmd.go
@@ -206,10 +206,22 @@ func serve(ctx context.Context) error {
 		),
 	)
 
+	authcerts, err := getTemporalAuthCertificate()
+	if err != nil {
+		return err
+	}
+	tfwfmgr := clientmanager.New(&clientmanager.Config{
+		AuthCertificates: authcerts,
+		DefaultTemporalConfig: &clientmanager.DefaultTemporalConfig{
+			Url:              getDefaultTemporalUrl(),
+			Namespace:        getDefaultTemporalNamespace(),
+			SyncJobQueueName: getDefaultTemporalSyncJobQueue(),
+		},
+	}, db.Q, db.Db)
+
 	useraccountService := v1alpha1_useraccountservice.New(&v1alpha1_useraccountservice.Config{
 		IsAuthEnabled: isAuthEnabled,
-		Temporal:      getDefaultTemporalConfig(),
-	}, db, authService)
+	}, db, authService, tfwfmgr)
 	api.Handle(
 		mgmtv1alpha1connect.NewUserAccountServiceHandler(
 			useraccountService,
@@ -237,18 +249,6 @@ func serve(ctx context.Context) error {
 			connect.WithInterceptors(stdAuthInterceptors...),
 		),
 	)
-	authcerts, err := getTemporalAuthCertificate()
-	if err != nil {
-		return err
-	}
-	tfwfmgr := clientmanager.New(&clientmanager.Config{
-		AuthCertificates: authcerts,
-		DefaultTemporalConfig: &clientmanager.DefaultTemporalConfig{
-			Url:              getDefaultTemporalUrl(),
-			Namespace:        getDefaultTemporalNamespace(),
-			SyncJobQueueName: getDefaultTemporalSyncJobQueue(),
-		},
-	}, db.Q, db.Db)
 
 	jobServiceConfig := &v1alpha1_jobservice.Config{
 		IsAuthEnabled: isAuthEnabled,
@@ -412,14 +412,6 @@ func getTemporalAuthCertificate() ([]tls.Certificate, error) {
 		return []tls.Certificate{cert}, nil
 	}
 	return []tls.Certificate{}, nil
-}
-
-func getDefaultTemporalConfig() *v1alpha1_useraccountservice.TemporalConfig {
-	return &v1alpha1_useraccountservice.TemporalConfig{
-		DefaultTemporalNamespace:        getDefaultTemporalNamespace(),
-		DefaultTemporalSyncJobQueueName: getDefaultTemporalSyncJobQueue(),
-		DefaultTemporalUrl:              getDefaultTemporalUrl(),
-	}
 }
 
 func getDefaultTemporalUrl() string {

--- a/backend/internal/dtomaps/transformers.go
+++ b/backend/internal/dtomaps/transformers.go
@@ -16,7 +16,7 @@ func ToUserDefinedTransformerDto(
 		Description: input.Description,
 		DataType:    input.Type,
 		Source:      input.Source,
-		Config:      input.TransformerConfig.ToTransformerConfigDto(input.TransformerConfig),
+		Config:      input.TransformerConfig.ToTransformerConfigDto(),
 		CreatedAt:   timestamppb.New(input.CreatedAt.Time),
 		UpdatedAt:   timestamppb.New(input.UpdatedAt.Time),
 		AccountId:   nucleusdb.UUIDString(input.AccountID),

--- a/backend/internal/nucleusdb/mock_DBTX.go
+++ b/backend/internal/nucleusdb/mock_DBTX.go
@@ -28,6 +28,10 @@ func (_m *MockDBTX) EXPECT() *MockDBTX_Expecter {
 func (_m *MockDBTX) Begin(ctx context.Context) (pgx.Tx, error) {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Begin")
+	}
+
 	var r0 pgx.Tx
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context) (pgx.Tx, error)); ok {
@@ -81,6 +85,10 @@ func (_c *MockDBTX_Begin_Call) RunAndReturn(run func(context.Context) (pgx.Tx, e
 // BeginTx provides a mock function with given fields: ctx, txOptions
 func (_m *MockDBTX) BeginTx(ctx context.Context, txOptions pgx.TxOptions) (pgx.Tx, error) {
 	ret := _m.Called(ctx, txOptions)
+
+	if len(ret) == 0 {
+		panic("no return value specified for BeginTx")
+	}
 
 	var r0 pgx.Tx
 	var r1 error
@@ -136,6 +144,10 @@ func (_c *MockDBTX_BeginTx_Call) RunAndReturn(run func(context.Context, pgx.TxOp
 // CopyFrom provides a mock function with given fields: ctx, tableName, columnNames, rowSrc
 func (_m *MockDBTX) CopyFrom(ctx context.Context, tableName pgx.Identifier, columnNames []string, rowSrc pgx.CopyFromSource) (int64, error) {
 	ret := _m.Called(ctx, tableName, columnNames, rowSrc)
+
+	if len(ret) == 0 {
+		panic("no return value specified for CopyFrom")
+	}
 
 	var r0 int64
 	var r1 error
@@ -194,6 +206,10 @@ func (_m *MockDBTX) Exec(_a0 context.Context, _a1 string, _a2 ...interface{}) (p
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Exec")
+	}
 
 	var r0 pgconn.CommandTag
 	var r1 error
@@ -256,6 +272,10 @@ func (_c *MockDBTX_Exec_Call) RunAndReturn(run func(context.Context, string, ...
 func (_m *MockDBTX) Ping(ctx context.Context) error {
 	ret := _m.Called(ctx)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Ping")
+	}
+
 	var r0 error
 	if rf, ok := ret.Get(0).(func(context.Context) error); ok {
 		r0 = rf(ctx)
@@ -300,6 +320,10 @@ func (_m *MockDBTX) Query(_a0 context.Context, _a1 string, _a2 ...interface{}) (
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Query")
+	}
 
 	var r0 pgx.Rows
 	var r1 error
@@ -366,6 +390,10 @@ func (_m *MockDBTX) QueryRow(_a0 context.Context, _a1 string, _a2 ...interface{}
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryRow")
+	}
 
 	var r0 pgx.Row
 	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) pgx.Row); ok {

--- a/backend/internal/temporal/client-manager/manager-client.go
+++ b/backend/internal/temporal/client-manager/manager-client.go
@@ -279,10 +279,12 @@ func (t *TemporalClientManager) DoesAccountHaveTemporalWorkspace(
 		return false, err
 	}
 	_, err = nsclient.Describe(ctx, tc.Namespace)
-	if err != nil && !errors.Is(err, serviceerror.NewNamespaceNotFound(tc.Namespace)) {
+	if err != nil {
+		_, ok := err.(*serviceerror.NamespaceNotFound)
+		if ok {
+			return false, nil
+		}
 		return false, err
-	} else if err != nil && errors.Is(err, serviceerror.NewNamespaceNotFound(tc.Namespace)) {
-		return false, nil
 	}
 	return true, nil
 }

--- a/backend/internal/temporal/client-manager/manager-client.go
+++ b/backend/internal/temporal/client-manager/manager-client.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"sync"
 
+	"go.temporal.io/api/serviceerror"
 	temporalclient "go.temporal.io/sdk/client"
 
 	"github.com/jackc/pgx/v5/pgtype"
@@ -33,6 +34,12 @@ type TemporalClientManagerClient interface {
 	GetWorkflowClientByAccount(ctx context.Context, accountId string, logger *slog.Logger) (temporalclient.Client, error)
 	GetScheduleClientByAccount(ctx context.Context, accountId string, logger *slog.Logger) (temporalclient.ScheduleClient, error)
 	GetScheduleHandleClientByAccount(ctx context.Context, accountId string, scheduleId string, logger *slog.Logger) (temporalclient.ScheduleHandle, error)
+	GetTemporalConfigByAccount(ctx context.Context, accountId string) (*pg_models.TemporalConfig, error)
+	DoesAccountHaveTemporalWorkspace(
+		ctx context.Context,
+		accountId string,
+		logger *slog.Logger,
+	) (bool, error)
 }
 
 type DB interface {
@@ -199,7 +206,7 @@ func (t *TemporalClientManager) getNewNSClientByAccount(
 	accountId string,
 	logger *slog.Logger,
 ) (temporalclient.NamespaceClient, error) {
-	tc, err := t.getTemporalConfigByAccount(ctx, accountId)
+	tc, err := t.GetTemporalConfigByAccount(ctx, accountId)
 	if err != nil {
 		return nil, err
 	}
@@ -215,7 +222,7 @@ func (t *TemporalClientManager) getNewWFClientByAccount(
 	accountId string,
 	logger *slog.Logger,
 ) (temporalclient.Client, error) {
-	tc, err := t.getTemporalConfigByAccount(ctx, accountId)
+	tc, err := t.GetTemporalConfigByAccount(ctx, accountId)
 	if err != nil {
 		return nil, err
 	}
@@ -225,7 +232,7 @@ func (t *TemporalClientManager) getNewWFClientByAccount(
 	return temporalclient.NewLazyClient(*t.getClientOptions(accountId, tc, logger))
 }
 
-func (t *TemporalClientManager) getTemporalConfigByAccount(
+func (t *TemporalClientManager) GetTemporalConfigByAccount(
 	ctx context.Context,
 	accountId string,
 ) (*pg_models.TemporalConfig, error) {
@@ -253,6 +260,31 @@ func (t *TemporalClientManager) getTemporalConfigByAccount(
 		tc.Url = dbConfig.Url
 	}
 	return tc, nil
+}
+
+func (t *TemporalClientManager) DoesAccountHaveTemporalWorkspace(
+	ctx context.Context,
+	accountId string,
+	logger *slog.Logger,
+) (bool, error) {
+	tc, err := t.GetTemporalConfigByAccount(ctx, accountId)
+	if err != nil {
+		return false, err
+	}
+	if tc.Namespace == "" {
+		return false, nil
+	}
+	nsclient, err := t.GetNamespaceClientByAccount(ctx, accountId, logger)
+	if err != nil {
+		return false, err
+	}
+	_, err = nsclient.Describe(ctx, tc.Namespace)
+	if err != nil && !errors.Is(err, serviceerror.NewNamespaceNotFound(tc.Namespace)) {
+		return false, err
+	} else if err != nil && errors.Is(err, serviceerror.NewNamespaceNotFound(tc.Namespace)) {
+		return false, nil
+	}
+	return true, nil
 }
 
 func (t *TemporalClientManager) getClientOptions(

--- a/backend/internal/temporal/client-manager/manager-client_test.go
+++ b/backend/internal/temporal/client-manager/manager-client_test.go
@@ -267,7 +267,7 @@ func Test_ManagerClient_GetNamespaceClientByAccount_ConcurrentRequests(t *testin
 	assert.True(t, mockdb.AssertNumberOfCalls(t, "GetTemporalConfigByAccount", 1))
 }
 
-func Test_ManagerClient_getTemporalConfigByAccount_Db(t *testing.T) {
+func Test_ManagerClient_GetTemporalConfigByAccount_Db(t *testing.T) {
 	mockdb := NewMockDB(t)
 	mockdbtx := nucleusdb.NewMockDBTX(t)
 	mgr := New(&Config{}, mockdb, mockdbtx)
@@ -279,7 +279,7 @@ func Test_ManagerClient_getTemporalConfigByAccount_Db(t *testing.T) {
 	}, nil)
 
 	accountUuid := uuid.New().String()
-	tc, err := mgr.getTemporalConfigByAccount(context.Background(), accountUuid)
+	tc, err := mgr.GetTemporalConfigByAccount(context.Background(), accountUuid)
 	assert.NoError(t, err)
 	assert.NotNil(t, tc)
 	assert.Equal(t, tc, &pg_models.TemporalConfig{
@@ -289,7 +289,7 @@ func Test_ManagerClient_getTemporalConfigByAccount_Db(t *testing.T) {
 	})
 }
 
-func Test_ManagerClient_getTemporalConfigByAccount_Default(t *testing.T) {
+func Test_ManagerClient_GetTemporalConfigByAccount_Default(t *testing.T) {
 	mockdb := NewMockDB(t)
 	mockdbtx := nucleusdb.NewMockDBTX(t)
 	mgr := New(&Config{DefaultTemporalConfig: defaultTemporalConfig}, mockdb, mockdbtx)
@@ -297,7 +297,7 @@ func Test_ManagerClient_getTemporalConfigByAccount_Default(t *testing.T) {
 	mockdb.On("GetTemporalConfigByAccount", mock.Anything, mock.Anything, mock.Anything).Return(&pg_models.TemporalConfig{}, nil)
 
 	accountUuid := uuid.New().String()
-	tc, err := mgr.getTemporalConfigByAccount(context.Background(), accountUuid)
+	tc, err := mgr.GetTemporalConfigByAccount(context.Background(), accountUuid)
 	assert.NoError(t, err)
 	assert.NotNil(t, tc)
 	assert.Equal(t, tc, &pg_models.TemporalConfig{
@@ -307,7 +307,7 @@ func Test_ManagerClient_getTemporalConfigByAccount_Default(t *testing.T) {
 	})
 }
 
-func Test_ManagerClient_getTemporalConfigByAccount_Empty(t *testing.T) {
+func Test_ManagerClient_GetTemporalConfigByAccount_Empty(t *testing.T) {
 	mockdb := NewMockDB(t)
 	mockdbtx := nucleusdb.NewMockDBTX(t)
 	mgr := New(&Config{DefaultTemporalConfig: nil}, mockdb, mockdbtx)
@@ -315,7 +315,7 @@ func Test_ManagerClient_getTemporalConfigByAccount_Empty(t *testing.T) {
 	mockdb.On("GetTemporalConfigByAccount", mock.Anything, mock.Anything, mock.Anything).Return(&pg_models.TemporalConfig{}, nil)
 
 	accountUuid := uuid.New().String()
-	tc, err := mgr.getTemporalConfigByAccount(context.Background(), accountUuid)
+	tc, err := mgr.GetTemporalConfigByAccount(context.Background(), accountUuid)
 	assert.NoError(t, err)
 	assert.NotNil(t, tc)
 	assert.Equal(t, tc, &pg_models.TemporalConfig{

--- a/backend/internal/temporal/client-manager/mock_DB.go
+++ b/backend/internal/temporal/client-manager/mock_DB.go
@@ -30,6 +30,10 @@ func (_m *MockDB) EXPECT() *MockDB_Expecter {
 func (_m *MockDB) GetTemporalConfigByAccount(ctx context.Context, db db_queries.DBTX, accountId pgtype.UUID) (*pg_models.TemporalConfig, error) {
 	ret := _m.Called(ctx, db, accountId)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetTemporalConfigByAccount")
+	}
+
 	var r0 *pg_models.TemporalConfig
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, db_queries.DBTX, pgtype.UUID) (*pg_models.TemporalConfig, error)); ok {

--- a/backend/internal/temporal/client-manager/mock_Temporal.go
+++ b/backend/internal/temporal/client-manager/mock_Temporal.go
@@ -1,0 +1,281 @@
+//nolint:all
+package clientmanager
+
+import (
+	"context"
+
+	"github.com/stretchr/testify/mock"
+	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/operatorservice/v1"
+	"go.temporal.io/api/workflowservice/v1"
+	temporalclient "go.temporal.io/sdk/client"
+	"go.temporal.io/sdk/converter"
+)
+
+// MockTemporalClient is a mock of temporal client interface.
+type MockTemporalClient struct {
+	mock.Mock
+}
+
+func (m *MockTemporalClient) ExecuteWorkflow(ctx context.Context, options temporalclient.StartWorkflowOptions, workflow interface{}, args ...interface{}) (temporalclient.WorkflowRun, error) {
+	ret := m.Called(ctx, options, workflow, args)
+	return ret.Get(0).(temporalclient.WorkflowRun), ret.Error(1)
+}
+
+func (m *MockTemporalClient) GetWorkflow(ctx context.Context, workflowID string, runID string) temporalclient.WorkflowRun {
+	ret := m.Called(ctx, workflowID, runID)
+	return ret.Get(0).(temporalclient.WorkflowRun)
+}
+
+func (m *MockTemporalClient) SignalWorkflow(ctx context.Context, workflowID string, runID string, signalName string, arg interface{}) error {
+	args := m.Called(ctx, workflowID, runID, signalName, arg)
+	return args.Error(0)
+}
+
+func (m *MockTemporalClient) SignalWithStartWorkflow(ctx context.Context, workflowID string, signalName string, signalArg interface{}, options temporalclient.StartWorkflowOptions, workflow interface{}, workflowArgs ...interface{}) (temporalclient.WorkflowRun, error) {
+	args := m.Called(ctx, workflowID, signalName, signalArg, options, workflow, workflowArgs)
+	return args.Get(0).(temporalclient.WorkflowRun), args.Error(1)
+}
+
+func (m *MockTemporalClient) CancelWorkflow(ctx context.Context, workflowID string, runID string) error {
+	args := m.Called(ctx, workflowID, runID)
+	return args.Error(0)
+}
+
+func (m *MockTemporalClient) TerminateWorkflow(ctx context.Context, workflowID string, runID string, reason string, details ...interface{}) error {
+	args := m.Called(ctx, workflowID, runID, reason, details)
+	return args.Error(0)
+}
+
+func (m *MockTemporalClient) GetWorkflowHistory(ctx context.Context, workflowID string, runID string, isLongPoll bool, filterType enums.HistoryEventFilterType) temporalclient.HistoryEventIterator {
+	args := m.Called(ctx, workflowID, runID, isLongPoll, filterType)
+	return args.Get(0).(temporalclient.HistoryEventIterator)
+}
+
+func (m *MockTemporalClient) CompleteActivity(ctx context.Context, taskToken []byte, result interface{}, err error) error {
+	args := m.Called(ctx, taskToken, result, err)
+	return args.Error(0)
+}
+
+func (m *MockTemporalClient) CompleteActivityByID(ctx context.Context, namespace, workflowID, runID, activityID string, result interface{}, err error) error {
+	args := m.Called(ctx, namespace, workflowID, runID, activityID, result, err)
+	return args.Error(0)
+}
+
+func (m *MockTemporalClient) RecordActivityHeartbeat(ctx context.Context, taskToken []byte, details ...interface{}) error {
+	args := m.Called(ctx, taskToken, details)
+	return args.Error(0)
+}
+
+func (m *MockTemporalClient) RecordActivityHeartbeatByID(ctx context.Context, namespace, workflowID, runID, activityID string, details ...interface{}) error {
+	args := m.Called(ctx, namespace, workflowID, runID, activityID, details)
+	return args.Error(0)
+}
+
+func (m *MockTemporalClient) ListClosedWorkflow(ctx context.Context, request *workflowservice.ListClosedWorkflowExecutionsRequest) (*workflowservice.ListClosedWorkflowExecutionsResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*workflowservice.ListClosedWorkflowExecutionsResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) ListOpenWorkflow(ctx context.Context, request *workflowservice.ListOpenWorkflowExecutionsRequest) (*workflowservice.ListOpenWorkflowExecutionsResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*workflowservice.ListOpenWorkflowExecutionsResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) ListWorkflow(ctx context.Context, request *workflowservice.ListWorkflowExecutionsRequest) (*workflowservice.ListWorkflowExecutionsResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*workflowservice.ListWorkflowExecutionsResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) ListArchivedWorkflow(ctx context.Context, request *workflowservice.ListArchivedWorkflowExecutionsRequest) (*workflowservice.ListArchivedWorkflowExecutionsResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*workflowservice.ListArchivedWorkflowExecutionsResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) ScanWorkflow(ctx context.Context, request *workflowservice.ScanWorkflowExecutionsRequest) (*workflowservice.ScanWorkflowExecutionsResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*workflowservice.ScanWorkflowExecutionsResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) CountWorkflow(ctx context.Context, request *workflowservice.CountWorkflowExecutionsRequest) (*workflowservice.CountWorkflowExecutionsResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*workflowservice.CountWorkflowExecutionsResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) GetSearchAttributes(ctx context.Context) (*workflowservice.GetSearchAttributesResponse, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*workflowservice.GetSearchAttributesResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) QueryWorkflow(ctx context.Context, workflowID string, runID string, queryType string, args ...interface{}) (converter.EncodedValue, error) {
+	mockArgs := m.Called(ctx, workflowID, runID, queryType, args)
+	return mockArgs.Get(0).(converter.EncodedValue), mockArgs.Error(1)
+}
+
+func (m *MockTemporalClient) QueryWorkflowWithOptions(ctx context.Context, request *temporalclient.QueryWorkflowWithOptionsRequest) (*temporalclient.QueryWorkflowWithOptionsResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*temporalclient.QueryWorkflowWithOptionsResponse), args.Error(1)
+}
+func (m *MockTemporalClient) DescribeWorkflowExecution(ctx context.Context, workflowID, runID string) (*workflowservice.DescribeWorkflowExecutionResponse, error) {
+	args := m.Called(ctx, workflowID, runID)
+	return args.Get(0).(*workflowservice.DescribeWorkflowExecutionResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) DescribeTaskQueue(ctx context.Context, taskqueue string, taskqueueType enums.TaskQueueType) (*workflowservice.DescribeTaskQueueResponse, error) {
+	args := m.Called(ctx, taskqueue, taskqueueType)
+	return args.Get(0).(*workflowservice.DescribeTaskQueueResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) ResetWorkflowExecution(ctx context.Context, request *workflowservice.ResetWorkflowExecutionRequest) (*workflowservice.ResetWorkflowExecutionResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*workflowservice.ResetWorkflowExecutionResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) UpdateWorkerBuildIdCompatibility(ctx context.Context, options *temporalclient.UpdateWorkerBuildIdCompatibilityOptions) error {
+	args := m.Called(ctx, options)
+	return args.Error(0)
+}
+
+func (m *MockTemporalClient) GetWorkerBuildIdCompatibility(ctx context.Context, options *temporalclient.GetWorkerBuildIdCompatibilityOptions) (*temporalclient.WorkerBuildIDVersionSets, error) {
+	args := m.Called(ctx, options)
+	return args.Get(0).(*temporalclient.WorkerBuildIDVersionSets), args.Error(1)
+}
+
+func (m *MockTemporalClient) GetWorkerTaskReachability(ctx context.Context, options *temporalclient.GetWorkerTaskReachabilityOptions) (*temporalclient.WorkerTaskReachability, error) {
+	args := m.Called(ctx, options)
+	return args.Get(0).(*temporalclient.WorkerTaskReachability), args.Error(1)
+}
+
+func (m *MockTemporalClient) CheckHealth(ctx context.Context, request *temporalclient.CheckHealthRequest) (*temporalclient.CheckHealthResponse, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(*temporalclient.CheckHealthResponse), args.Error(1)
+}
+
+func (m *MockTemporalClient) UpdateWorkflow(ctx context.Context, workflowID string, workflowRunID string, updateName string, args ...interface{}) (temporalclient.WorkflowUpdateHandle, error) {
+	mockArgs := m.Called(ctx, workflowID, workflowRunID, updateName, args)
+	return mockArgs.Get(0).(temporalclient.WorkflowUpdateHandle), mockArgs.Error(1)
+}
+
+func (m *MockTemporalClient) UpdateWorkflowWithOptions(ctx context.Context, request *temporalclient.UpdateWorkflowWithOptionsRequest) (temporalclient.WorkflowUpdateHandle, error) {
+	args := m.Called(ctx, request)
+	return args.Get(0).(temporalclient.WorkflowUpdateHandle), args.Error(1)
+}
+
+func (m *MockTemporalClient) GetWorkflowUpdateHandle(ref temporalclient.GetWorkflowUpdateHandleOptions) temporalclient.WorkflowUpdateHandle {
+	args := m.Called(ref)
+	return args.Get(0).(temporalclient.WorkflowUpdateHandle)
+}
+
+func (m *MockTemporalClient) WorkflowService() workflowservice.WorkflowServiceClient {
+	args := m.Called()
+	return args.Get(0).(workflowservice.WorkflowServiceClient)
+}
+
+func (m *MockTemporalClient) OperatorService() operatorservice.OperatorServiceClient {
+	args := m.Called()
+	return args.Get(0).(operatorservice.OperatorServiceClient)
+}
+
+func (m *MockTemporalClient) ScheduleClient() temporalclient.ScheduleClient {
+	args := m.Called()
+	return args.Get(0).(temporalclient.ScheduleClient)
+}
+
+func (m *MockTemporalClient) Close() {
+	m.Called()
+}
+
+// MockScheduleHandle is a mock of ScheduleHandle interface.
+type MockScheduleHandle struct {
+	mock.Mock
+}
+
+func (m *MockScheduleHandle) GetID() string {
+	args := m.Called()
+	return args.String(0)
+}
+
+func (m *MockScheduleHandle) Delete(ctx context.Context) error {
+	args := m.Called(ctx)
+	return args.Error(0)
+}
+
+func (m *MockScheduleHandle) Backfill(ctx context.Context, options temporalclient.ScheduleBackfillOptions) error {
+	args := m.Called(ctx, options)
+	return args.Error(0)
+}
+
+func (m *MockScheduleHandle) Update(ctx context.Context, options temporalclient.ScheduleUpdateOptions) error {
+	args := m.Called(ctx, options)
+	return args.Error(0)
+}
+
+func (m *MockScheduleHandle) Describe(ctx context.Context) (*temporalclient.ScheduleDescription, error) {
+	args := m.Called(ctx)
+	return args.Get(0).(*temporalclient.ScheduleDescription), args.Error(1)
+}
+
+func (m *MockScheduleHandle) Trigger(ctx context.Context, options temporalclient.ScheduleTriggerOptions) error {
+	args := m.Called(ctx, options)
+	return args.Error(0)
+}
+
+func (m *MockScheduleHandle) Pause(ctx context.Context, options temporalclient.SchedulePauseOptions) error {
+	args := m.Called(ctx, options)
+	return args.Error(0)
+}
+
+func (m *MockScheduleHandle) Unpause(ctx context.Context, options temporalclient.ScheduleUnpauseOptions) error {
+	args := m.Called(ctx, options)
+	return args.Error(0)
+}
+
+// MockNamespaceClient is a mock of Namespace Client interface.
+type MockNamespaceClient struct {
+	mock.Mock
+}
+
+func (_m *MockNamespaceClient) Register(ctx context.Context, request *workflowservice.RegisterNamespaceRequest) error {
+	ret := _m.Called(ctx, request)
+	return ret.Error(0)
+}
+
+func (_m *MockNamespaceClient) Describe(ctx context.Context, name string) (*workflowservice.DescribeNamespaceResponse, error) {
+	ret := _m.Called(ctx, name)
+	return ret.Get(0).(*workflowservice.DescribeNamespaceResponse), ret.Error(1)
+}
+
+func (_m *MockNamespaceClient) Update(ctx context.Context, request *workflowservice.UpdateNamespaceRequest) error {
+	ret := _m.Called(ctx, request)
+	return ret.Error(0)
+}
+
+func (_m *MockNamespaceClient) Close() {
+	_m.Called()
+}
+
+// MockScheduleClient is a mock of Schedule Client interface.
+type MockScheduleClient struct {
+	mock.Mock
+	Handle temporalclient.ScheduleHandle
+}
+
+func (_m *MockScheduleClient) Create(ctx context.Context, options temporalclient.ScheduleOptions) (temporalclient.ScheduleHandle, error) {
+	args := _m.Called(ctx, options)
+	if h := args.Get(0); h != nil {
+		return h.(temporalclient.ScheduleHandle), args.Error(1)
+	}
+	return nil, args.Error(1)
+}
+
+func (_m *MockScheduleClient) List(ctx context.Context, options temporalclient.ScheduleListOptions) (temporalclient.ScheduleListIterator, error) {
+	return nil, nil
+}
+
+func (_m *MockScheduleClient) GetHandle(ctx context.Context, scheduleID string) temporalclient.ScheduleHandle {
+	args := _m.Called(ctx, scheduleID)
+	if h := args.Get(0); h != nil {
+		return h.(temporalclient.ScheduleHandle)
+	}
+	return nil
+}

--- a/backend/internal/temporal/client-manager/mock_TemporalClientManagerClient.go
+++ b/backend/internal/temporal/client-manager/mock_TemporalClientManagerClient.go
@@ -9,6 +9,8 @@ import (
 
 	mock "github.com/stretchr/testify/mock"
 
+	pg_models "github.com/nucleuscloud/neosync/backend/sql/postgresql/models"
+
 	slog "log/slog"
 )
 
@@ -93,9 +95,71 @@ func (_c *MockTemporalClientManagerClient_ClearWorkflowClientByAccount_Call) Run
 	return _c
 }
 
+// DoesAccountHaveTemporalWorkspace provides a mock function with given fields: ctx, accountId, logger
+func (_m *MockTemporalClientManagerClient) DoesAccountHaveTemporalWorkspace(ctx context.Context, accountId string, logger *slog.Logger) (bool, error) {
+	ret := _m.Called(ctx, accountId, logger)
+
+	if len(ret) == 0 {
+		panic("no return value specified for DoesAccountHaveTemporalWorkspace")
+	}
+
+	var r0 bool
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string, *slog.Logger) (bool, error)); ok {
+		return rf(ctx, accountId, logger)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string, *slog.Logger) bool); ok {
+		r0 = rf(ctx, accountId, logger)
+	} else {
+		r0 = ret.Get(0).(bool)
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string, *slog.Logger) error); ok {
+		r1 = rf(ctx, accountId, logger)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'DoesAccountHaveTemporalWorkspace'
+type MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call struct {
+	*mock.Call
+}
+
+// DoesAccountHaveTemporalWorkspace is a helper method to define mock.On call
+//   - ctx context.Context
+//   - accountId string
+//   - logger *slog.Logger
+func (_e *MockTemporalClientManagerClient_Expecter) DoesAccountHaveTemporalWorkspace(ctx interface{}, accountId interface{}, logger interface{}) *MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call {
+	return &MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call{Call: _e.mock.On("DoesAccountHaveTemporalWorkspace", ctx, accountId, logger)}
+}
+
+func (_c *MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call) Run(run func(ctx context.Context, accountId string, logger *slog.Logger)) *MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string), args[2].(*slog.Logger))
+	})
+	return _c
+}
+
+func (_c *MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call) Return(_a0 bool, _a1 error) *MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call) RunAndReturn(run func(context.Context, string, *slog.Logger) (bool, error)) *MockTemporalClientManagerClient_DoesAccountHaveTemporalWorkspace_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetNamespaceClientByAccount provides a mock function with given fields: ctx, accountId, logger
 func (_m *MockTemporalClientManagerClient) GetNamespaceClientByAccount(ctx context.Context, accountId string, logger *slog.Logger) (client.NamespaceClient, error) {
 	ret := _m.Called(ctx, accountId, logger)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetNamespaceClientByAccount")
+	}
 
 	var r0 client.NamespaceClient
 	var r1 error
@@ -153,6 +217,10 @@ func (_c *MockTemporalClientManagerClient_GetNamespaceClientByAccount_Call) RunA
 func (_m *MockTemporalClientManagerClient) GetScheduleClientByAccount(ctx context.Context, accountId string, logger *slog.Logger) (client.ScheduleClient, error) {
 	ret := _m.Called(ctx, accountId, logger)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetScheduleClientByAccount")
+	}
+
 	var r0 client.ScheduleClient
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, *slog.Logger) (client.ScheduleClient, error)); ok {
@@ -209,6 +277,10 @@ func (_c *MockTemporalClientManagerClient_GetScheduleClientByAccount_Call) RunAn
 func (_m *MockTemporalClientManagerClient) GetScheduleHandleClientByAccount(ctx context.Context, accountId string, scheduleId string, logger *slog.Logger) (client.ScheduleHandle, error) {
 	ret := _m.Called(ctx, accountId, scheduleId, logger)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetScheduleHandleClientByAccount")
+	}
+
 	var r0 client.ScheduleHandle
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, string, *slog.Logger) (client.ScheduleHandle, error)); ok {
@@ -262,9 +334,72 @@ func (_c *MockTemporalClientManagerClient_GetScheduleHandleClientByAccount_Call)
 	return _c
 }
 
+// GetTemporalConfigByAccount provides a mock function with given fields: ctx, accountId
+func (_m *MockTemporalClientManagerClient) GetTemporalConfigByAccount(ctx context.Context, accountId string) (*pg_models.TemporalConfig, error) {
+	ret := _m.Called(ctx, accountId)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTemporalConfigByAccount")
+	}
+
+	var r0 *pg_models.TemporalConfig
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, string) (*pg_models.TemporalConfig, error)); ok {
+		return rf(ctx, accountId)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, string) *pg_models.TemporalConfig); ok {
+		r0 = rf(ctx, accountId)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*pg_models.TemporalConfig)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
+		r1 = rf(ctx, accountId)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetTemporalConfigByAccount'
+type MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call struct {
+	*mock.Call
+}
+
+// GetTemporalConfigByAccount is a helper method to define mock.On call
+//   - ctx context.Context
+//   - accountId string
+func (_e *MockTemporalClientManagerClient_Expecter) GetTemporalConfigByAccount(ctx interface{}, accountId interface{}) *MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call {
+	return &MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call{Call: _e.mock.On("GetTemporalConfigByAccount", ctx, accountId)}
+}
+
+func (_c *MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call) Run(run func(ctx context.Context, accountId string)) *MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(string))
+	})
+	return _c
+}
+
+func (_c *MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call) Return(_a0 *pg_models.TemporalConfig, _a1 error) *MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call) RunAndReturn(run func(context.Context, string) (*pg_models.TemporalConfig, error)) *MockTemporalClientManagerClient_GetTemporalConfigByAccount_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetWorkflowClientByAccount provides a mock function with given fields: ctx, accountId, logger
 func (_m *MockTemporalClientManagerClient) GetWorkflowClientByAccount(ctx context.Context, accountId string, logger *slog.Logger) (client.Client, error) {
 	ret := _m.Called(ctx, accountId, logger)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetWorkflowClientByAccount")
+	}
 
 	var r0 client.Client
 	var r1 error

--- a/backend/services/mgmt/v1alpha1/job-service/jobs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/jobs.go
@@ -135,11 +135,16 @@ func (s *Service) doesAccountHaveTemporalNamespace(
 	accountUuid pgtype.UUID,
 	logger *slog.Logger,
 ) (bool, error) {
-	tc, err := s.db.Q.GetTemporalConfigByAccount(ctx, s.db.Db, accountUuid)
+	resp, err := s.useraccountService.GetAccountTemporalConfig(ctx, connect.NewRequest(&mgmtv1alpha1.GetAccountTemporalConfigRequest{
+		AccountId: nucleusdb.UUIDString(accountUuid),
+	}))
 	if err != nil {
 		return false, err
 	}
-	if tc.Namespace == "" {
+
+	tc := resp.Msg.Config
+
+	if resp.Msg.Config == nil || resp.Msg.Config.Namespace == "" {
 		return false, nil
 	}
 	nsclient, err := s.temporalWfManager.GetNamespaceClientByAccount(ctx, nucleusdb.UUIDString(accountUuid), logger)

--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -70,7 +70,7 @@ func (s *Service) GetJobRuns(
 	if err != nil {
 		return nil, err
 	}
-	tconfig, err := s.db.Q.GetTemporalConfigByAccount(ctx, s.db.Db, accountUuid)
+	tconfig, err := s.temporalWfManager.GetTemporalConfigByAccount(ctx, accountId)
 	if err != nil {
 		return nil, err
 	}
@@ -389,11 +389,8 @@ func (s *Service) getVerifiedJobRun(
 	if err != nil {
 		return nil, err
 	}
-	accountUuid, err := nucleusdb.ToUuid(accountId)
-	if err != nil {
-		return nil, err
-	}
-	hasNs, err := s.doesAccountHaveTemporalNamespace(ctx, accountUuid, logger)
+
+	hasNs, err := s.temporalWfManager.DoesAccountHaveTemporalWorkspace(ctx, accountId, logger)
 	if err != nil {
 		return nil, err
 	}
@@ -404,7 +401,7 @@ func (s *Service) getVerifiedJobRun(
 	if err != nil {
 		return nil, err
 	}
-	tconfig, err := s.db.Q.GetTemporalConfigByAccount(ctx, s.db.Db, accountUuid)
+	tconfig, err := s.temporalWfManager.GetTemporalConfigByAccount(ctx, accountId)
 	if err != nil {
 		return nil, err
 	}

--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -7,7 +7,6 @@ import (
 	"strings"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5/pgtype"
 	mgmtv1alpha1 "github.com/nucleuscloud/neosync/backend/gen/go/protos/mgmt/v1alpha1"
 	logger_interceptor "github.com/nucleuscloud/neosync/backend/internal/connect/interceptors/logger"
 	"github.com/nucleuscloud/neosync/backend/internal/dtomaps"
@@ -32,7 +31,6 @@ func (s *Service) GetJobRuns(
 	logger := logger_interceptor.GetLoggerFromContextOrDefault(ctx)
 
 	var accountId string
-	var accountUuid pgtype.UUID
 	jobIds := []string{}
 	var workflows []*workflowpb.WorkflowExecutionInfo
 	switch id := req.Msg.Id.(type) {
@@ -45,7 +43,6 @@ func (s *Service) GetJobRuns(
 		if err != nil {
 			return nil, err
 		}
-		accountUuid = job.AccountID
 		accountId = nucleusdb.UUIDString(job.AccountID)
 		jobIds = append(jobIds, id.JobId)
 	case *mgmtv1alpha1.GetJobRunsRequest_AccountId:
@@ -54,8 +51,7 @@ func (s *Service) GetJobRuns(
 		if err != nil {
 			return nil, err
 		}
-		accountUuid = accountPgUuid
-		jobs, err := s.db.Q.GetJobsByAccount(ctx, s.db.Db, accountUuid)
+		jobs, err := s.db.Q.GetJobsByAccount(ctx, s.db.Db, accountPgUuid)
 		if err != nil {
 			return nil, err
 		}

--- a/backend/services/mgmt/v1alpha1/user-account-service/account-temporal-config_test.go
+++ b/backend/services/mgmt/v1alpha1/user-account-service/account-temporal-config_test.go
@@ -5,11 +5,11 @@ import (
 	"testing"
 
 	"connectrpc.com/connect"
-	"github.com/jackc/pgx/v5"
 	db_queries "github.com/nucleuscloud/neosync/backend/gen/go/db"
 	mgmtv1alpha1 "github.com/nucleuscloud/neosync/backend/gen/go/protos/mgmt/v1alpha1"
 	"github.com/nucleuscloud/neosync/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect"
 	"github.com/nucleuscloud/neosync/backend/internal/nucleusdb"
+	clientmanager "github.com/nucleuscloud/neosync/backend/internal/temporal/client-manager"
 	pg_models "github.com/nucleuscloud/neosync/backend/sql/postgresql/models"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
@@ -23,16 +23,14 @@ func Test_Service_GetAccountTemporalConfig(t *testing.T) {
 	mockDbtx := nucleusdb.NewMockDBTX(t)
 	mockQuerier := db_queries.NewMockQuerier(t)
 	mockAuthService := mgmtv1alpha1connect.NewMockAuthServiceClient(t)
+	mockTfWfMgr := clientmanager.NewMockTemporalClientManagerClient(t)
 
 	mockQuerier.On("GetAnonymousUser", mock.Anything, mock.Anything).Return(*getAnonTestApiUser(), nil)
-	mockQuerier.On("GetTemporalConfigByUserAccount", mock.Anything, mock.Anything, mock.Anything).
+	mockQuerier.On("IsUserInAccount", mock.Anything, mock.Anything, mock.Anything).Return(int64(1), nil)
+	mockTfWfMgr.On("GetTemporalConfigByAccount", mock.Anything, mock.Anything).
 		Return(&pg_models.TemporalConfig{Namespace: "foo", SyncJobQueueName: "foo-queue", Url: "localhost:1234"}, nil)
 
-	service := New(&Config{IsAuthEnabled: false, Temporal: &TemporalConfig{
-		DefaultTemporalNamespace:        "default-ns",
-		DefaultTemporalSyncJobQueueName: "default-sync",
-		DefaultTemporalUrl:              "default-url",
-	}}, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService)
+	service := New(&Config{IsAuthEnabled: false}, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService, mockTfWfMgr)
 
 	resp, err := service.GetAccountTemporalConfig(context.Background(), connect.NewRequest(&mgmtv1alpha1.GetAccountTemporalConfigRequest{
 		AccountId: fakeAccountId,
@@ -45,62 +43,11 @@ func Test_Service_GetAccountTemporalConfig(t *testing.T) {
 	})
 }
 
-func Test_Service_GetAccountTemporalConfig_Defaults(t *testing.T) {
-	mockDbtx := nucleusdb.NewMockDBTX(t)
-	mockQuerier := db_queries.NewMockQuerier(t)
-	mockAuthService := mgmtv1alpha1connect.NewMockAuthServiceClient(t)
-
-	mockQuerier.On("GetAnonymousUser", mock.Anything, mock.Anything).Return(*getAnonTestApiUser(), nil)
-	mockQuerier.On("GetTemporalConfigByUserAccount", mock.Anything, mock.Anything, mock.Anything).
-		Return(nil, pgx.ErrNoRows)
-
-	service := New(&Config{IsAuthEnabled: false, Temporal: &TemporalConfig{
-		DefaultTemporalNamespace:        "default-ns",
-		DefaultTemporalSyncJobQueueName: "default-sync",
-		DefaultTemporalUrl:              "default-url",
-	}}, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService)
-
-	resp, err := service.GetAccountTemporalConfig(context.Background(), connect.NewRequest(&mgmtv1alpha1.GetAccountTemporalConfigRequest{
-		AccountId: fakeAccountId,
-	}))
-	assert.Nil(t, err)
-	assert.Equal(t, resp.Msg.Config, &mgmtv1alpha1.AccountTemporalConfig{
-		Namespace:        "default-ns",
-		SyncJobQueueName: "default-sync",
-		Url:              "default-url",
-	})
-}
-
-func Test_Service_GetAccountTemporalConfig_EmptyObject(t *testing.T) {
-	mockDbtx := nucleusdb.NewMockDBTX(t)
-	mockQuerier := db_queries.NewMockQuerier(t)
-	mockAuthService := mgmtv1alpha1connect.NewMockAuthServiceClient(t)
-
-	mockQuerier.On("GetAnonymousUser", mock.Anything, mock.Anything).Return(*getAnonTestApiUser(), nil)
-	mockQuerier.On("GetTemporalConfigByUserAccount", mock.Anything, mock.Anything, mock.Anything).
-		Return(&pg_models.TemporalConfig{}, nil)
-
-	service := New(&Config{IsAuthEnabled: false, Temporal: &TemporalConfig{
-		DefaultTemporalNamespace:        "default-ns",
-		DefaultTemporalSyncJobQueueName: "default-sync",
-		DefaultTemporalUrl:              "default-url",
-	}}, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService)
-
-	resp, err := service.GetAccountTemporalConfig(context.Background(), connect.NewRequest(&mgmtv1alpha1.GetAccountTemporalConfigRequest{
-		AccountId: fakeAccountId,
-	}))
-	assert.Nil(t, err)
-	assert.Equal(t, resp.Msg.Config, &mgmtv1alpha1.AccountTemporalConfig{
-		Namespace:        "default-ns",
-		SyncJobQueueName: "default-sync",
-		Url:              "default-url",
-	})
-}
-
 func Test_Service_SetAccountTemporalConfig(t *testing.T) {
 	mockDbtx := nucleusdb.NewMockDBTX(t)
 	mockQuerier := db_queries.NewMockQuerier(t)
 	mockAuthService := mgmtv1alpha1connect.NewMockAuthServiceClient(t)
+	mockTfWfMgr := clientmanager.NewMockTemporalClientManagerClient(t)
 
 	mgmtTc := &mgmtv1alpha1.AccountTemporalConfig{
 		Namespace:        "foo",
@@ -118,7 +65,7 @@ func Test_Service_SetAccountTemporalConfig(t *testing.T) {
 		},
 	}, nil)
 
-	service := New(&Config{IsAuthEnabled: false}, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService)
+	service := New(&Config{IsAuthEnabled: false}, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService, mockTfWfMgr)
 
 	resp, err := service.SetAccountTemporalConfig(context.Background(), connect.NewRequest(&mgmtv1alpha1.SetAccountTemporalConfigRequest{
 		AccountId: fakeAccountId,
@@ -132,13 +79,14 @@ func Test_Service_SetAccountTemporalConfig_NotInAccount(t *testing.T) {
 	mockDbtx := nucleusdb.NewMockDBTX(t)
 	mockQuerier := db_queries.NewMockQuerier(t)
 	mockAuthService := mgmtv1alpha1connect.NewMockAuthServiceClient(t)
+	mockTfWfMgr := clientmanager.NewMockTemporalClientManagerClient(t)
 
 	mgmtTc := &mgmtv1alpha1.AccountTemporalConfig{}
 
 	mockQuerier.On("GetAnonymousUser", mock.Anything, mock.Anything).Return(*getAnonTestApiUser(), nil)
 	mockQuerier.On("IsUserInAccount", mock.Anything, mock.Anything, mock.Anything).Return(int64(0), nil)
 
-	service := New(&Config{IsAuthEnabled: false}, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService)
+	service := New(&Config{IsAuthEnabled: false}, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService, mockTfWfMgr)
 
 	resp, err := service.SetAccountTemporalConfig(context.Background(), connect.NewRequest(&mgmtv1alpha1.SetAccountTemporalConfigRequest{
 		AccountId: fakeAccountId,

--- a/backend/services/mgmt/v1alpha1/user-account-service/service.go
+++ b/backend/services/mgmt/v1alpha1/user-account-service/service.go
@@ -3,34 +3,30 @@ package v1alpha1_useraccountservice
 import (
 	"github.com/nucleuscloud/neosync/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect"
 	"github.com/nucleuscloud/neosync/backend/internal/nucleusdb"
+	clientmanager "github.com/nucleuscloud/neosync/backend/internal/temporal/client-manager"
 )
 
 type Service struct {
-	cfg         *Config
-	db          *nucleusdb.NucleusDb
-	authService mgmtv1alpha1connect.AuthServiceClient
+	cfg                   *Config
+	db                    *nucleusdb.NucleusDb
+	authService           mgmtv1alpha1connect.AuthServiceClient
+	temporalClientManager clientmanager.TemporalClientManagerClient
 }
 
 type Config struct {
 	IsAuthEnabled bool
-	Temporal      *TemporalConfig
-}
-
-type TemporalConfig struct {
-	DefaultTemporalNamespace        string
-	DefaultTemporalSyncJobQueueName string
-	DefaultTemporalUrl              string
 }
 
 func New(
 	cfg *Config,
 	db *nucleusdb.NucleusDb,
 	authService mgmtv1alpha1connect.AuthServiceClient,
+	temporalClientManager clientmanager.TemporalClientManagerClient,
 ) *Service {
-
 	return &Service{
-		cfg:         cfg,
-		db:          db,
-		authService: authService,
+		cfg:                   cfg,
+		db:                    db,
+		authService:           authService,
+		temporalClientManager: temporalClientManager,
 	}
 }

--- a/backend/services/mgmt/v1alpha1/user-account-service/users_test.go
+++ b/backend/services/mgmt/v1alpha1/user-account-service/users_test.go
@@ -17,6 +17,7 @@ import (
 	auth_apikey "github.com/nucleuscloud/neosync/backend/internal/auth/apikey"
 	authjwt "github.com/nucleuscloud/neosync/backend/internal/auth/jwt"
 	"github.com/nucleuscloud/neosync/backend/internal/nucleusdb"
+	clientmanager "github.com/nucleuscloud/neosync/backend/internal/temporal/client-manager"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/mock"
 )
@@ -584,24 +585,27 @@ func Test_AcceptTeamAccountInvite(t *testing.T) {
 }
 
 type serviceMocks struct {
-	Service         *Service
-	DbtxMock        *nucleusdb.MockDBTX
-	QuerierMock     *db_queries.MockQuerier
-	AuthServiceMock *mgmtv1alpha1connect.MockAuthServiceClient
+	Service                   *Service
+	DbtxMock                  *nucleusdb.MockDBTX
+	QuerierMock               *db_queries.MockQuerier
+	AuthServiceMock           *mgmtv1alpha1connect.MockAuthServiceClient
+	TemporalClientManagerMock *clientmanager.MockTemporalClientManagerClient
 }
 
 func createServiceMock(t *testing.T, config *Config) *serviceMocks {
 	mockDbtx := nucleusdb.NewMockDBTX(t)
 	mockQuerier := db_queries.NewMockQuerier(t)
 	mockAuthService := mgmtv1alpha1connect.NewMockAuthServiceClient(t)
+	temporalClientManager := clientmanager.NewMockTemporalClientManagerClient(t)
 
-	service := New(config, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService)
+	service := New(config, nucleusdb.New(mockDbtx, mockQuerier), mockAuthService, temporalClientManager)
 
 	return &serviceMocks{
-		Service:         service,
-		DbtxMock:        mockDbtx,
-		QuerierMock:     mockQuerier,
-		AuthServiceMock: mockAuthService,
+		Service:                   service,
+		DbtxMock:                  mockDbtx,
+		QuerierMock:               mockQuerier,
+		AuthServiceMock:           mockAuthService,
+		TemporalClientManagerMock: temporalClientManager,
 	}
 }
 

--- a/backend/sql/postgresql/models/transformers.go
+++ b/backend/sql/postgresql/models/transformers.go
@@ -323,288 +323,285 @@ func (t *TransformerConfigs) FromTransformerConfigDto(tr *mgmtv1alpha1.Transform
 // DB -> API
 
 func (t *JobMappingTransformerModel) ToTransformerDto() *mgmtv1alpha1.JobMappingTransformer {
-
-	config := &TransformerConfigs{}
-
 	return &mgmtv1alpha1.JobMappingTransformer{
 		Source: t.Source,
 		Name:   t.Name,
-		Config: config.ToTransformerConfigDto(t.Config),
+		Config: t.Config.ToTransformerConfigDto(),
 	}
 }
 
-func (t *TransformerConfigs) ToTransformerConfigDto(tr *TransformerConfigs) *mgmtv1alpha1.TransformerConfig {
+func (t *TransformerConfigs) ToTransformerConfigDto() *mgmtv1alpha1.TransformerConfig {
 	switch {
-	case tr.GenerateEmail != nil:
+	case t.GenerateEmail != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateEmailConfig{
 				GenerateEmailConfig: &mgmtv1alpha1.GenerateEmail{},
 			},
 		}
-	case tr.GenerateRealisticEmail != nil:
+	case t.GenerateRealisticEmail != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateRealisticEmailConfig{
 				GenerateRealisticEmailConfig: &mgmtv1alpha1.GenerateRealisticEmail{},
 			},
 		}
-	case tr.TransformEmail != nil:
+	case t.TransformEmail != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformEmailConfig{
 				TransformEmailConfig: &mgmtv1alpha1.TransformEmail{
-					PreserveDomain: tr.TransformEmail.PreserveDomain,
-					PreserveLength: tr.TransformEmail.PreserveLength,
+					PreserveDomain: t.TransformEmail.PreserveDomain,
+					PreserveLength: t.TransformEmail.PreserveLength,
 				},
 			},
 		}
-	case tr.GenerateBool != nil:
+	case t.GenerateBool != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateBoolConfig{
 				GenerateBoolConfig: &mgmtv1alpha1.GenerateBool{},
 			},
 		}
-	case tr.GenerateCardNumber != nil:
+	case t.GenerateCardNumber != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateCardNumberConfig{
 				GenerateCardNumberConfig: &mgmtv1alpha1.GenerateCardNumber{
-					ValidLuhn: tr.GenerateCardNumber.ValidLuhn,
+					ValidLuhn: t.GenerateCardNumber.ValidLuhn,
 				},
 			},
 		}
-	case tr.GenerateCity != nil:
+	case t.GenerateCity != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateCityConfig{
 				GenerateCityConfig: &mgmtv1alpha1.GenerateCity{},
 			},
 		}
-	case tr.GenerateE164Number != nil:
+	case t.GenerateE164Number != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateE164NumberConfig{
 				GenerateE164NumberConfig: &mgmtv1alpha1.GenerateE164Number{
-					Length: tr.GenerateE164Number.Length,
+					Length: t.GenerateE164Number.Length,
 				},
 			},
 		}
-	case tr.GenerateFirstName != nil:
+	case t.GenerateFirstName != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateFirstNameConfig{
 				GenerateFirstNameConfig: &mgmtv1alpha1.GenerateFirstName{},
 			},
 		}
-	case tr.GenerateFloat != nil:
+	case t.GenerateFloat != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateFloatConfig{
 				GenerateFloatConfig: &mgmtv1alpha1.GenerateFloat{
-					Sign:                tr.GenerateFloat.Sign,
-					DigitsBeforeDecimal: tr.GenerateFloat.DigitsBeforeDecimal,
-					DigitsAfterDecimal:  tr.GenerateFloat.DigitsAfterDecimal,
+					Sign:                t.GenerateFloat.Sign,
+					DigitsBeforeDecimal: t.GenerateFloat.DigitsBeforeDecimal,
+					DigitsAfterDecimal:  t.GenerateFloat.DigitsAfterDecimal,
 				},
 			},
 		}
-	case tr.GenerateFullAddress != nil:
+	case t.GenerateFullAddress != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateFullAddressConfig{
 				GenerateFullAddressConfig: &mgmtv1alpha1.GenerateFullAddress{},
 			},
 		}
-	case tr.GenerateFullName != nil:
+	case t.GenerateFullName != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateFullNameConfig{
 				GenerateFullNameConfig: &mgmtv1alpha1.GenerateFullName{},
 			},
 		}
-	case tr.GenerateGender != nil:
+	case t.GenerateGender != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateGenderConfig{
 				GenerateGenderConfig: &mgmtv1alpha1.GenerateGender{
-					Abbreviate: tr.GenerateGender.Abbreviate,
+					Abbreviate: t.GenerateGender.Abbreviate,
 				},
 			},
 		}
-	case tr.GenerateInt64Phone != nil:
+	case t.GenerateInt64Phone != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateInt64PhoneConfig{
 				GenerateInt64PhoneConfig: &mgmtv1alpha1.GenerateInt64Phone{},
 			},
 		}
-	case tr.GenerateInt != nil:
+	case t.GenerateInt != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateIntConfig{
 				GenerateIntConfig: &mgmtv1alpha1.GenerateInt{
-					Length: tr.GenerateInt.Length,
-					Sign:   tr.GenerateInt.Sign,
+					Length: t.GenerateInt.Length,
+					Sign:   t.GenerateInt.Sign,
 				},
 			},
 		}
-	case tr.GenerateLastName != nil:
+	case t.GenerateLastName != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateLastNameConfig{
 				GenerateLastNameConfig: &mgmtv1alpha1.GenerateLastName{},
 			},
 		}
-	case tr.GenerateSha256Hash != nil:
+	case t.GenerateSha256Hash != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateSha256HashConfig{
 				GenerateSha256HashConfig: &mgmtv1alpha1.GenerateSha256Hash{},
 			},
 		}
-	case tr.GenerateSsn != nil:
+	case t.GenerateSsn != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateSsnConfig{
 				GenerateSsnConfig: &mgmtv1alpha1.GenerateSSN{},
 			},
 		}
-	case tr.GenerateState != nil:
+	case t.GenerateState != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateStateConfig{
 				GenerateStateConfig: &mgmtv1alpha1.GenerateState{},
 			},
 		}
-	case tr.GenerateStreetAddress != nil:
+	case t.GenerateStreetAddress != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateStreetAddressConfig{
 				GenerateStreetAddressConfig: &mgmtv1alpha1.GenerateStreetAddress{},
 			},
 		}
-	case tr.GenerateStringPhone != nil:
+	case t.GenerateStringPhone != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateStringPhoneConfig{
 				GenerateStringPhoneConfig: &mgmtv1alpha1.GenerateStringPhone{
-					IncludeHyphens: tr.GenerateStringPhone.IncludeHyphens,
+					IncludeHyphens: t.GenerateStringPhone.IncludeHyphens,
 				},
 			},
 		}
-	case tr.GenerateString != nil:
+	case t.GenerateString != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateStringConfig{
 				GenerateStringConfig: &mgmtv1alpha1.GenerateString{
-					Length: tr.GenerateString.Length,
+					Length: t.GenerateString.Length,
 				},
 			},
 		}
-	case tr.GenerateUnixTimestamp != nil:
+	case t.GenerateUnixTimestamp != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateUnixtimestampConfig{
 				GenerateUnixtimestampConfig: &mgmtv1alpha1.GenerateUnixTimestamp{},
 			},
 		}
-	case tr.GenerateUsername != nil:
+	case t.GenerateUsername != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateUsernameConfig{
 				GenerateUsernameConfig: &mgmtv1alpha1.GenerateUsername{},
 			},
 		}
-	case tr.GenerateUtcTimestamp != nil:
+	case t.GenerateUtcTimestamp != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateUtctimestampConfig{
 				GenerateUtctimestampConfig: &mgmtv1alpha1.GenerateUtcTimestamp{},
 			},
 		}
-	case tr.GenerateUuid != nil:
+	case t.GenerateUuid != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateUuidConfig{
 				GenerateUuidConfig: &mgmtv1alpha1.GenerateUuid{
-					IncludeHyphens: tr.GenerateUuid.IncludeHyphens,
+					IncludeHyphens: t.GenerateUuid.IncludeHyphens,
 				},
 			},
 		}
-	case tr.GenerateZipcode != nil:
+	case t.GenerateZipcode != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_GenerateZipcodeConfig{
 				GenerateZipcodeConfig: &mgmtv1alpha1.GenerateZipcode{},
 			},
 		}
-	case tr.TransformE164Phone != nil:
+	case t.TransformE164Phone != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformE164PhoneConfig{
 				TransformE164PhoneConfig: &mgmtv1alpha1.TransformE164Phone{
-					PreserveLength: tr.TransformE164Phone.PreserveLength,
+					PreserveLength: t.TransformE164Phone.PreserveLength,
 				},
 			},
 		}
-	case tr.TransformFirstname != nil:
+	case t.TransformFirstname != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformFirstNameConfig{
 				TransformFirstNameConfig: &mgmtv1alpha1.TransformFirstName{
-					PreserveLength: tr.TransformFirstname.PreserveLength,
+					PreserveLength: t.TransformFirstname.PreserveLength,
 				},
 			},
 		}
-	case tr.TransformFloat != nil:
+	case t.TransformFloat != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformFloatConfig{
 				TransformFloatConfig: &mgmtv1alpha1.TransformFloat{
-					PreserveLength: tr.TransformFloat.PreserveLength,
-					PreserveSign:   tr.TransformFloat.PreserveSign,
+					PreserveLength: t.TransformFloat.PreserveLength,
+					PreserveSign:   t.TransformFloat.PreserveSign,
 				},
 			},
 		}
-	case tr.TransformFullName != nil:
+	case t.TransformFullName != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformFullNameConfig{
 				TransformFullNameConfig: &mgmtv1alpha1.TransformFullName{
-					PreserveLength: tr.TransformFullName.PreserveLength,
+					PreserveLength: t.TransformFullName.PreserveLength,
 				},
 			},
 		}
-	case tr.TransformIntPhone != nil:
+	case t.TransformIntPhone != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformIntPhoneConfig{
 				TransformIntPhoneConfig: &mgmtv1alpha1.TransformIntPhone{
-					PreserveLength: tr.TransformInt.PreserveLength,
+					PreserveLength: t.TransformInt.PreserveLength,
 				},
 			},
 		}
-	case tr.TransformInt != nil:
+	case t.TransformInt != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformIntConfig{
 				TransformIntConfig: &mgmtv1alpha1.TransformInt{
-					PreserveLength: tr.TransformInt.PreserveLength,
-					PreserveSign:   tr.TransformInt.PreserveSign,
+					PreserveLength: t.TransformInt.PreserveLength,
+					PreserveSign:   t.TransformInt.PreserveSign,
 				},
 			},
 		}
-	case tr.TransformLastName != nil:
+	case t.TransformLastName != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformLastNameConfig{
 				TransformLastNameConfig: &mgmtv1alpha1.TransformLastName{
-					PreserveLength: tr.TransformLastName.PreserveLength,
+					PreserveLength: t.TransformLastName.PreserveLength,
 				},
 			},
 		}
-	case tr.TransformPhone != nil:
+	case t.TransformPhone != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformPhoneConfig{
 				TransformPhoneConfig: &mgmtv1alpha1.TransformPhone{
-					PreserveLength: tr.TransformPhone.PreserveLength,
-					IncludeHyphens: tr.TransformPhone.IncludeHyphens,
+					PreserveLength: t.TransformPhone.PreserveLength,
+					IncludeHyphens: t.TransformPhone.IncludeHyphens,
 				},
 			},
 		}
-	case tr.TransformString != nil:
+	case t.TransformString != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_TransformStringConfig{
 				TransformStringConfig: &mgmtv1alpha1.TransformString{
-					PreserveLength: tr.TransformString.PreserveLength,
+					PreserveLength: t.TransformString.PreserveLength,
 				},
 			},
 		}
-	case tr.Passthrough != nil:
+	case t.Passthrough != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_PassthroughConfig{
 				PassthroughConfig: &mgmtv1alpha1.Passthrough{},
 			},
 		}
-	case tr.Null != nil:
+	case t.Null != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_Nullconfig{
 				Nullconfig: &mgmtv1alpha1.Null{},
 			},
 		}
-	case tr.UserDefinedTransformer != nil:
+	case t.UserDefinedTransformer != nil:
 		return &mgmtv1alpha1.TransformerConfig{
 			Config: &mgmtv1alpha1.TransformerConfig_UserDefinedTransformerConfig{
 				UserDefinedTransformerConfig: &mgmtv1alpha1.UserDefinedTransformerConfig{
-					Id: tr.UserDefinedTransformer.Id,
+					Id: t.UserDefinedTransformer.Id,
 				},
 			},
 		}

--- a/frontend/app/new/job/generate/single/connect/page.tsx
+++ b/frontend/app/new/job/generate/single/connect/page.tsx
@@ -53,7 +53,8 @@ export default function Page({ searchParams }: PageProps): ReactElement {
   const [defaultValues] = useSessionStorage<SingleTableConnectFormValues>(
     formKey,
     {
-      destination: { connectionId: '', destinationOptions: {} },
+      connectionId: '',
+      destinationOptions: {},
     }
   );
 
@@ -125,7 +126,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
             <div className="space-y-4 col-span-2">
               <FormField
                 control={form.control}
-                name="destination.connectionId"
+                name="connectionId"
                 render={({ field }) => (
                   <FormItem>
                     <FormControl>
@@ -143,7 +144,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                               return;
                             }
                             field.onChange(value);
-                            form.setValue('destination.destinationOptions', {
+                            form.setValue('destinationOptions', {
                               initTableSchema: false,
                               truncateBeforeInsert: false,
                               truncateCascade: false,
@@ -204,9 +205,8 @@ export default function Page({ searchParams }: PageProps): ReactElement {
               />
 
               <DestinationOptionsForm
-                index={0}
                 connection={connections.find(
-                  (c) => c.id == form.getValues().destination.connectionId
+                  (c) => c.id == form.getValues().connectionId
                 )}
                 maxColNum={2}
               />
@@ -220,7 +220,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
             </Button>
             <Button
               type="submit"
-              disabled={(errors?.destination?.message?.length ?? 0) > 0}
+              disabled={(errors?.root?.message?.length ?? 0) > 0}
             >
               Next
             </Button>

--- a/frontend/app/new/job/generate/single/schema/page.tsx
+++ b/frontend/app/new/job/generate/single/schema/page.tsx
@@ -90,11 +90,12 @@ export default function Page({ searchParams }: PageProps): ReactElement {
   const [connectFormValues] = useSessionStorage<SingleTableConnectFormValues>(
     connectFormKey,
     {
-      destination: { connectionId: '', destinationOptions: {} },
+      connectionId: '',
+      destinationOptions: {},
     }
   );
   const { data: connSchemaData } = useGetConnectionSchema(
-    connectFormValues.destination.connectionId
+    connectFormValues.connectionId
   );
 
   const formKey = `${sessionPrefix}-new-job-single-table-schema`;
@@ -111,9 +112,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
 
   async function getSchema(): Promise<SingleTableSchemaFormValues> {
     try {
-      const res = await getConnectionSchema(
-        connectFormValues.destination.connectionId
-      );
+      const res = await getConnectionSchema(connectFormValues.connectionId);
       if (!res) {
         return defaultValues;
       }
@@ -419,7 +418,7 @@ async function createNewJob(
         config: {
           case: 'generate',
           value: new GenerateSourceOptions({
-            fkSourceConnectionId: connect.destination.connectionId,
+            fkSourceConnectionId: connect.connectionId,
             schemas: [
               new GenerateSourceSchemaOption({
                 schema: schema.schema,
@@ -437,10 +436,10 @@ async function createNewJob(
     }),
     destinations: [
       new JobDestination({
-        connectionId: connect.destination.connectionId,
+        connectionId: connect.connectionId,
         options: toJobDestinationOptions(
-          connect.destination,
-          connectionIdMap.get(connect.destination.connectionId)
+          connect,
+          connectionIdMap.get(connect.connectionId)
         ),
       }),
     ],

--- a/frontend/app/new/job/schema.ts
+++ b/frontend/app/new/job/schema.ts
@@ -55,9 +55,9 @@ const SINGLE_SUBSET_FORM_SCSHEMA = Yup.object({
 
 // export type SingleSubset = Yup.InferType<typeof SINGLE_SUBSET_FORM_SCSHEMA>;
 
-export const SINGLE_TABLE_CONNECT_FORM_SCHEMA = Yup.object({
-  destination: DESTINATION_FORM_SCHEMA,
-});
+export const SINGLE_TABLE_CONNECT_FORM_SCHEMA = Yup.object({}).concat(
+  DESTINATION_FORM_SCHEMA
+);
 export type SingleTableConnectFormValues = Yup.InferType<
   typeof SINGLE_TABLE_CONNECT_FORM_SCHEMA
 >;

--- a/worker/gen/go/db/mysql/mock_DBTX.go
+++ b/worker/gen/go/db/mysql/mock_DBTX.go
@@ -29,6 +29,10 @@ func (_m *MockDBTX) ExecContext(_a0 context.Context, _a1 string, _a2 ...interfac
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for ExecContext")
+	}
+
 	var r0 sql.Result
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (sql.Result, error)); ok {
@@ -92,6 +96,10 @@ func (_c *MockDBTX_ExecContext_Call) RunAndReturn(run func(context.Context, stri
 func (_m *MockDBTX) PrepareContext(_a0 context.Context, _a1 string) (*sql.Stmt, error) {
 	ret := _m.Called(_a0, _a1)
 
+	if len(ret) == 0 {
+		panic("no return value specified for PrepareContext")
+	}
+
 	var r0 *sql.Stmt
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string) (*sql.Stmt, error)); ok {
@@ -149,6 +157,10 @@ func (_m *MockDBTX) QueryContext(_a0 context.Context, _a1 string, _a2 ...interfa
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryContext")
+	}
 
 	var r0 *sql.Rows
 	var r1 error
@@ -215,6 +227,10 @@ func (_m *MockDBTX) QueryRowContext(_a0 context.Context, _a1 string, _a2 ...inte
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryRowContext")
+	}
 
 	var r0 *sql.Row
 	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) *sql.Row); ok {

--- a/worker/gen/go/db/mysql/mock_Querier.go
+++ b/worker/gen/go/db/mysql/mock_Querier.go
@@ -25,6 +25,10 @@ func (_m *MockQuerier) EXPECT() *MockQuerier_Expecter {
 func (_m *MockQuerier) GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error) {
 	ret := _m.Called(ctx, db)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetDatabaseSchema")
+	}
+
 	var r0 []*GetDatabaseSchemaRow
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetDatabaseSchemaRow, error)); ok {
@@ -79,6 +83,10 @@ func (_c *MockQuerier_GetDatabaseSchema_Call) RunAndReturn(run func(context.Cont
 // GetForeignKeyConstraints provides a mock function with given fields: ctx, db, tableSchema
 func (_m *MockQuerier) GetForeignKeyConstraints(ctx context.Context, db DBTX, tableSchema string) ([]*GetForeignKeyConstraintsRow, error) {
 	ret := _m.Called(ctx, db, tableSchema)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetForeignKeyConstraints")
+	}
 
 	var r0 []*GetForeignKeyConstraintsRow
 	var r1 error

--- a/worker/gen/go/db/postgresql/mock_DBTX.go
+++ b/worker/gen/go/db/postgresql/mock_DBTX.go
@@ -31,6 +31,10 @@ func (_m *MockDBTX) Exec(_a0 context.Context, _a1 string, _a2 ...interface{}) (p
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
 
+	if len(ret) == 0 {
+		panic("no return value specified for Exec")
+	}
+
 	var r0 pgconn.CommandTag
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) (pgconn.CommandTag, error)); ok {
@@ -94,6 +98,10 @@ func (_m *MockDBTX) Query(_a0 context.Context, _a1 string, _a2 ...interface{}) (
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for Query")
+	}
 
 	var r0 pgx.Rows
 	var r1 error
@@ -160,6 +168,10 @@ func (_m *MockDBTX) QueryRow(_a0 context.Context, _a1 string, _a2 ...interface{}
 	_ca = append(_ca, _a0, _a1)
 	_ca = append(_ca, _a2...)
 	ret := _m.Called(_ca...)
+
+	if len(ret) == 0 {
+		panic("no return value specified for QueryRow")
+	}
 
 	var r0 pgx.Row
 	if rf, ok := ret.Get(0).(func(context.Context, string, ...interface{}) pgx.Row); ok {

--- a/worker/gen/go/db/postgresql/mock_Querier.go
+++ b/worker/gen/go/db/postgresql/mock_Querier.go
@@ -25,6 +25,10 @@ func (_m *MockQuerier) EXPECT() *MockQuerier_Expecter {
 func (_m *MockQuerier) GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error) {
 	ret := _m.Called(ctx, db)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetDatabaseSchema")
+	}
+
 	var r0 []*GetDatabaseSchemaRow
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetDatabaseSchemaRow, error)); ok {
@@ -79,6 +83,10 @@ func (_c *MockQuerier_GetDatabaseSchema_Call) RunAndReturn(run func(context.Cont
 // GetDatabaseTableSchema provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) GetDatabaseTableSchema(ctx context.Context, db DBTX, arg *GetDatabaseTableSchemaParams) ([]*GetDatabaseTableSchemaRow, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDatabaseTableSchema")
+	}
 
 	var r0 []*GetDatabaseTableSchemaRow
 	var r1 error
@@ -136,6 +144,10 @@ func (_c *MockQuerier_GetDatabaseTableSchema_Call) RunAndReturn(run func(context
 func (_m *MockQuerier) GetForeignKeyConstraints(ctx context.Context, db DBTX, tableschema string) ([]*GetForeignKeyConstraintsRow, error) {
 	ret := _m.Called(ctx, db, tableschema)
 
+	if len(ret) == 0 {
+		panic("no return value specified for GetForeignKeyConstraints")
+	}
+
 	var r0 []*GetForeignKeyConstraintsRow
 	var r1 error
 	if rf, ok := ret.Get(0).(func(context.Context, DBTX, string) ([]*GetForeignKeyConstraintsRow, error)); ok {
@@ -191,6 +203,10 @@ func (_c *MockQuerier_GetForeignKeyConstraints_Call) RunAndReturn(run func(conte
 // GetTableConstraints provides a mock function with given fields: ctx, db, arg
 func (_m *MockQuerier) GetTableConstraints(ctx context.Context, db DBTX, arg *GetTableConstraintsParams) ([]*GetTableConstraintsRow, error) {
 	ret := _m.Called(ctx, db, arg)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetTableConstraints")
+	}
 
 	var r0 []*GetTableConstraintsRow
 	var r1 error


### PR DESCRIPTION
A double whammy.
Fixes destination connection options in new gen job page
Ended up fixing more of the temporal config issues


Also:
Closes NEOS-315