### PR TITLE
NEOS-504 Reworks Transformer(s) Forms to no longer user DTO Type

### DIFF
--- a/frontend/apps/web/app/[account]/jobs/[id]/source/components/DataGenConnectionCard.tsx
+++ b/frontend/apps/web/app/[account]/jobs/[id]/source/components/DataGenConnectionCard.tsx
@@ -251,7 +251,13 @@ export default function DataGenConnectionCard({ jobId }: Props): ReactElement {
               <FormLabel>Number of Rows</FormLabel>
               <FormDescription>The number of rows to generate.</FormDescription>
               <FormControl>
-                <Input value={field.value} onChange={field.onChange} />
+                <Input
+                  type="number"
+                  {...field}
+                  onChange={(e) => {
+                    field.onChange(e.target.valueAsNumber);
+                  }}
+                />
               </FormControl>
               <FormMessage />
             </FormItem>

--- a/frontend/apps/web/app/[account]/jobs/[id]/source/components/DataGenConnectionCard.tsx
+++ b/frontend/apps/web/app/[account]/jobs/[id]/source/components/DataGenConnectionCard.tsx
@@ -210,6 +210,8 @@ export default function DataGenConnectionCard({ jobId }: Props): ReactElement {
                       )
                       .map((r) => {
                         return {
+                          schema: formValues.schema,
+                          table: value,
                           column: r.column,
                           dataType: r.dataType,
                           transformer: r.transformer,
@@ -340,6 +342,8 @@ function getJobSource(
         colMapping?.transformer ?? new JobMappingTransformer({});
 
       return {
+        schema: schema,
+        table: table,
         column: c.column,
         dataType: c.dataType,
         transformer: transformer as TransformerFormValues,

--- a/frontend/apps/web/app/[account]/jobs/[id]/source/components/DataGenConnectionCard.tsx
+++ b/frontend/apps/web/app/[account]/jobs/[id]/source/components/DataGenConnectionCard.tsx
@@ -30,7 +30,11 @@ import { useToast } from '@/components/ui/use-toast';
 import { useGetConnectionSchema } from '@/libs/hooks/useGetConnectionSchema';
 import { useGetJob } from '@/libs/hooks/useGetJob';
 import { getErrorMessage } from '@/util/util';
-import { TransformerFormValues } from '@/yup-validations/jobs';
+import {
+  JobMappingTransformerForm,
+  convertJobMappingTransformerFormToJobMappingTransformer,
+  convertJobMappingTransformerToForm,
+} from '@/yup-validations/jobs';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   DatabaseColumn,
@@ -42,7 +46,6 @@ import {
   JobMappingTransformer,
   JobSource,
   JobSourceOptions,
-  TransformerConfig,
   UpdateJobSourceConnectionRequest,
   UpdateJobSourceConnectionResponse,
 } from '@neosync/sdk';
@@ -84,19 +87,22 @@ export default function DataGenConnectionCard({ jobId }: Props): ReactElement {
 
   const allJobMappings =
     schema?.schemas.map((r) => {
+      const t: JobMappingTransformerForm = {
+        source: '',
+        config: { case: '', value: {} },
+      };
       return {
         ...r,
-        transformer: new JobMappingTransformer({}) as TransformerFormValues,
+        transformer: t,
       };
     }) || [];
-
   const form = useForm<SingleTableSchemaFormValues>({
     resolver: yupResolver(SINGLE_TABLE_SCHEMA_FORM_SCHEMA),
     defaultValues: {
       mappings: [],
       numRows: 0,
-      schema: 'foo',
-      table: 'bar',
+      schema: '',
+      table: '',
     },
     values: getJobSource(data?.job, schema?.schemas),
   });
@@ -318,19 +324,25 @@ function getJobSource(
       schemaMap[c.schema] = {
         [c.table]: {
           [c.column]: {
-            transformer: c?.transformer ?? new JobMappingTransformer({}),
+            transformer: convertJobMappingTransformerToForm(
+              c?.transformer ?? new JobMappingTransformer({})
+            ),
           },
         },
       };
     } else if (!schemaMap[c.schema][c.table]) {
       schemaMap[c.schema][c.table] = {
         [c.column]: {
-          transformer: c?.transformer ?? new JobMappingTransformer({}),
+          transformer: convertJobMappingTransformerToForm(
+            c?.transformer ?? new JobMappingTransformer({})
+          ),
         },
       };
     } else {
       schemaMap[c.schema][c.table][c.column] = {
-        transformer: c.transformer ?? new JobMappingTransformer({}),
+        transformer: convertJobMappingTransformerToForm(
+          c.transformer ?? new JobMappingTransformer({})
+        ),
       };
     }
   });
@@ -345,17 +357,17 @@ function getJobSource(
         c.column
       );
       const transformer =
-        colMapping?.transformer ?? new JobMappingTransformer({});
+        colMapping?.transformer ??
+        convertJobMappingTransformerToForm(new JobMappingTransformer({}));
 
       return {
         schema: schema,
         table: table,
         column: c.column,
         dataType: c.dataType,
-        transformer: transformer as TransformerFormValues,
+        transformer: transformer,
       };
     });
-
   return {
     mappings: mappings,
     numRows: numRows,
@@ -380,16 +392,14 @@ async function updateJobConnection(
         new UpdateJobSourceConnectionRequest({
           id: job.id,
           mappings: values.mappings.map((m) => {
-            const jmt = new JobMappingTransformer({
-              source: m.transformer.source,
-              config: m.transformer.config as TransformerConfig,
-            });
-
             return new JobMapping({
               schema: values.schema,
               table: values.table,
               column: m.column,
-              transformer: jmt,
+              transformer:
+                convertJobMappingTransformerFormToJobMappingTransformer(
+                  m.transformer
+                ),
             });
           }),
           source: new JobSource({

--- a/frontend/apps/web/app/[account]/new/job/generate/single/schema/page.tsx
+++ b/frontend/apps/web/app/[account]/new/job/generate/single/schema/page.tsx
@@ -351,23 +351,16 @@ async function createNewJob(
   const connectionIdMap = new Map(
     connections.map((connection) => [connection.id, connection])
   );
-  console.log('schema mappings', schema.mappings);
   const body = new CreateJobRequest({
     accountId,
     jobName: define.jobName,
     cronSchedule: define.cronSchedule,
     initiateJobRun: define.initiateJobRun,
     mappings: schema.mappings.map((m) => {
-      console.log('transformer', m.transformer);
       const jmt =
         m.transformer instanceof JobMappingTransformer
           ? m.transformer
           : JobMappingTransformer.fromJson(m.transformer);
-      // : new JobMappingTransformer({
-      //     source: m.transformer.source,
-      //     config: m.transformer.config as TransformerConfig,
-      //   });
-      console.log('transformer', m.transformer, jmt);
       return new JobMapping({
         schema: m.schema,
         table: m.table,

--- a/frontend/apps/web/app/[account]/new/job/generate/single/schema/page.tsx
+++ b/frontend/apps/web/app/[account]/new/job/generate/single/schema/page.tsx
@@ -1,12 +1,8 @@
 'use client';
 
-import FormError from '@/components/FormError';
 import OverviewContainer from '@/components/containers/OverviewContainer';
 import PageHeader from '@/components/headers/PageHeader';
-import {
-  SchemaTable,
-  getConnectionSchema,
-} from '@/components/jobs/SchemaTable/schema-table';
+import { SchemaTable } from '@/components/jobs/SchemaTable/schema-table';
 import { useAccount } from '@/components/providers/account-provider';
 import { PageProps } from '@/components/types';
 import { Alert, AlertTitle } from '@/components/ui/alert';
@@ -33,6 +29,7 @@ import { useGetConnectionSchema } from '@/libs/hooks/useGetConnectionSchema';
 import { useGetConnections } from '@/libs/hooks/useGetConnections';
 import { getErrorMessage } from '@/util/util';
 import {
+  JobMappingFormValues,
   TransformerFormValues,
   toJobDestinationOptions,
 } from '@/yup-validations/jobs';
@@ -42,6 +39,7 @@ import {
   CreateJobRequest,
   CreateJobResponse,
   DatabaseColumn,
+  GenerateDefault,
   GenerateSourceOptions,
   GenerateSourceSchemaOption,
   GenerateSourceTableOption,
@@ -55,7 +53,7 @@ import {
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { useRouter } from 'next/navigation';
 import { ReactElement, useEffect, useState } from 'react';
-import { Controller, useForm } from 'react-hook-form';
+import { useForm } from 'react-hook-form';
 import useFormPersist from 'react-hook-form-persist';
 import { useSessionStorage } from 'usehooks-ts';
 import JobsProgressSteps, { DATA_GEN_STEPS } from '../../../JobsProgressSteps';
@@ -114,62 +112,17 @@ export default function Page({ searchParams }: PageProps): ReactElement {
     }
   );
 
-  const [allMappings, setAllMappings] = useState<DatabaseColumn[]>([]);
-  async function getSchema(): Promise<SingleTableSchemaFormValues> {
-    try {
-      const res = await getConnectionSchema(
-        account?.id || '',
-        connectFormValues.connectionId
-      );
-      if (!res) {
-        return { mappings: [], numRows: 10, schema: '', table: '' };
-      }
-
-      const allJobMappings = res.schemas.map((r) => {
-        return {
-          ...r,
-          transformer: new JobMappingTransformer({}) as TransformerFormValues,
-        };
-      });
-      setAllMappings(res.schemas);
-      if (schemaFormData.mappings.length > 0) {
-        //pull values from default values for transformers if already set
-        return {
-          ...schemaFormData,
-          mappings: schemaFormData.mappings.map((r) => {
-            var pt = JobMappingTransformer.fromJson(
-              r.transformer
-            ) as TransformerFormValues;
-            return {
-              ...r,
-              transformer: pt,
-            };
-          }),
-        };
-      } else {
-        return {
-          ...schemaFormData,
-          mappings: allJobMappings,
-        };
-      }
-    } catch (err) {
-      console.error(err);
-      toast({
-        title: 'Unable to get connection schema',
-        description: getErrorMessage(err),
-        variant: 'destructive',
-      });
-      return schemaFormData;
-    }
-  }
+  const { data: connectionSchemaData } = useGetConnectionSchema(
+    account?.id ?? '',
+    connectFormValues.connectionId
+  );
 
   const form = useForm({
+    mode: 'onChange',
     resolver: yupResolver<SingleTableSchemaFormValues>(
       SINGLE_TABLE_SCHEMA_FORM_SCHEMA
     ),
-    defaultValues: async () => {
-      return getSchema();
-    },
+    values: getFormValues(connectionSchemaData?.schemas ?? [], schemaFormData),
   });
 
   useFormPersist(formKey, {
@@ -177,8 +130,12 @@ export default function Page({ searchParams }: PageProps): ReactElement {
     setValue: form.setValue,
     storage: isBrowser() ? window.sessionStorage : undefined,
   });
+  const [isClient, setIsClient] = useState(false);
+  useEffect(() => {
+    setIsClient(true);
+  }, []);
 
-  async function onSubmit(values: SingleTableSchemaFormValues) {
+  async function onSubmit(_values: SingleTableSchemaFormValues) {
     if (!account) {
       return;
     }
@@ -186,7 +143,8 @@ export default function Page({ searchParams }: PageProps): ReactElement {
       const job = await createNewJob(
         defineFormValues,
         connectFormValues,
-        values,
+        // using this instead of form values because the transformer object is really messed up. It is a combination of both the class and json version and it's really difficult to parse
+        schemaFormData,
         account.id,
         connections
       );
@@ -213,11 +171,8 @@ export default function Page({ searchParams }: PageProps): ReactElement {
   }
 
   const formValues = form.watch();
-  const schemaTableData = formValues.mappings?.map((mapping) => ({
-    ...mapping,
-    schema: formValues.schema,
-    table: formValues.table,
-  }));
+  // console.log('form values', formValues);
+  const schemaTableData = formValues.mappings ?? [];
 
   const uniqueSchemas = Array.from(
     new Set(connSchemaData?.schemas.map((s) => s.schema))
@@ -225,24 +180,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
   const schemaTableMap = getSchemaTableMap(connSchemaData?.schemas ?? []);
 
   const selectedSchemaTables = schemaTableMap.get(formValues.schema) ?? [];
-
-  /* turning the input field into a controlled component due to console warning a component going from uncontrolled to controlled. The input at first receives an undefined value because the async getSchema() call hasn't returned yet then once it returns it sets the value which throws the error. Ideally, react hook form should just handle this but for some reason it's throwing an error. Revist this in the future.
-   */
-
-  const [rowNum, setRowNum] = useState<number>(
-    form.getValues('numRows')
-      ? form.getValues('numRows')
-      : schemaFormData.numRows
-  );
-  const [rowNumError, setRowNumError] = useState<boolean>(false);
-  useEffect(() => {
-    if (rowNum > 10000) {
-      setRowNumError(true);
-    } else {
-      setRowNumError(false);
-      form.setValue(`numRows`, rowNum);
-    }
-  }, [rowNum]);
+  // console.log('schema table data', schemaTableData);
 
   return (
     <div className="flex flex-col gap-5">
@@ -269,30 +207,32 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 <FormLabel>Schema</FormLabel>
                 <FormDescription>The name of the schema.</FormDescription>
                 <FormControl>
-                  <Select
-                    onValueChange={(value: string) => {
-                      if (value) {
-                        field.onChange(value);
-                        form.setValue('table', ''); // reset the table value because it may no longer apply
-                      }
-                    }}
-                    value={field.value}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select a schema..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {uniqueSchemas.map((schema) => (
-                        <SelectItem
-                          className="cursor-pointer"
-                          key={schema}
-                          value={schema}
-                        >
-                          {schema}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  {isClient && (
+                    <Select
+                      onValueChange={(value: string) => {
+                        if (value) {
+                          field.onChange(value);
+                          form.setValue('table', ''); // reset the table value because it may no longer apply
+                        }
+                      }}
+                      value={field.value}
+                    >
+                      <SelectTrigger>
+                        <SelectValue />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {uniqueSchemas.map((schema) => (
+                          <SelectItem
+                            className="cursor-pointer"
+                            key={schema}
+                            value={schema}
+                          >
+                            {schema}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
                 </FormControl>
                 <FormMessage />
               </FormItem>
@@ -306,57 +246,61 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 <FormLabel>Table Name</FormLabel>
                 <FormDescription>The name of the table.</FormDescription>
                 <FormControl>
-                  <Select
-                    disabled={!formValues.schema}
-                    onValueChange={(value: string) => {
-                      if (value) {
-                        field.onChange(value);
-                        form.setValue(
-                          'mappings',
-                          allMappings
-                            .filter(
-                              (m) =>
-                                m.schema == formValues.schema &&
-                                m.table == value
-                            )
-                            .map((r) => {
-                              return {
-                                ...r,
-                                transformer: new JobMappingTransformer(
-                                  {}
-                                ) as TransformerFormValues,
-                              };
-                            })
-                        );
-                      }
-                    }}
-                    value={field.value}
-                  >
-                    <SelectTrigger>
-                      <SelectValue placeholder="Select a table..." />
-                    </SelectTrigger>
-                    <SelectContent>
-                      {selectedSchemaTables.map((table) => (
-                        <SelectItem
-                          className="cursor-pointer"
-                          key={table}
-                          value={table}
-                        >
-                          {table}
-                        </SelectItem>
-                      ))}
-                    </SelectContent>
-                  </Select>
+                  {isClient && (
+                    <Select
+                      disabled={!formValues.schema}
+                      onValueChange={(value: string) => {
+                        if (value) {
+                          field.onChange(value);
+                          form.setValue(
+                            'mappings',
+                            (connectionSchemaData?.schemas ?? [])
+                              .filter(
+                                (s) =>
+                                  s.schema === formValues.schema &&
+                                  s.table === value
+                              )
+                              .map((s) => {
+                                return {
+                                  schema: s.schema,
+                                  table: s.table,
+                                  column: s.column,
+                                  dataType: s.dataType,
+                                  transformer:
+                                    newDefaultJobMappingTransformer() as TransformerFormValues,
+                                };
+                              })
+                          );
+                        }
+                      }}
+                      value={field.value}
+                    >
+                      <SelectTrigger>
+                        <SelectValue placeholder="Select a table..." />
+                      </SelectTrigger>
+                      <SelectContent>
+                        {selectedSchemaTables.map((table) => (
+                          <SelectItem
+                            className="cursor-pointer"
+                            key={table}
+                            value={table}
+                          >
+                            {table}
+                          </SelectItem>
+                        ))}
+                      </SelectContent>
+                    </Select>
+                  )}
                 </FormControl>
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          <Controller
+          <FormField
             control={form.control}
             name="numRows"
-            render={() => (
+            render={({ field }) => (
               <FormItem>
                 <FormLabel>Number of Rows</FormLabel>
                 <FormDescription>
@@ -364,24 +308,22 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 </FormDescription>
                 <FormControl>
                   <Input
-                    value={rowNum}
+                    type="number"
+                    {...field}
                     onChange={(e) => {
-                      setRowNum(Number(e.target.value));
+                      field.onChange(e.target.valueAsNumber);
                     }}
                   />
                 </FormControl>
-                {rowNumError && (
-                  <FormError errorMessage="The number of rows must be less than 10,000" />
-                )}
                 <FormMessage />
               </FormItem>
             )}
           />
 
-          {formValues.schema && formValues.table && (
+          {isClient && formValues.schema && formValues.table && (
             <SchemaTable data={schemaTableData} excludeInputReqTransformers />
           )}
-          {form.formState.errors.mappings && (
+          {form.formState.errors.root && (
             <Alert variant="destructive">
               <AlertTitle className="flex flex-row space-x-2 justify-center">
                 <ExclamationTriangleIcon />
@@ -413,25 +355,26 @@ async function createNewJob(
   const connectionIdMap = new Map(
     connections.map((connection) => [connection.id, connection])
   );
+  console.log('schema mappings', schema.mappings);
   const body = new CreateJobRequest({
     accountId,
     jobName: define.jobName,
     cronSchedule: define.cronSchedule,
     initiateJobRun: define.initiateJobRun,
     mappings: schema.mappings.map((m) => {
-      const jmt = new JobMappingTransformer({
-        source: m.transformer.source,
-        config: new TransformerConfig({
-          config: {
-            // eslint-disable-next-line @typescript-eslint/no-explicit-any
-            case: m.transformer.config.config.case as any,
-            value: m.transformer.config.config.value,
-          },
-        }),
-      });
+      console.log('transformer', m.transformer);
+      const jmt =
+        m.transformer instanceof JobMappingTransformer
+          ? m.transformer
+          : JobMappingTransformer.fromJson(m.transformer);
+      // : new JobMappingTransformer({
+      //     source: m.transformer.source,
+      //     config: m.transformer.config as TransformerConfig,
+      //   });
+      console.log('transformer', m.transformer, jmt);
       return new JobMapping({
-        schema: schema.schema,
-        table: schema.table,
+        schema: m.schema,
+        table: m.table,
         column: m.column,
         transformer: jmt,
       });
@@ -496,4 +439,101 @@ function getSchemaTableMap(schemas: DatabaseColumn[]): Map<string, string[]> {
   const outMap = new Map<string, string[]>();
   map.forEach((tableSet, schema) => outMap.set(schema, Array.from(tableSet)));
   return outMap;
+}
+
+function getFormValues(
+  dbCols: DatabaseColumn[],
+  existingData: SingleTableSchemaFormValues | undefined
+): SingleTableSchemaFormValues {
+  const schema = existingData?.schema ?? '';
+  const table = existingData?.table ?? '';
+  const defaultMappings = dbCols
+    .filter((dbCol) => dbCol.schema === schema && dbCol.table === table)
+    .map((dbCol) => {
+      return {
+        ...dbCol,
+        transformer: newDefaultJobMappingTransformer() as TransformerFormValues,
+      };
+    });
+  const existingMappings = (existingData?.mappings ?? [])
+    .filter((mapping) => mapping.schema === schema && mapping.table === table)
+    .map((mapping) => {
+      return {
+        ...mapping,
+        transformer: (mapping.transformer instanceof JobMappingTransformer
+          ? mapping.transformer
+          : JobMappingTransformer.fromJson(
+              mapping.transformer
+            )) as TransformerFormValues,
+      };
+    });
+  const mappingMap = new Map<string, JobMappingFormValues>();
+  defaultMappings.forEach((mapping) =>
+    mappingMap.set(
+      `${mapping.schema}-${mapping.table}-${mapping.column}`,
+      mapping
+    )
+  );
+  existingMappings.forEach((mapping) =>
+    mappingMap.set(
+      `${mapping.schema}-${mapping.table}-${mapping.column}`,
+      mapping
+    )
+  );
+  console.log('getFormValues mappings', Array.from(mappingMap.values()));
+  return {
+    numRows: existingData?.numRows ?? 10,
+    schema,
+    table,
+    mappings: Array.from(mappingMap.values()),
+  };
+  // const existingDataMappings = existingData?.mappings ?? [];
+  // if (existingDataMappings.length > 0) {
+  //   // pull values from default values for transformers if already set
+  //   return {
+  //     numRows: existingData?.numRows ?? 10,
+  //     schema: existingData?.schema ?? '',
+  //     table: existingData?.table ?? '',
+  //     mappings: existingDataMappings.map((r) => {
+  //       var pt = JobMappingTransformer.fromJson(
+  //         r.transformer
+  //       ) as TransformerFormValues;
+  //       return {
+  //         ...r,
+  //         transformer: pt,
+  //       };
+  //     }),
+  //   };
+  // } else {
+  //   return {
+  //     numRows: existingData?.numRows ?? 10,
+  //     schema: existingData?.schema ?? '',
+  //     table: existingData?.table ?? '',
+  //     mappings: dbCols
+  //       .filter(
+  //         (dbcol) =>
+  //           dbcol.schema === existingData?.schema &&
+  //           dbcol.table === existingData?.table
+  //       )
+  //       .map((r) => {
+  //         return {
+  //           ...r,
+  //           transformer:
+  //             newDefaultJobMappingTransformer() as TransformerFormValues,
+  //         };
+  //       }),
+  //   };
+  // }
+}
+
+function newDefaultJobMappingTransformer(): JobMappingTransformer {
+  return new JobMappingTransformer({
+    source: 'generate_default',
+    config: new TransformerConfig({
+      config: {
+        case: 'generateDefaultConfig',
+        value: new GenerateDefault(),
+      },
+    }),
+  });
 }

--- a/frontend/apps/web/app/[account]/new/job/generate/single/schema/page.tsx
+++ b/frontend/apps/web/app/[account]/new/job/generate/single/schema/page.tsx
@@ -39,7 +39,6 @@ import {
   CreateJobRequest,
   CreateJobResponse,
   DatabaseColumn,
-  GenerateDefault,
   GenerateSourceOptions,
   GenerateSourceSchemaOption,
   GenerateSourceTableOption,
@@ -48,7 +47,6 @@ import {
   JobMappingTransformer,
   JobSource,
   JobSourceOptions,
-  TransformerConfig,
 } from '@neosync/sdk';
 import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { useRouter } from 'next/navigation';
@@ -171,7 +169,6 @@ export default function Page({ searchParams }: PageProps): ReactElement {
   }
 
   const formValues = form.watch();
-  // console.log('form values', formValues);
   const schemaTableData = formValues.mappings ?? [];
 
   const uniqueSchemas = Array.from(
@@ -180,7 +177,6 @@ export default function Page({ searchParams }: PageProps): ReactElement {
   const schemaTableMap = getSchemaTableMap(connSchemaData?.schemas ?? []);
 
   const selectedSchemaTables = schemaTableMap.get(formValues.schema) ?? [];
-  // console.log('schema table data', schemaTableData);
 
   return (
     <div className="flex flex-col gap-5">
@@ -480,60 +476,14 @@ function getFormValues(
       mapping
     )
   );
-  console.log('getFormValues mappings', Array.from(mappingMap.values()));
   return {
     numRows: existingData?.numRows ?? 10,
     schema,
     table,
     mappings: Array.from(mappingMap.values()),
   };
-  // const existingDataMappings = existingData?.mappings ?? [];
-  // if (existingDataMappings.length > 0) {
-  //   // pull values from default values for transformers if already set
-  //   return {
-  //     numRows: existingData?.numRows ?? 10,
-  //     schema: existingData?.schema ?? '',
-  //     table: existingData?.table ?? '',
-  //     mappings: existingDataMappings.map((r) => {
-  //       var pt = JobMappingTransformer.fromJson(
-  //         r.transformer
-  //       ) as TransformerFormValues;
-  //       return {
-  //         ...r,
-  //         transformer: pt,
-  //       };
-  //     }),
-  //   };
-  // } else {
-  //   return {
-  //     numRows: existingData?.numRows ?? 10,
-  //     schema: existingData?.schema ?? '',
-  //     table: existingData?.table ?? '',
-  //     mappings: dbCols
-  //       .filter(
-  //         (dbcol) =>
-  //           dbcol.schema === existingData?.schema &&
-  //           dbcol.table === existingData?.table
-  //       )
-  //       .map((r) => {
-  //         return {
-  //           ...r,
-  //           transformer:
-  //             newDefaultJobMappingTransformer() as TransformerFormValues,
-  //         };
-  //       }),
-  //   };
-  // }
 }
 
 function newDefaultJobMappingTransformer(): JobMappingTransformer {
-  return new JobMappingTransformer({
-    source: 'generate_default',
-    config: new TransformerConfig({
-      config: {
-        case: 'generateDefaultConfig',
-        value: new GenerateDefault(),
-      },
-    }),
-  });
+  return new JobMappingTransformer({});
 }

--- a/frontend/apps/web/app/[account]/new/job/generate/single/schema/page.tsx
+++ b/frontend/apps/web/app/[account]/new/job/generate/single/schema/page.tsx
@@ -214,7 +214,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                       value={field.value}
                     >
                       <SelectTrigger>
-                        <SelectValue />
+                        <SelectValue placeholder="Select a schema..." />
                       </SelectTrigger>
                       <SelectContent>
                         {uniqueSchemas.map((schema) => (

--- a/frontend/apps/web/app/[account]/new/job/schema.ts
+++ b/frontend/apps/web/app/[account]/new/job/schema.ts
@@ -1,6 +1,6 @@
 import {
   DESTINATION_FORM_SCHEMA,
-  JOB_MAPPING_COLUMN_SCHEMA,
+  JOB_MAPPING_SCHEMA,
   SCHEMA_FORM_SCHEMA,
   SOURCE_FORM_SCHEMA,
 } from '@/yup-validations/jobs';
@@ -62,7 +62,7 @@ export const SINGLE_TABLE_SCHEMA_FORM_SCHEMA = Yup.object({
   schema: Yup.string().required(),
   table: Yup.string().required(),
 
-  mappings: Yup.array().of(JOB_MAPPING_COLUMN_SCHEMA).required(),
+  mappings: Yup.array().of(JOB_MAPPING_SCHEMA).required(),
 });
 export type SingleTableSchemaFormValues = Yup.InferType<
   typeof SINGLE_TABLE_SCHEMA_FORM_SCHEMA

--- a/frontend/apps/web/app/[account]/new/job/schema.ts
+++ b/frontend/apps/web/app/[account]/new/job/schema.ts
@@ -48,8 +48,6 @@ const SINGLE_SUBSET_FORM_SCSHEMA = Yup.object({
   whereClause: Yup.string().trim().optional(),
 });
 
-// export type SingleSubset = Yup.InferType<typeof SINGLE_SUBSET_FORM_SCSHEMA>;
-
 export const SINGLE_TABLE_CONNECT_FORM_SCHEMA = Yup.object({}).concat(
   DESTINATION_FORM_SCHEMA
 );

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateCardNumber.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateCardNumber.tsx
@@ -10,6 +10,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -18,14 +22,16 @@ interface Props {
 export default function UserDefinedGenerateCardNumberForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.validLuhn`}
+        name={`config.value.validLuhn`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateE164PhoneNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateE164PhoneNumberForm.tsx
@@ -47,12 +47,12 @@ export default function UserDefinedGenerateE164NumberForm(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseInt(field.value) : 0}
                       type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(BigInt(e.target.valueAsNumber));
+                        }
                       }}
                       disabled={isDisabled}
                     />
@@ -81,12 +81,12 @@ export default function UserDefinedGenerateE164NumberForm(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseInt(field.value) : 1}
                       type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(BigInt(e.target.valueAsNumber));
+                        }
                       }}
                       disabled={isDisabled}
                     />

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateE164PhoneNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateE164PhoneNumberForm.tsx
@@ -10,6 +10,10 @@ import {
 import { Input } from '@/components/ui/input';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -18,14 +22,16 @@ interface Props {
 export default function UserDefinedGenerateE164NumberForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.min`}
+        name={`config.value.min`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -59,7 +65,7 @@ export default function UserDefinedGenerateE164NumberForm(
         )}
       />
       <FormField
-        name={`config.config.value.max`}
+        name={`config.value.max`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateFloat64Form.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateFloat64Form.tsx
@@ -12,6 +12,10 @@ import { Switch } from '@/components/ui/switch';
 
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -20,14 +24,16 @@ interface Props {
 export default function UserDefinedGenerateFloat64Form(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.randomizeSign`}
+        name={`config.value.randomizeSign`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -56,7 +62,7 @@ export default function UserDefinedGenerateFloat64Form(
         )}
       />
       <FormField
-        name={`config.config.value.min`}
+        name={`config.value.min`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -90,7 +96,7 @@ export default function UserDefinedGenerateFloat64Form(
         )}
       />
       <FormField
-        name={`config.config.value.max`}
+        name={`config.value.max`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateFloat64Form.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateFloat64Form.tsx
@@ -78,12 +78,12 @@ export default function UserDefinedGenerateFloat64Form(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseFloat(field.value) : 0}
                       type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(e.target.valueAsNumber);
+                        }
                       }}
                       disabled={isDisabled}
                     />
@@ -112,12 +112,12 @@ export default function UserDefinedGenerateFloat64Form(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseFloat(field.value) : 1}
                       type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(e.target.valueAsNumber);
+                        }
                       }}
                       disabled={isDisabled}
                     />

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateGenderForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateGenderForm.tsx
@@ -10,6 +10,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -18,14 +22,16 @@ interface Props {
 export default function UserDefinedGenerateGenderForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.abbreviate`}
+        name={`config.value.abbreviate`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateInt64Form.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateInt64Form.tsx
@@ -12,6 +12,10 @@ import { Switch } from '@/components/ui/switch';
 
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -20,14 +24,16 @@ interface Props {
 export default function UserDefinedGenerateInt64Form(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.randomizeSign`}
+        name={`config.value.randomizeSign`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -56,7 +62,7 @@ export default function UserDefinedGenerateInt64Form(
         )}
       />
       <FormField
-        name={`config.config.value.min`}
+        name={`config.value.min`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -89,7 +95,7 @@ export default function UserDefinedGenerateInt64Form(
         )}
       />
       <FormField
-        name={`config.config.value.max`}
+        name={`config.value.max`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateInt64Form.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateInt64Form.tsx
@@ -30,6 +30,8 @@ export default function UserDefinedGenerateInt64Form(
 
   const { isDisabled } = props;
 
+  console.log('errors', fc.formState.errors);
+
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
@@ -78,11 +80,12 @@ export default function UserDefinedGenerateInt64Form(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      type="number"
+                      value={field.value ? parseInt(field.value) : 0}
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(BigInt(e.target.valueAsNumber));
+                        }
                       }}
                       disabled={isDisabled}
                     />
@@ -111,11 +114,12 @@ export default function UserDefinedGenerateInt64Form(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      type="number"
+                      value={field.value ? parseInt(field.value) : 1}
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(BigInt(e.target.valueAsNumber));
+                        }
                       }}
                       disabled={isDisabled}
                     />

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateInt64Form.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateInt64Form.tsx
@@ -30,8 +30,6 @@ export default function UserDefinedGenerateInt64Form(
 
   const { isDisabled } = props;
 
-  console.log('errors', fc.formState.errors);
-
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateStringForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateStringForm.tsx
@@ -47,11 +47,12 @@ export default function UserDefinedGenerateStringForm(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseInt(field.value) : 0}
+                      type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(BigInt(e.target.valueAsNumber));
+                        }
                       }}
                       disabled={isDisabled}
                     />
@@ -79,11 +80,12 @@ export default function UserDefinedGenerateStringForm(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseInt(field.value) : 1}
+                      type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(BigInt(e.target.valueAsNumber));
+                        }
                       }}
                       disabled={isDisabled}
                     />

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateStringForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateStringForm.tsx
@@ -11,6 +11,10 @@ import { Input } from '@/components/ui/input';
 
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -19,14 +23,16 @@ interface Props {
 export default function UserDefinedGenerateStringForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.min`}
+        name={`config.value.min`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -58,7 +64,7 @@ export default function UserDefinedGenerateStringForm(
         )}
       />
       <FormField
-        name={`config.config.value.max`}
+        name={`config.value.max`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateStringPhoneNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateStringPhoneNumberForm.tsx
@@ -9,6 +9,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 interface Props {
   isDisabled?: boolean;
 }
@@ -16,14 +20,16 @@ interface Props {
 export default function UserDefinedGenerateStringPhoneNumberNumberForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.includeHyphens`}
+        name={`config.value.includeHyphens`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateUuidForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedGenerateUuidForm.tsx
@@ -9,6 +9,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -17,14 +21,16 @@ interface Props {
 export default function UserDefinedGenerateUuidForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.includeHyphens`}
+        name={`config.value.includeHyphens`}
         control={fc.control}
         disabled={isDisabled}
         render={({ field }) => (

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformE164PhoneNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformE164PhoneNumberForm.tsx
@@ -9,6 +9,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -16,14 +20,16 @@ interface Props {
 export default function UserDefinedTransformE164NumberForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.preserveLength`}
+        name={`config.value.preserveLength`}
         control={fc.control}
         disabled={isDisabled}
         render={({ field }) => (

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformEmailForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformEmailForm.tsx
@@ -9,6 +9,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -17,14 +21,16 @@ interface Props {
 export default function UserDefinedTransformEmailForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.preserveLength`}
+        name={`config.value.preserveLength`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -45,7 +51,7 @@ export default function UserDefinedTransformEmailForm(
         )}
       />
       <FormField
-        name={`config.config.value.preserveDomain`}
+        name={`config.value.preserveDomain`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformFirstNameForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformFirstNameForm.tsx
@@ -9,6 +9,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -17,12 +21,14 @@ interface Props {
 export default function UserDefinedTransformFirstNameForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
   const { isDisabled } = props;
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.preserveLength`}
+        name={`config.value.preserveLength`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformFloat64Form.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformFloat64Form.tsx
@@ -48,12 +48,12 @@ export default function UserDefinedTransformFloat64Form(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseFloat(field.value) : 0}
                       type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(e.target.valueAsNumber);
+                        }
                       }}
                       disabled={isDisabled}
                     />
@@ -84,12 +84,12 @@ export default function UserDefinedTransformFloat64Form(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseFloat(field.value) : 1}
                       type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(e.target.valueAsNumber);
+                        }
                       }}
                       disabled={isDisabled}
                     />

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformFloat64Form.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformFloat64Form.tsx
@@ -10,6 +10,10 @@ import {
 import { Input } from '@/components/ui/input';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -18,13 +22,15 @@ interface Props {
 export default function UserDefinedTransformFloat64Form(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.randomizationRangeMin`}
+        name={`config.value.randomizationRangeMin`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -60,7 +66,7 @@ export default function UserDefinedTransformFloat64Form(
         )}
       />
       <FormField
-        name={`config.config.value.randomizationRangeMax`}
+        name={`config.value.randomizationRangeMax`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformFullNameForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformFullNameForm.tsx
@@ -9,6 +9,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 interface Props {
   isDisabled?: boolean;
 }
@@ -16,12 +20,14 @@ interface Props {
 export default function UserDefinedTransformFullNameForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
   const { isDisabled } = props;
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.preserveLength`}
+        name={`config.value.preserveLength`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformInt64Form.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformInt64Form.tsx
@@ -26,6 +26,7 @@ export default function UserDefinedTransformInt64Form(
     UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
   >();
   const { isDisabled } = props;
+
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
@@ -47,12 +48,12 @@ export default function UserDefinedTransformInt64Form(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseInt(field.value) : 0}
                       type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(BigInt(e.target.valueAsNumber));
+                        }
                       }}
                       disabled={isDisabled}
                     />
@@ -83,12 +84,12 @@ export default function UserDefinedTransformInt64Form(
                 <FormControl>
                   <div className="max-w-[180px]">
                     <Input
-                      value={field.value !== null ? String(field.value) : ''}
+                      value={field.value ? parseInt(field.value) : 1}
                       type="number"
                       onChange={(e) => {
-                        field.onChange(
-                          e.target.value === '' ? null : Number(e.target.value)
-                        );
+                        if (!isNaN(e.target.valueAsNumber)) {
+                          field.onChange(BigInt(e.target.valueAsNumber));
+                        }
                       }}
                       disabled={isDisabled}
                     />

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformInt64Form.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformInt64Form.tsx
@@ -10,6 +10,10 @@ import {
 import { Input } from '@/components/ui/input';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -18,12 +22,14 @@ interface Props {
 export default function UserDefinedTransformInt64Form(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
   const { isDisabled } = props;
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.randomizationRangeMin`}
+        name={`config.value.randomizationRangeMin`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -59,7 +65,7 @@ export default function UserDefinedTransformInt64Form(
         )}
       />
       <FormField
-        name={`config.config.value.randomizationRangeMax`}
+        name={`config.value.randomizationRangeMax`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformInt64PhoneForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformInt64PhoneForm.tsx
@@ -9,6 +9,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -17,14 +21,16 @@ interface Props {
 export default function UserDefinedTransformIntPhoneNumberForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.preserveLength`}
+        name={`config.value.preserveLength`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700  p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformLastNameForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformLastNameForm.tsx
@@ -9,6 +9,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -17,13 +21,15 @@ interface Props {
 export default function UserDefinedTransformLastNameForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.preserveLength`}
+        name={`config.value.preserveLength`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformPhoneNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformPhoneNumberForm.tsx
@@ -9,6 +9,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 interface Props {
   isDisabled?: boolean;
 }
@@ -16,14 +20,16 @@ interface Props {
 export default function UserDefinedTransformPhoneNumberForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.preserveLength`}
+        name={`config.value.preserveLength`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -45,7 +51,7 @@ export default function UserDefinedTransformPhoneNumberForm(
         )}
       />
       <FormField
-        name={`config.config.value.includeHyphens`}
+        name={`config.value.includeHyphens`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformStringForm.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/UserDefinedTransformerForms/UserDefinedTransformStringForm.tsx
@@ -10,6 +10,10 @@ import {
 import { Switch } from '@/components/ui/switch';
 import { ReactElement } from 'react';
 import { useFormContext } from 'react-hook-form';
+import {
+  CreateUserDefinedTransformerSchema,
+  UpdateUserDefinedTransformer,
+} from '../schema';
 
 interface Props {
   isDisabled?: boolean;
@@ -18,14 +22,16 @@ interface Props {
 export default function UserDefinedTransformStringForm(
   props: Props
 ): ReactElement {
-  const fc = useFormContext();
+  const fc = useFormContext<
+    UpdateUserDefinedTransformer | CreateUserDefinedTransformerSchema
+  >();
 
   const { isDisabled } = props;
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`config.config.value.preserveLength`}
+        name={`config.value.preserveLength`}
         control={fc.control}
         render={({ field }) => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
@@ -39,9 +45,7 @@ export default function UserDefinedTransformStringForm(
               <Switch
                 checked={field.value}
                 onCheckedChange={field.onChange}
-                disabled={
-                  fc.watch('config.config.value.strLength') || isDisabled
-                }
+                disabled={fc.watch('config.value.strLength') || isDisabled}
               />
             </FormControl>
           </FormItem>

--- a/frontend/apps/web/app/[account]/new/transformer/page.tsx
+++ b/frontend/apps/web/app/[account]/new/transformer/page.tsx
@@ -27,6 +27,10 @@ import { toast } from '@/components/ui/use-toast';
 import { useGetSystemTransformers } from '@/libs/hooks/useGetSystemTransformers';
 import { cn } from '@/libs/utils';
 import { getErrorMessage } from '@/util/util';
+import {
+  convertTransformerConfigSchemaToTransformerConfig,
+  convertTransformerConfigToForm,
+} from '@/yup-validations/jobs';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   CreateUserDefinedTransformerRequest,
@@ -42,7 +46,6 @@ import { handleUserDefinedTransformerForm } from './UserDefinedTransformerForms/
 import {
   CREATE_USER_DEFINED_TRANSFORMER_SCHEMA,
   CreateUserDefinedTransformerSchema,
-  YupTransformerConfig,
 } from './schema';
 
 export default function NewTransformer(): ReactElement {
@@ -59,7 +62,7 @@ export default function NewTransformer(): ReactElement {
       name: '',
       source: '',
       type: '',
-      config: new TransformerConfig(),
+      config: convertTransformerConfigToForm(new TransformerConfig()),
       description: '',
     },
     context: { accountId: account?.id ?? '' },
@@ -135,7 +138,7 @@ export default function NewTransformer(): ReactElement {
                                 field.onChange(t.source);
                                 form.setValue(
                                   'config',
-                                  t.config as YupTransformerConfig
+                                  convertTransformerConfigToForm(t.config)
                                 );
                                 form.setValue('type', t.dataType);
                                 setBase(t ?? new SystemTransformer({}));
@@ -238,7 +241,9 @@ async function createNewTransformer(
     description: formData.description,
     type: formData.type,
     source: formData.source,
-    transformerConfig: formData.config as TransformerConfig,
+    transformerConfig: convertTransformerConfigSchemaToTransformerConfig(
+      formData.config
+    ),
   });
 
   const res = await fetch(

--- a/frontend/apps/web/app/[account]/new/transformer/schema.ts
+++ b/frontend/apps/web/app/[account]/new/transformer/schema.ts
@@ -38,7 +38,7 @@ const generateE164PhoneNumberConfig = Yup.object().shape({
 const generateFloat64Config = Yup.object().shape({
   randomizeSign: Yup.bool(),
   min: Yup.number().required('This field is required.'),
-  max: Yup.number().required('This field is required.'),
+  max: Yup.number().max(10).required('This field is required.'),
 });
 
 const generateGenderConfig = Yup.object().shape({

--- a/frontend/apps/web/app/[account]/new/transformer/schema.ts
+++ b/frontend/apps/web/app/[account]/new/transformer/schema.ts
@@ -38,7 +38,7 @@ const generateE164PhoneNumberConfig = Yup.object().shape({
 const generateFloat64Config = Yup.object().shape({
   randomizeSign: Yup.bool(),
   min: Yup.number().required('This field is required.'),
-  max: Yup.number().max(10).required('This field is required.'),
+  max: Yup.number().required('This field is required.'),
 });
 
 const generateGenderConfig = Yup.object().shape({
@@ -215,6 +215,7 @@ export const TRANSFORMER_SCHEMA_CONFIGS: Record<
 };
 
 export const TransformerConfigSchema = Yup.lazy((v) => {
+  console.log('hit here', v);
   const ccase = v?.case as TransformerConfigCase;
   if (!ccase) {
     return EMPTY_TRANSFORMER_CONFIG;

--- a/frontend/apps/web/app/[account]/new/transformer/schema.ts
+++ b/frontend/apps/web/app/[account]/new/transformer/schema.ts
@@ -215,7 +215,6 @@ export const TRANSFORMER_SCHEMA_CONFIGS: Record<
 };
 
 export const TransformerConfigSchema = Yup.lazy((v) => {
-  console.log('hit here', v);
   const ccase = v?.case as TransformerConfigCase;
   if (!ccase) {
     return EMPTY_TRANSFORMER_CONFIG;

--- a/frontend/apps/web/app/[account]/new/transformer/schema.ts
+++ b/frontend/apps/web/app/[account]/new/transformer/schema.ts
@@ -198,7 +198,7 @@ export const transformerConfig = Yup.object({
   }),
 });
 
-export type YupTransformerConfig = Yup.InferType<typeof transformerConfig>;
+// export type YupTransformerConfig = Yup.InferType<typeof transformerConfig>;
 
 const transformerNameSchema = Yup.string()
   .required()

--- a/frontend/apps/web/app/[account]/new/transformer/schema.ts
+++ b/frontend/apps/web/app/[account]/new/transformer/schema.ts
@@ -198,8 +198,6 @@ export const transformerConfig = Yup.object({
   }),
 });
 
-// export type YupTransformerConfig = Yup.InferType<typeof transformerConfig>;
-
 const transformerNameSchema = Yup.string()
   .required()
   .test(

--- a/frontend/apps/web/app/[account]/new/transformer/schema.ts
+++ b/frontend/apps/web/app/[account]/new/transformer/schema.ts
@@ -1,4 +1,7 @@
-import { IsTransformerNameAvailableResponse } from '@neosync/sdk';
+import {
+  IsTransformerNameAvailableResponse,
+  TransformerConfig,
+} from '@neosync/sdk';
 import * as Yup from 'yup';
 
 const transformEmailConfig = Yup.object().shape({
@@ -152,15 +155,44 @@ const userDefinedTransformerConfig = Yup.object().shape({
   id: Yup.string().required('This field is required.'),
 });
 
-type ConfigCase = keyof typeof customConfigs;
+type ConfigType = TransformerConfig['config'];
 
-const emptyConfig = () =>
-  Yup.object({
-    value: Yup.object().shape({}),
-    case: Yup.string(),
-  });
+// Helper function to extract the 'case' property from a config type
+type ExtractCase<T> = T extends { case: infer U } ? U : never;
 
-const customConfigs = {
+// Computed type that extracts all case types from the config union
+export type TransformerConfigCase = ExtractCase<ConfigType>;
+
+export const EMPTY_TRANSFORMER_CONFIG = Yup.object({
+  case: Yup.string(),
+  value: Yup.object(),
+});
+
+// todo: this should be properly typed
+export const TRANSFORMER_SCHEMA_CONFIGS: Record<
+  NonNullable<TransformerConfigCase>,
+  Yup.ObjectSchema<any> // eslint-disable-line @typescript-eslint/no-explicit-any
+> = {
+  generateBoolConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateCityConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateDefaultConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateEmailConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateFirstNameConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateFullAddressConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateFullNameConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateInt64PhoneNumberConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateLastNameConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateSha256hashConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateSsnConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateStateConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateStreetAddressConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateUnixtimestampConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateUsernameConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateUtctimestampConfig: EMPTY_TRANSFORMER_CONFIG,
+  generateZipcodeConfig: EMPTY_TRANSFORMER_CONFIG,
+  nullconfig: EMPTY_TRANSFORMER_CONFIG,
+  passthroughConfig: EMPTY_TRANSFORMER_CONFIG,
+
   transformEmailConfig: transformEmailConfig,
   generateCardNumberConfig: generateCardNumberConfig,
   generateE164PhoneNumberConfig: generateE164PhoneNumberConfig,
@@ -182,21 +214,22 @@ const customConfigs = {
   userDefinedTransformerConfig: userDefinedTransformerConfig,
 };
 
-export const transformerConfig = Yup.object({
-  config: Yup.lazy((value) => {
-    const configCase = value?.case as ConfigCase;
-    const customConfig = customConfigs[configCase];
-
-    if (customConfig) {
-      return Yup.object({
-        value: customConfig,
-        case: Yup.string().oneOf([configCase]),
-      });
-    } else {
-      return emptyConfig();
-    }
-  }),
+export const TransformerConfigSchema = Yup.lazy((v) => {
+  const ccase = v?.case as TransformerConfigCase;
+  if (!ccase) {
+    return EMPTY_TRANSFORMER_CONFIG;
+  }
+  const cconfig = TRANSFORMER_SCHEMA_CONFIGS[ccase];
+  return Yup.object({
+    case: Yup.string().required().oneOf([ccase]),
+    value: cconfig,
+  });
 });
+
+// Simplified version of a job mapping transformer config for use with react-hook-form only
+export type TransformerConfigSchema = Yup.InferType<
+  typeof TransformerConfigSchema
+>;
 
 const transformerNameSchema = Yup.string()
   .required()
@@ -250,7 +283,7 @@ export const CREATE_USER_DEFINED_TRANSFORMER_SCHEMA = Yup.object({
   source: Yup.string(),
   description: Yup.string().required(),
   type: Yup.string().required(),
-  config: transformerConfig,
+  config: TransformerConfigSchema,
 });
 
 export type CreateUserDefinedTransformerSchema = Yup.InferType<
@@ -263,7 +296,7 @@ export const UPDATE_USER_DEFINED_TRANSFORMER = Yup.object({
   source: Yup.string(),
   description: Yup.string().required(),
   type: Yup.string(),
-  config: transformerConfig,
+  config: TransformerConfigSchema,
 });
 
 export type UpdateUserDefinedTransformer = Yup.InferType<
@@ -293,7 +326,7 @@ export const SYSTEM_TRANSFORMER_SCHEMA = Yup.object({
   name: Yup.string(),
   type: Yup.string(),
   description: Yup.string().required(),
-  config: transformerConfig,
+  config: TransformerConfigSchema,
 });
 
 export type SystemTransformersSchema = Yup.InferType<

--- a/frontend/apps/web/app/[account]/new/transformer/schema.ts
+++ b/frontend/apps/web/app/[account]/new/transformer/schema.ts
@@ -161,15 +161,15 @@ type ConfigType = TransformerConfig['config'];
 type ExtractCase<T> = T extends { case: infer U } ? U : never;
 
 // Computed type that extracts all case types from the config union
-export type TransformerConfigCase = ExtractCase<ConfigType>;
+type TransformerConfigCase = ExtractCase<ConfigType>;
 
-export const EMPTY_TRANSFORMER_CONFIG = Yup.object({
+const EMPTY_TRANSFORMER_CONFIG = Yup.object({
   case: Yup.string(),
   value: Yup.object(),
 });
 
 // todo: this should be properly typed
-export const TRANSFORMER_SCHEMA_CONFIGS: Record<
+const TRANSFORMER_SCHEMA_CONFIGS: Record<
   NonNullable<TransformerConfigCase>,
   Yup.ObjectSchema<any> // eslint-disable-line @typescript-eslint/no-explicit-any
 > = {

--- a/frontend/apps/web/app/[account]/transformers/EditTransformerOptions.tsx
+++ b/frontend/apps/web/app/[account]/transformers/EditTransformerOptions.tsx
@@ -89,6 +89,11 @@ export default function EditTransformerOptions(props: Props): ReactElement {
         <Button
           variant="outline"
           size="sm"
+          // disabling this form if the transformer is user defined becuase the form is meant to load job mappings that are system transformers
+          // however, that doesn't really work when the job mapping is "custom" because the config is not a system transformer config so it doens't know how to load the values
+          // we need to load the custom transformer values and push them into the component, but the components expect the "form", which is the Job Mapping.
+          // this would require a refactor of the lower components to not rely on the react-hook-form and instead values as props to the component itself.
+          // until that is true, this needs to be disabled.
           disabled={!transformer || isUserDefinedTransformer(transformer)}
           onClick={() => setIsSheetOpen(true)}
           className="ml-auto hidden h-[36px] lg:flex"

--- a/frontend/apps/web/app/[account]/transformers/EditTransformerOptions.tsx
+++ b/frontend/apps/web/app/[account]/transformers/EditTransformerOptions.tsx
@@ -10,7 +10,7 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { Transformer } from '@/shared/transformers';
+import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
 import { SystemTransformer, UserDefinedTransformer } from '@neosync/sdk';
 import {
   Cross2Icon,
@@ -89,7 +89,7 @@ export default function EditTransformerOptions(props: Props): ReactElement {
         <Button
           variant="outline"
           size="sm"
-          disabled={!transformer}
+          disabled={!transformer || isUserDefinedTransformer(transformer)}
           onClick={() => setIsSheetOpen(true)}
           className="ml-auto hidden h-[36px] lg:flex"
         >

--- a/frontend/apps/web/app/[account]/transformers/EditTransformerOptions.tsx
+++ b/frontend/apps/web/app/[account]/transformers/EditTransformerOptions.tsx
@@ -39,6 +39,7 @@ import TransformStringForm from './Sheetforms/TransformStringForm';
 
 interface Props {
   transformer: Transformer | undefined;
+  // mapping index
   index: number;
 }
 

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateCardNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateCardNumberForm.tsx
@@ -9,6 +9,7 @@ import {
 
 import { Switch } from '@/components/ui/switch';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { GenerateCardNumber } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { Controller, useFormContext } from 'react-hook-form';
 interface Props {
@@ -23,14 +24,14 @@ export default function GenerateCardNumberForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const vlValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.validLuhn`
+    `mappings.${index}.transformer.config.value.validLuhn`
   );
   const [vl, setVl] = useState<boolean>(vlValue);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.validLuhn`,
-      vl,
+      `mappings.${index}.transformer.config.value`,
+      new GenerateCardNumber({ validLuhn: vl }),
       {
         shouldValidate: false,
       }
@@ -41,7 +42,7 @@ export default function GenerateCardNumberForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <Controller
-        name={`mappings.${index}.transformer.config.config.value.validLuhn`}
+        name={`mappings.${index}.transformer.config.value.validLuhn`}
         defaultValue={vl}
         disabled={isUserDefinedTransformer(transformer)}
         render={() => (

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateE164PhoneNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateE164PhoneNumberForm.tsx
@@ -9,6 +9,7 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { GenerateE164PhoneNumber } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -23,12 +24,8 @@ export default function GenerateE164PhoneNumberForm(
 
   const fc = useFormContext();
 
-  const minVal = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.min`
-  );
-  const maxVal = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.max`
-  );
+  const minVal = fc.getValues(`mappings.${index}.transformer.config.value.min`);
+  const maxVal = fc.getValues(`mappings.${index}.transformer.config.value.max`);
   const [min, setMin] = useState<number>(minVal);
   const [max, setMax] = useState<number>(maxVal);
   const [disableSave, setDisableSave] = useState<boolean>(false);
@@ -36,12 +33,16 @@ export default function GenerateE164PhoneNumberForm(
   const [maxError, setMaxError] = useState<string>('');
 
   const handleSubmit = () => {
-    fc.setValue(`mappings.${index}.transformer.config.config.value.min`, min, {
-      shouldValidate: false,
-    });
-    fc.setValue(`mappings.${index}.transformer.config.config.value.max`, max, {
-      shouldValidate: false,
-    });
+    fc.setValue(
+      `mappings.${index}.transformer.config.value`,
+      new GenerateE164PhoneNumber({
+        min: BigInt(min),
+        max: BigInt(max),
+      }),
+      {
+        shouldValidate: false,
+      }
+    );
     setIsSheetOpen!(false);
   };
 
@@ -75,7 +76,7 @@ export default function GenerateE164PhoneNumberForm(
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.min`}
+        name={`mappings.${index}.transformer.config.value.min`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">
@@ -100,7 +101,7 @@ export default function GenerateE164PhoneNumberForm(
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.max`}
+        name={`mappings.${index}.transformer.config.value.max`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateFloat64Form.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateFloat64Form.tsx
@@ -9,8 +9,9 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
+import { GenerateFloat64 } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
-import { Controller, useFormContext } from 'react-hook-form';
+import { useFormContext } from 'react-hook-form';
 interface Props {
   index?: number;
   setIsSheetOpen?: (val: boolean) => void;
@@ -22,41 +23,36 @@ export default function GenerateFloat64Form(props: Props): ReactElement {
   const fc = useFormContext();
 
   const s = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.randomizeSign`
+    `mappings.${index}.transformer.config.value.randomizeSign`
   );
   const [sign, setSign] = useState<boolean>(s);
 
   const minValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.min`
+    `mappings.${index}.transformer.config.value.min`
   );
   const [min, setMin] = useState<number>(minValue);
 
-  const maxVal = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.max`
-  );
+  const maxVal = fc.getValues(`mappings.${index}.transformer.config.value.max`);
   const [max, setMax] = useState<number>(maxVal);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.randomizeSign`,
-      sign,
+      `mappings.${index}.transformer.config.value`,
+      new GenerateFloat64({
+        randomizeSign: sign,
+        min,
+        max,
+      }),
       {
         shouldValidate: false,
       }
     );
-    fc.setValue(`mappings.${index}.transformer.config.config.value.min`, min, {
-      shouldValidate: false,
-    });
-    fc.setValue(`mappings.${index}.transformer.config.config.value.max`, max, {
-      shouldValidate: false,
-    });
     setIsSheetOpen!(false);
   };
-
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
-      <Controller
-        name={`mappings.${index}.transformer.config.config.value.randomizeSign`}
+      <FormField
+        name={`mappings.${index}.transformer.config.value.randomizeSign`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0 z-10">
@@ -70,7 +66,7 @@ export default function GenerateFloat64Form(props: Props): ReactElement {
               <Switch
                 checked={sign}
                 onCheckedChange={() => {
-                  sign ? setSign(false) : setSign(true);
+                  setSign(!sign);
                 }}
               />
             </FormControl>
@@ -78,7 +74,7 @@ export default function GenerateFloat64Form(props: Props): ReactElement {
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.min`}
+        name={`mappings.${index}.transformer.config.value.min`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">
@@ -102,7 +98,7 @@ export default function GenerateFloat64Form(props: Props): ReactElement {
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.max`}
+        name={`mappings.${index}.transformer.config.value.max`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateFloat64Form.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateFloat64Form.tsx
@@ -6,6 +6,7 @@ import {
   FormField,
   FormItem,
   FormLabel,
+  FormMessage,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
@@ -70,6 +71,7 @@ export default function GenerateFloat64Form(props: Props): ReactElement {
                 }}
               />
             </FormControl>
+            <FormMessage />
           </FormItem>
         )}
       />
@@ -94,6 +96,7 @@ export default function GenerateFloat64Form(props: Props): ReactElement {
                 }}
               />
             </FormControl>
+            <FormMessage />
           </FormItem>
         )}
       />
@@ -118,6 +121,7 @@ export default function GenerateFloat64Form(props: Props): ReactElement {
                 }}
               />
             </FormControl>
+            <FormMessage />
           </FormItem>
         )}
       />

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateGenderForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateGenderForm.tsx
@@ -8,6 +8,7 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
+import { GenerateGender } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -21,15 +22,15 @@ export default function GenerateGenderForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const aValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.abbreviate`
+    `mappings.${index}.transformer.config.value.abbreviate`
   );
 
   const [ab, setAb] = useState<boolean>(aValue);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.abbreviate`,
-      ab,
+      `mappings.${index}.transformer.config.value`,
+      new GenerateGender({ abbreviate: ab }),
       {
         shouldValidate: false,
       }
@@ -40,7 +41,7 @@ export default function GenerateGenderForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.abbreviate`}
+        name={`mappings.${index}.transformer.config.value.abbreviate`}
         defaultValue={ab}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateInt64Form.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateInt64Form.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Switch } from '@/components/ui/switch';
+import { GenerateInt64 } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -22,42 +23,37 @@ export default function GenerateInt64Form(props: Props): ReactElement {
   const fc = useFormContext();
 
   const s = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.randomizeSign`
+    `mappings.${index}.transformer.config.value.randomizeSign`
   );
   const [sign, setSign] = useState<boolean>(s);
 
   const minValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.min`
+    `mappings.${index}.transformer.config.value.min`
   );
   const [min, setMin] = useState<number>(minValue);
 
-  const maxVal = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.max`
-  );
+  const maxVal = fc.getValues(`mappings.${index}.transformer.config.value.max`);
   const [max, setMax] = useState<number>(maxVal);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.randomizeSign`,
-      sign,
+      `mappings.${index}.transformer.config.value`,
+      new GenerateInt64({
+        randomizeSign: sign,
+        min: BigInt(min),
+        max: BigInt(max),
+      }),
       {
         shouldValidate: false,
       }
     );
-    fc.setValue(`mappings.${index}.transformer.config.config.value.min`, min, {
-      shouldValidate: false,
-    });
-
-    fc.setValue(`mappings.${index}.transformer.config.config.value.max`, max, {
-      shouldValidate: false,
-    });
     setIsSheetOpen!(false);
   };
 
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.randomizeSign`}
+        name={`mappings.${index}.transformer.config.value.randomizeSign`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">
@@ -79,7 +75,7 @@ export default function GenerateInt64Form(props: Props): ReactElement {
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.min`}
+        name={`mappings.${index}.transformer.config.value.min`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">
@@ -103,7 +99,7 @@ export default function GenerateInt64Form(props: Props): ReactElement {
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.max`}
+        name={`mappings.${index}.transformer.config.value.max`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateStringForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateStringForm.tsx
@@ -9,6 +9,7 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
+import { GenerateString } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -22,25 +23,27 @@ export default function GenerateStringForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const minValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.min`
+    `mappings.${index}.transformer.config.value.min`
   );
   const [min, setMin] = useState<number>(minValue);
 
-  const maxVal = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.max`
-  );
+  const maxVal = fc.getValues(`mappings.${index}.transformer.config.value.max`);
   const [max, setMax] = useState<number>(maxVal);
   const [disableSave, setDisableSave] = useState<boolean>(false);
   const [minError, setMinError] = useState<string>('');
   const [maxError, setMaxError] = useState<string>('');
 
   const handleSubmit = () => {
-    fc.setValue(`mappings.${index}.transformer.config.config.value.min`, min, {
-      shouldValidate: false,
-    });
-    fc.setValue(`mappings.${index}.transformer.config.config.value.max`, max, {
-      shouldValidate: false,
-    });
+    fc.setValue(
+      `mappings.${index}.transformer.config.value`,
+      new GenerateString({
+        min: BigInt(min),
+        max: BigInt(max),
+      }),
+      {
+        shouldValidate: false,
+      }
+    );
     setIsSheetOpen!(false);
   };
 
@@ -74,7 +77,7 @@ export default function GenerateStringForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.min`}
+        name={`mappings.${index}.transformer.config.value.min`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">
@@ -100,7 +103,7 @@ export default function GenerateStringForm(props: Props): ReactElement {
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.max`}
+        name={`mappings.${index}.transformer.config.value.max`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateStringPhoneNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateStringPhoneNumberForm.tsx
@@ -8,6 +8,7 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
+import { GenerateStringPhoneNumber } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -23,14 +24,16 @@ export default function GenerateStringPhoneNumberForm(
   const fc = useFormContext();
 
   const ihValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.includeHyphens`
+    `mappings.${index}.transformer.config.value.includeHyphens`
   );
 
   const [ih, setIh] = useState<boolean>(ihValue);
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.includeHyphens`,
-      ih,
+      `mappings.${index}.transformer.config.value`,
+      new GenerateStringPhoneNumber({
+        includeHyphens: ih,
+      }),
       {
         shouldValidate: false,
       }
@@ -41,7 +44,7 @@ export default function GenerateStringPhoneNumberForm(
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.includeHyphens`}
+        name={`mappings.${index}.transformer.config.value.includeHyphens`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateUuidForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/GenerateUuidForm.tsx
@@ -8,6 +8,7 @@ import {
   FormLabel,
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
+import { GenerateUuid } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -21,15 +22,15 @@ export default function GenerateUuidForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const ihValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.includeHyphens`
+    `mappings.${index}.transformer.config.value.includeHyphens`
   );
 
   const [ih, setIh] = useState<boolean>(ihValue);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.includeHyphens`,
-      ih,
+      `mappings.${index}.transformer.config.value`,
+      new GenerateUuid({ includeHyphens: ih }),
       {
         shouldValidate: false,
       }
@@ -40,7 +41,7 @@ export default function GenerateUuidForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.includeHyphens`}
+        name={`mappings.${index}.transformer.config.value.includeHyphens`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformE164PhoneNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformE164PhoneNumberForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformE164PhoneNumber } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -25,15 +26,17 @@ export default function TransformE164PhoneNumberForm(
   const fc = useFormContext();
 
   const plValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.preserveLength`
+    `mappings.${index}.transformer.config.value.preserveLength`
   );
 
   const [pl, setPl] = useState<boolean>(plValue);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.preserveLength`,
-      pl,
+      `mappings.${index}.transformer.config.value`,
+      new TransformE164PhoneNumber({
+        preserveLength: pl,
+      }),
       {
         shouldValidate: false,
       }
@@ -44,7 +47,7 @@ export default function TransformE164PhoneNumberForm(
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.preserveLength`}
+        name={`mappings.${index}.transformer.config.value.preserveLength`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformEmailForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformEmailForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformEmail } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -23,27 +24,23 @@ export default function TransformEmailForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const pdValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.preserveDomain`
+    `mappings.${index}.transformer.config.value.preserveDomain`
   );
 
   const [pd, setPd] = useState<boolean>(pdValue);
 
   const plValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.preserveLength`
+    `mappings.${index}.transformer.config.value.preserveLength`
   );
   const [pl, setPl] = useState<boolean>(plValue);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.preserveDomain`,
-      pd,
-      {
-        shouldValidate: false,
-      }
-    );
-    fc.setValue(
-      `mappings.${index}.transformer.config.config.value.preserveLength`,
-      pl,
+      `mappings.${index}.transformer.config.value`,
+      new TransformEmail({
+        preserveDomain: pd,
+        preserveLength: pl,
+      }),
       {
         shouldValidate: false,
       }
@@ -54,7 +51,7 @@ export default function TransformEmailForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.preserveLength`}
+        name={`mappings.${index}.transformer.config.value.preserveLength`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">
@@ -76,7 +73,7 @@ export default function TransformEmailForm(props: Props): ReactElement {
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.preserveDomain`}
+        name={`mappings.${index}.transformer.config.value.preserveDomain`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformFirstNameForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformFirstNameForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformFirstName } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -23,15 +24,17 @@ export default function TransformFirstNameForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const plValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.preserveLength`
+    `mappings.${index}.transformer.config.value.preserveLength`
   );
 
   const [pl, setPl] = useState<boolean>(plValue);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.preserveLength`,
-      pl,
+      `mappings.${index}.transformer.config.value`,
+      new TransformFirstName({
+        preserveLength: pl,
+      }),
       {
         shouldValidate: false,
       }
@@ -42,7 +45,7 @@ export default function TransformFirstNameForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.preserveLength`}
+        name={`mappings.${index}.transformer.config.value.preserveLength`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformFloat64Form.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformFloat64Form.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformFloat64 } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -25,13 +26,13 @@ export default function TransformFloat64Form(props: Props): ReactElement {
   const fc = useFormContext();
 
   const rMinVal = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.randomizationRangeMin`
+    `mappings.${index}.transformer.config.value.randomizationRangeMin`
   );
 
   const [rMin, setRMin] = useState<number>(rMinVal);
 
   const rMaxVal = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.randomizationRangeMax`
+    `mappings.${index}.transformer.config.value.randomizationRangeMax`
   );
 
   const [rMax, setRMax] = useState<number>(rMaxVal);
@@ -41,15 +42,11 @@ export default function TransformFloat64Form(props: Props): ReactElement {
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.randomizationRangeMin`,
-      rMin,
-      {
-        shouldValidate: false,
-      }
-    );
-    fc.setValue(
-      `mappings.${index}.transformer.config.config.value.randomizationRangeMax`,
-      rMax,
+      `mappings.${index}.transformer.config.value`,
+      new TransformFloat64({
+        randomizationRangeMin: rMin,
+        randomizationRangeMax: rMax,
+      }),
       {
         shouldValidate: false,
       }
@@ -83,7 +80,7 @@ export default function TransformFloat64Form(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.randomizationRangeMin`}
+        name={`mappings.${index}.transformer.config.value.randomizationRangeMin`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">
@@ -112,7 +109,7 @@ export default function TransformFloat64Form(props: Props): ReactElement {
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.randomizationRangeMax`}
+        name={`mappings.${index}.transformer.config.value.randomizationRangeMax`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformFullNameForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformFullNameForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformFullName } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -23,15 +24,17 @@ export default function TransformFullNameForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const plValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.preserveLength`
+    `mappings.${index}.transformer.config.value.preserveLength`
   );
 
   const [pl, setPl] = useState<boolean>(plValue);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.preserveLength`,
-      pl,
+      `mappings.${index}.transformer.config.value`,
+      new TransformFullName({
+        preserveLength: pl,
+      }),
       {
         shouldValidate: false,
       }
@@ -42,7 +45,7 @@ export default function TransformFullNameForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.preserveLength`}
+        name={`mappings.${index}.transformer.config.value.preserveLength`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformInt64Form.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformInt64Form.tsx
@@ -10,6 +10,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformInt64 } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 
@@ -24,13 +25,13 @@ export default function TransformInt64Form(props: Props): ReactElement {
   const fc = useFormContext();
 
   const rMinVal = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.randomizationRangeMin`
+    `mappings.${index}.transformer.config.value.randomizationRangeMin`
   );
 
   const [rMin, setRMin] = useState<number>(rMinVal);
 
   const rMaxVal = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.randomizationRangeMax`
+    `mappings.${index}.transformer.config.value.randomizationRangeMax`
   );
 
   const [rMax, setRMax] = useState<number>(rMaxVal);
@@ -40,15 +41,11 @@ export default function TransformInt64Form(props: Props): ReactElement {
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.randomizationRangeMin`,
-      rMin,
-      {
-        shouldValidate: false,
-      }
-    );
-    fc.setValue(
-      `mappings.${index}.transformer.config.config.value.randomizationRangeMax`,
-      rMax,
+      `mappings.${index}.transformer.config.value`,
+      new TransformInt64({
+        randomizationRangeMin: BigInt(rMin),
+        randomizationRangeMax: BigInt(rMax),
+      }),
       {
         shouldValidate: false,
       }
@@ -82,7 +79,7 @@ export default function TransformInt64Form(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.randomizationRangeMin`}
+        name={`mappings.${index}.transformer.config.value.randomizationRangeMin`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">
@@ -110,7 +107,7 @@ export default function TransformInt64Form(props: Props): ReactElement {
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.randomizationRangeMax`}
+        name={`mappings.${index}.transformer.config.value.randomizationRangeMax`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformInt64PhoneForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformInt64PhoneForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformInt64PhoneNumber } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -23,14 +24,16 @@ export default function TransformInt64PhoneForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const plValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.preserveLength`
+    `mappings.${index}.transformer.config.value.preserveLength`
   );
 
   const [pl, setPl] = useState<boolean>(plValue);
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.preserveLength`,
-      pl,
+      `mappings.${index}.transformer.config.value`,
+      new TransformInt64PhoneNumber({
+        preserveLength: pl,
+      }),
       {
         shouldValidate: false,
       }
@@ -41,7 +44,7 @@ export default function TransformInt64PhoneForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.preserveLength`}
+        name={`mappings.${index}.transformer.config.value.preserveLength`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformLastNameForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformLastNameForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformLastName } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -23,14 +24,14 @@ export default function TransformLastNameForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const plValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.preserveLength`
+    `mappings.${index}.transformer.config.value.preserveLength`
   );
 
   const [pl, setPl] = useState<boolean>(plValue);
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.preserveLength`,
-      pl,
+      `mappings.${index}.transformer.config.value`,
+      new TransformLastName({ preserveLength: pl }),
       {
         shouldValidate: false,
       }
@@ -41,7 +42,7 @@ export default function TransformLastNameForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.preserveLength`}
+        name={`mappings.${index}.transformer.config.value.preserveLength`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformPhoneNumberForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformPhoneNumberForm.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/form';
 import { Switch } from '@/components/ui/switch';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformPhoneNumber } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -22,27 +23,20 @@ export default function TransformPhoneNumberForm(props: Props): ReactElement {
 
   const fc = useFormContext();
   const ihValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.includeHyphens`
+    `mappings.${index}.transformer.config.value.includeHyphens`
   );
 
   const [ih, setIh] = useState<boolean>(ihValue);
   const plValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.preserveLength`
+    `mappings.${index}.transformer.config.value.preserveLength`
   );
 
   const [pl, setPl] = useState<boolean>(plValue);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.preserveLength`,
-      pl,
-      {
-        shouldValidate: false,
-      }
-    );
-    fc.setValue(
-      `mappings.${index}.transformer.config.config.value.includeHyphens`,
-      ih,
+      `mappings.${index}.transformer.config.value`,
+      new TransformPhoneNumber({ includeHyphens: ih, preserveLength: pl }),
       {
         shouldValidate: false,
       }
@@ -53,7 +47,7 @@ export default function TransformPhoneNumberForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.preserveLength`}
+        name={`mappings.${index}.transformer.config.value.preserveLength`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">
@@ -74,7 +68,7 @@ export default function TransformPhoneNumberForm(props: Props): ReactElement {
         )}
       />
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.includeHyphens`}
+        name={`mappings.${index}.transformer.config.value.includeHyphens`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformStringForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/Sheetforms/TransformStringForm.tsx
@@ -10,6 +10,7 @@ import {
 
 import { Switch } from '@/components/ui/switch';
 import { Transformer, isUserDefinedTransformer } from '@/shared/transformers';
+import { TransformString } from '@neosync/sdk';
 import { ReactElement, useState } from 'react';
 import { useFormContext } from 'react-hook-form';
 interface Props {
@@ -24,15 +25,15 @@ export default function TransformStringForm(props: Props): ReactElement {
   const fc = useFormContext();
 
   const plValue = fc.getValues(
-    `mappings.${index}.transformer.config.config.value.preserveLength`
+    `mappings.${index}.transformer.config.value.preserveLength`
   );
 
   const [pl, setPl] = useState<boolean>(plValue);
 
   const handleSubmit = () => {
     fc.setValue(
-      `mappings.${index}.transformer.config.config.value.preserveLength`,
-      pl,
+      `mappings.${index}.transformer.config.value`,
+      new TransformString({ preserveLength: pl }),
       {
         shouldValidate: false,
       }
@@ -44,7 +45,7 @@ export default function TransformStringForm(props: Props): ReactElement {
   return (
     <div className="flex flex-col w-full space-y-4 pt-4">
       <FormField
-        name={`mappings.${index}.transformer.config.config.value.preserveLength`}
+        name={`mappings.${index}.transformer.config.value.preserveLength`}
         render={() => (
           <FormItem className="flex flex-row items-center justify-between rounded-lg border p-3 shadow-sm">
             <div className="space-y-0.5">

--- a/frontend/apps/web/app/[account]/transformers/[id]/components/UpdateUserDefinedTransformerForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/[id]/components/UpdateUserDefinedTransformerForm.tsx
@@ -43,10 +43,6 @@ export default function UpdateUserDefinedTransformerForm(
   const { currentTransformer, onUpdated } = props;
   const { account } = useAccount();
 
-  console.log(
-    currentTransformer.config,
-    convertTransformerConfigToForm(currentTransformer.config)
-  );
   const form = useForm<UpdateUserDefinedTransformer>({
     mode: 'onChange',
     resolver: yupResolver(UPDATE_USER_DEFINED_TRANSFORMER),

--- a/frontend/apps/web/app/[account]/transformers/[id]/components/UpdateUserDefinedTransformerForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/[id]/components/UpdateUserDefinedTransformerForm.tsx
@@ -25,7 +25,6 @@ import {
 } from '@/yup-validations/jobs';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
-  TransformerConfig,
   UpdateUserDefinedTransformerRequest,
   UpdateUserDefinedTransformerResponse,
   UserDefinedTransformer,
@@ -34,7 +33,7 @@ import { ReactElement } from 'react';
 import { Controller, useForm } from 'react-hook-form';
 
 interface Props {
-  currentTransformer: UserDefinedTransformer | undefined;
+  currentTransformer: UserDefinedTransformer;
   onUpdated(transformer: UserDefinedTransformer): void;
 }
 
@@ -44,25 +43,20 @@ export default function UpdateUserDefinedTransformerForm(
   const { currentTransformer, onUpdated } = props;
   const { account } = useAccount();
 
+  console.log(
+    currentTransformer.config,
+    convertTransformerConfigToForm(currentTransformer.config)
+  );
   const form = useForm<UpdateUserDefinedTransformer>({
+    mode: 'onChange',
     resolver: yupResolver(UPDATE_USER_DEFINED_TRANSFORMER),
-    defaultValues: {
-      name: '',
-      source: '',
-      description: '',
-      id: '',
-      config: convertTransformerConfigToForm(new TransformerConfig()),
-    },
     values: {
       name: currentTransformer?.name ?? '',
       source: currentTransformer?.source ?? '',
       description: currentTransformer?.description ?? '',
       type: currentTransformer?.dataType ?? '',
       id: currentTransformer?.id ?? '',
-      config: {
-        case: currentTransformer?.config?.config.case,
-        value: currentTransformer?.config?.config.value ?? {},
-      },
+      config: convertTransformerConfigToForm(currentTransformer.config),
     },
     context: { name: currentTransformer?.name, accountId: account?.id ?? '' },
   });

--- a/frontend/apps/web/app/[account]/transformers/[id]/components/UpdateUserDefinedTransformerForm.tsx
+++ b/frontend/apps/web/app/[account]/transformers/[id]/components/UpdateUserDefinedTransformerForm.tsx
@@ -19,6 +19,10 @@ import { Input } from '@/components/ui/input';
 import { Select, SelectTrigger, SelectValue } from '@/components/ui/select';
 import { toast } from '@/components/ui/use-toast';
 import { getErrorMessage } from '@/util/util';
+import {
+  convertTransformerConfigSchemaToTransformerConfig,
+  convertTransformerConfigToForm,
+} from '@/yup-validations/jobs';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   TransformerConfig,
@@ -47,7 +51,7 @@ export default function UpdateUserDefinedTransformerForm(
       source: '',
       description: '',
       id: '',
-      config: { config: { case: '', value: {} } },
+      config: convertTransformerConfigToForm(new TransformerConfig()),
     },
     values: {
       name: currentTransformer?.name ?? '',
@@ -56,10 +60,8 @@ export default function UpdateUserDefinedTransformerForm(
       type: currentTransformer?.dataType ?? '',
       id: currentTransformer?.id ?? '',
       config: {
-        config: {
-          case: currentTransformer?.config?.config.case,
-          value: currentTransformer?.config?.config.value ?? {},
-        },
+        case: currentTransformer?.config?.config.case,
+        value: currentTransformer?.config?.config.value ?? {},
       },
     },
     context: { name: currentTransformer?.name, accountId: account?.id ?? '' },
@@ -178,7 +180,9 @@ async function updateCustomTransformer(
     transformerId: transformerId,
     name: formData.name,
     description: formData.description,
-    transformerConfig: formData.config as TransformerConfig,
+    transformerConfig: convertTransformerConfigSchemaToTransformerConfig(
+      formData.config
+    ),
   });
 
   const res = await fetch(

--- a/frontend/apps/web/app/[account]/transformers/[id]/page.tsx
+++ b/frontend/apps/web/app/[account]/transformers/[id]/page.tsx
@@ -45,16 +45,18 @@ export default function NewUserDefinedTransformerPage({ params }: PageProps) {
         <div>
           <div className="flex flex-col">
             <div>
-              <UpdateUserDefinedTransformerForm
-                currentTransformer={data?.transformer}
-                onUpdated={(updatedTransformer) => {
-                  mutate(
-                    new GetUserDefinedTransformerByIdResponse({
-                      transformer: updatedTransformer,
-                    })
-                  );
-                }}
-              />
+              {data?.transformer && (
+                <UpdateUserDefinedTransformerForm
+                  currentTransformer={data.transformer}
+                  onUpdated={(updatedTransformer) => {
+                    mutate(
+                      new GetUserDefinedTransformerByIdResponse({
+                        transformer: updatedTransformer,
+                      })
+                    );
+                  }}
+                />
+              )}
             </div>
           </div>
         </div>

--- a/frontend/apps/web/app/[account]/transformers/[id]/page.tsx
+++ b/frontend/apps/web/app/[account]/transformers/[id]/page.tsx
@@ -9,7 +9,9 @@ import { GetUserDefinedTransformerByIdResponse } from '@neosync/sdk';
 import RemoveTransformerButton from './components/RemoveTransformerButton';
 import UpdateUserDefinedTransformerForm from './components/UpdateUserDefinedTransformerForm';
 
-export default function NewUserDefinedTransformerPage({ params }: PageProps) {
+export default function UpdateUserDefinedTransformerPage({
+  params,
+}: PageProps) {
   const id = params?.id ?? '';
   const { account } = useAccount();
 

--- a/frontend/apps/web/app/[account]/transformers/systemTransformers/[name]/page.tsx
+++ b/frontend/apps/web/app/[account]/transformers/systemTransformers/[name]/page.tsx
@@ -21,6 +21,7 @@ import {
 } from '@/components/ui/form';
 import { Input } from '@/components/ui/input';
 import { useGetSystemTransformers } from '@/libs/hooks/useGetSystemTransformers';
+import { convertTransformerConfigToForm } from '@/yup-validations/jobs';
 import { yupResolver } from '@hookform/resolvers/yup';
 import { SystemTransformer } from '@neosync/sdk';
 import NextLink from 'next/link';
@@ -44,22 +45,11 @@ export default function ViewSystemTransformers({
 
   const form = useForm<SystemTransformersSchema>({
     resolver: yupResolver(SYSTEM_TRANSFORMER_SCHEMA),
-    defaultValues: {
-      name: '',
-      description: '',
-      type: '',
-      config: { config: { case: '', value: {} } },
-    },
     values: {
       name: currentTransformer?.name ?? '',
       description: currentTransformer?.description ?? '',
       type: currentTransformer?.dataType ?? '',
-      config: {
-        config: {
-          case: currentTransformer?.config?.config.case,
-          value: currentTransformer?.config?.config.value ?? {},
-        },
-      },
+      config: convertTransformerConfigToForm(currentTransformer?.config),
     },
   });
 

--- a/frontend/apps/web/components/MobileNav.tsx
+++ b/frontend/apps/web/components/MobileNav.tsx
@@ -19,8 +19,6 @@ export function MobileNav() {
   const { account } = useAccount();
   const pathname = usePathname();
 
-  console.log('pathname', pathname);
-
   return (
     <Sheet open={open} onOpenChange={setOpen}>
       <SheetTrigger asChild>

--- a/frontend/apps/web/components/jobs/SchemaTable/VirtualizedSchemaTable.tsx
+++ b/frontend/apps/web/components/jobs/SchemaTable/VirtualizedSchemaTable.tsx
@@ -445,7 +445,7 @@ function VirtualizedSchemaList({
               width={width}
               itemKey={(index: number) => {
                 const r = rows[index];
-                return `${r.schema}-${r.table}-${r.column}-${index}`;
+                return `${r.schema}-${r.table}-${r.column}`;
               }}
             >
               {Row}

--- a/frontend/apps/web/components/jobs/SchemaTable/schema-table.tsx
+++ b/frontend/apps/web/components/jobs/SchemaTable/schema-table.tsx
@@ -72,7 +72,7 @@ export async function getConnectionSchema(
   accountId: string,
   connectionId?: string
 ): Promise<GetConnectionSchemaResponse | undefined> {
-  if (!connectionId) {
+  if (!accountId || !connectionId) {
     return;
   }
   const res = await fetch(

--- a/frontend/apps/web/yup-validations/jobs.ts
+++ b/frontend/apps/web/yup-validations/jobs.ts
@@ -29,14 +29,9 @@ export type JobMappingTransformerForm = Yup.InferType<
 export function convertJobMappingTransformerToForm(
   jmt: JobMappingTransformer
 ): JobMappingTransformerForm {
-  let config = jmt.config?.config ?? { case: '', value: {} };
-  // handles: { case: undefined; value?: undefined };
-  if (!config.case) {
-    config = { case: '', value: {} };
-  }
   return {
     source: jmt.source,
-    config: config,
+    config: convertTransformerConfigToForm(jmt.config),
   };
 }
 export function convertJobMappingTransformerFormToJobMappingTransformer(
@@ -44,9 +39,25 @@ export function convertJobMappingTransformerFormToJobMappingTransformer(
 ): JobMappingTransformer {
   return new JobMappingTransformer({
     source: form.source,
-    config: TransformerConfig.fromJson({
-      [form.config.case ?? '']: form.config.value,
-    }),
+    config: convertTransformerConfigSchemaToTransformerConfig(form.config),
+  });
+}
+
+export function convertTransformerConfigToForm(
+  tc?: TransformerConfig
+): TransformerConfigSchema {
+  const config = tc?.config ?? { case: '', value: {} };
+  if (!config.case) {
+    return { case: '', value: {} };
+  }
+  return config;
+}
+
+export function convertTransformerConfigSchemaToTransformerConfig(
+  tcs: TransformerConfigSchema
+): TransformerConfig {
+  return TransformerConfig.fromJson({
+    [tcs.case ?? '']: tcs.value,
   });
 }
 

--- a/frontend/apps/web/yup-validations/jobs.ts
+++ b/frontend/apps/web/yup-validations/jobs.ts
@@ -1,4 +1,5 @@
 import { SubsetFormValues } from '@/app/[account]/new/job/schema';
+import { TransformerConfigSchema } from '@/app/[account]/new/transformer/schema';
 import {
   AwsS3DestinationConnectionOptions,
   Connection,
@@ -14,31 +15,10 @@ import {
 } from '@neosync/sdk';
 import * as Yup from 'yup';
 
-// type ConfigType = TransformerConfig['config'];
-
-// // Helper function to extract the 'case' property from a config type
-// type ExtractCase<T> = T extends { case: infer U } ? U : never;
-// type ExtractTransformerConfigValue<T> = T extends { value: infer U }
-//   ? U
-//   : never;
-
-// // Computed type that extracts all case types from the config union
-// type TransformerConfigCase = ExtractCase<ConfigType>;
-// type TransformerConfigValue = ExtractTransformerConfigValue<ConfigType>;
-
-const JobMappingTransformerConfig = Yup.object({
-  case: Yup.string().required(),
-  value: Yup.object<any, any>(),
-});
-// Simplified version of a job mapping transformer config for use with react-hook-form only
-export type JobMappingTransformerConfig = Yup.InferType<
-  typeof JobMappingTransformerConfig
->;
-
 // Yup schema form JobMappingTransformers
 const JobMappingTransformerForm = Yup.object({
   source: Yup.string().required(),
-  config: JobMappingTransformerConfig,
+  config: TransformerConfigSchema,
 });
 
 // Simplified version of a job mapping transformer for use with react-hook-form only
@@ -65,7 +45,7 @@ export function convertJobMappingTransformerFormToJobMappingTransformer(
   return new JobMappingTransformer({
     source: form.source,
     config: TransformerConfig.fromJson({
-      [form.config.case]: form.config.value,
+      [form.config.case ?? '']: form.config.value,
     }),
   });
 }

--- a/frontend/apps/web/yup-validations/jobs.ts
+++ b/frontend/apps/web/yup-validations/jobs.ts
@@ -22,17 +22,13 @@ export type TransformerFormValues = Yup.InferType<typeof TRANSFORMER_SCHEMA>;
 
 export type SchemaFormValues = Yup.InferType<typeof SCHEMA_FORM_SCHEMA>;
 
-export const JOB_MAPPING_COLUMN_SCHEMA = Yup.object({
+export const JOB_MAPPING_SCHEMA = Yup.object({
+  schema: Yup.string().required(),
+  table: Yup.string().required(),
   column: Yup.string().required(),
   dataType: Yup.string().required(),
   transformer: TRANSFORMER_SCHEMA,
-});
-const JOB_MAPPING_SCHEMA = JOB_MAPPING_COLUMN_SCHEMA.concat(
-  Yup.object({
-    schema: Yup.string().required(),
-    table: Yup.string().required(),
-  })
-).required();
+}).required();
 export type JobMappingFormValues = Yup.InferType<typeof JOB_MAPPING_SCHEMA>;
 
 export const SCHEMA_FORM_SCHEMA = Yup.object({


### PR DESCRIPTION
* Updates schema forms to use `values` instead of `defaultValues` to fix accountId missing on page refresh
* Replaces all uses of JobMappingTransformer on forms with a POJO type
* Updates /transformers pages to use POJO type instead of TransformerConfig DTO