### PR TITLE
Fixes API Key Input Box showing all the time, Fixes dark mode Success alert

### DIFF
--- a/frontend/apps/web/app/[account]/settings/api-keys/[id]/page.tsx
+++ b/frontend/apps/web/app/[account]/settings/api-keys/[id]/page.tsx
@@ -107,16 +107,18 @@ function ApiKeyDetails(props: ApiKeyDetailsProps): ReactElement {
           </div>
         </Alert>
       )}
-      <div className=" flex flex-col gap-6 rounded-xl border border-gray-200 p-4">
-        <div className="flex flex-row">
-          <Input value={keyValue} disabled={true} className="mr-3" />
-          <CopyButton
-            buttonVariant="outline"
-            textToCopy={keyValue ?? ''}
-            onCopiedText="Success!"
-            onHoverText="Copy the API key"
-          />
-        </div>
+      <div className="flex flex-col gap-6 rounded-xl border border-gray-200 p-4">
+        {keyValue && (
+          <div className="flex flex-row gap-3">
+            <Input value={keyValue} disabled={true} />
+            <CopyButton
+              buttonVariant="outline"
+              textToCopy={keyValue ?? ''}
+              onCopiedText="Success!"
+              onHoverText="Copy the API key"
+            />
+          </div>
+        )}
         <div className="flex flex-col gap-4">
           <div className="flex flex-row gap-2">
             <p className=" text-sm tracking-tight w-[100px]">Created At:</p>

--- a/frontend/apps/web/components/ui/alert.tsx
+++ b/frontend/apps/web/components/ui/alert.tsx
@@ -10,7 +10,7 @@ const alertVariants = cva(
       variant: {
         default: 'bg-background text-foreground',
         success:
-          'bg-background text-foreground bg-green-100 border border-green-300',
+          'bg-background text-foreground bg-green-100 dark:bg-green-800 border border-green-300 dark:border-green-400',
         destructive:
           'border-destructive/50 text-destructive dark:border-destructive [&>svg]:text-destructive',
         warning:


### PR DESCRIPTION
* Success alert now rendering properly in dark mode
* Fixes regression where keyvalue was not being checked causing the input box to always show
<img width="1246" alt="image" src="https://github.com/nucleuscloud/neosync/assets/2420177/bc2ecb23-7feb-405e-b392-dd9090e330af">
<img width="1253" alt="image" src="https://github.com/nucleuscloud/neosync/assets/2420177/0c97f949-cde4-40b7-b448-3da46c3f67be">
