### PR TITLE
NEOS-479 updates npm publish gha permissions

### DIFF
--- a/.github/workflows/artifact-release.yml
+++ b/.github/workflows/artifact-release.yml
@@ -460,6 +460,9 @@ jobs:
   ts-sdk:
     name: TypeScript SDK Release
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      id-token: write
     defaults:
       run:
         working-directory: frontend


### PR DESCRIPTION
Adds permission scopes to allow provenance publishing
https://docs.npmjs.com/generating-provenance-statements#example-github-actions-workflow