### PR TITLE
Feat use production images 582

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -13,7 +13,13 @@ jobs:
       
       - name: Check Docker Version
         run: docker --version
+
+      - name: Make Build
+        run: make all
         
       - name: Build Docker Images
         run: docker compose build
+
+      - name: Check Docker Images
+        run: docker images 
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,7 +1,6 @@
 name: Deploy
 
 on: 
-  push:
   release:
     types: [published]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,19 +6,19 @@ on:
     types: [published]
 
 jobs:
-  build-images:
+  build_and_deploy:
     runs-on: ubuntu-20.04
     steps:
       - name: Clone Repository
-        uses: actions/checkout@v4.1.1
+        uses: actions/checkout@v4
       
       - name: Check Docker Version
         run: docker --version
 
       - name: Setup Go v1.23
-        uses: actions/setup-go@v5.0.0
+        uses: actions/setup-go@v5
         with:
-          go-version: '1.21.3'
+          go-version: worker/go.sum
 
       - name: Make Build
         run: make all
@@ -37,14 +37,14 @@ jobs:
 
       - name: Tag Docker Images
         run: |
-          docker tag neosync-worker burnerjhon/burnerjhon-neosync-worker
-          docker tag neosync-api burnerjhon/burnerjhon-neosync-api
-          docker tag neosync-app burnerjhon/burnerjhon-neosync-app
+          docker tag neosync-worker neosync/neosync-worker
+          docker tag neosync-api neosync/neosync-api
+          docker tag neosync-app neosync/neosync-app
 
       - name: Push Docker Images
         run: |
-          docker push burnerjhon/burnerjhon-neosync-worker
-          docker push burnerjhon/burnerjhon-neosync-api
-          docker push burnerjhon/burnerjhon-neosync-app
+          docker push neosync/neosync-worker
+          docker push neosync/neosync-api
+          docker push neosync/neosync-app
         
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go v1.23
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: backend/go.mod
+          go-version: '1.21.3'
 
       - name: Make Build
         run: make all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go v1.23
         uses: actions/setup-go@v5
         with:
-          go-version: worker/go.sum
+          go-version: worker/go.mod
 
       - name: Make Build
         run: make all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -40,5 +40,11 @@ jobs:
           docker tag neosync-worker burnerjhon/burnerjhon-neosync-worker
           docker tag neosync-api burnerjhon/burnerjhon-neosync-api
           docker tag neosync-app burnerjhon/burnerjhon-neosync-app
+
+      - name: Push Docker Images
+        run: |
+          docker push burnerjhon/burnerjhon-neosync-worker
+          docker push burnerjhon/burnerjhon-neosync-api
+          docker push burnerjhon/burnerjhon-neosync-app
         
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -14,6 +14,11 @@ jobs:
       - name: Check Docker Version
         run: docker --version
 
+      - name: Setup Go v1.23
+        uses: actions/setup-go@v5.0.0
+        with:
+          go-version: '1.23'
+
       - name: Make Build
         run: make all
         

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -29,3 +29,16 @@ jobs:
       - name: Check Docker Images
         run: docker images 
 
+      - name: Login to Docker Hub
+        uses: docker/login-action@v3.0.0
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+
+      - name: Tag Docker Images
+        run: |
+          docker tag neosync-worker burnerjhon/burnerjhon-neosync-worker
+          docker tag neosync-api burnerjhon/burnerjhon-neosync-api
+          docker tag neosync-app burnerjhon/burnerjhon-neosync-app
+        
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,19 @@
+name: Deploy
+
+on: 
+  release:
+    types: [published]
+
+jobs:
+  build-images:
+    runs-on: ubuntu-20.04
+    steps:
+      - name: Clone Repository
+        uses: actions/checkout@v4.1.1
+      
+      - name: Check Docker Version
+        run: docker --version
+        
+      - name: Build Docker Images
+        run: docker compose build
+

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,6 +1,7 @@
 name: Deploy
 
 on: 
+  push:
   release:
     types: [published]
 

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -7,7 +7,7 @@ on:
 
 jobs:
   build_and_deploy:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
         uses: actions/checkout@v4

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -6,7 +6,7 @@ on:
     types: [published]
 
 jobs:
-  build_and_deploy:
+  Deploy_to_Prod:
     runs-on: ubuntu-latest
     steps:
       - name: Clone Repository
@@ -18,7 +18,7 @@ jobs:
       - name: Setup Go v1.23
         uses: actions/setup-go@v5
         with:
-          go-version: worker/go.mod
+          go-version: '1.21.3'
 
       - name: Make Build
         run: make all

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -17,7 +17,7 @@ jobs:
       - name: Setup Go v1.23
         uses: actions/setup-go@v5.0.0
         with:
-          go-version: '1.23'
+          go-version: backend/go.mod
 
       - name: Make Build
         run: make all

--- a/Makefile
+++ b/Makefile
@@ -9,3 +9,8 @@ cluster-destroy:
 	bash ./tilt/scripts/assert-context.sh
 	sh ./tilt/scripts/cluster-destroy.sh
 .PHONY: cluster-destroy
+
+all: 
+	sh -c "cd ./worker && make build"
+	sh -c "cd ./backend && make all"
+	sh -c "cd ./cli && make build"

--- a/compose-dev.yml
+++ b/compose-dev.yml
@@ -1,7 +1,10 @@
 services:
   app:
     container_name: neosync-app
-    image: neosync/neosync-app
+    image: neosync-app
+    build:
+      context: ./frontend
+      dockerfile: ./apps/web/dev/build/Dockerfile.dev
     ports:
       - 3000:3000
     environment:
@@ -50,7 +53,10 @@ services:
 
   api:
     container_name: neosync-api
-    image: neosync/neosync-api
+    image: neosync-api
+    build:
+      context: ./backend
+      dockerfile: ./dev/build/Dockerfile.dev
     ports:
       - 8080:8080
     command: serve connect
@@ -88,7 +94,10 @@ services:
 
   worker:
     container_name: neosync-worker
-    image: neosync/neosync-worker
+    image: neosync-worker
+    build:
+      context: ./worker
+      dockerfile: ./dev/build/Dockerfile.dev
     environment:
       - NUCLEUS_ENV=dev
       - TEMPORAL_URL=temporal:7233

--- a/compose.yml
+++ b/compose.yml
@@ -16,17 +16,6 @@ services:
 
     networks:
       - neosync-network
-    develop:
-      watch:
-        - path: frontend/package.json
-          action: rebuild
-        - path: frontend/package-lock.json
-          action: rebuild
-        - path: frontend/
-          action: sync
-          target: /app
-          ignore:
-            - frontend/node_modules/
 
   db:
     container_name: neosync-db
@@ -80,11 +69,6 @@ services:
       db:
         condition: service_healthy
         restart: true
-    develop:
-      watch:
-        - path: backend/bin
-          action: sync+restart
-          target: /app
 
   worker:
     container_name: neosync-worker
@@ -98,11 +82,6 @@ services:
     networks:
       - neosync-network
       - temporal-network
-    develop:
-      watch:
-        - path: worker/bin
-          action: sync+restart
-          target: /app
 
 networks:
   neosync-network:


### PR DESCRIPTION
## What does this PR do?

* Renamed `compose.yml` to `compose-dev.yml`.
* Replaced `compose.yml` with docker hub image rather than build. 
* Github Actions Workflow to deploy the latest docker image to docker hub when a new
release is triggered.
* `make all` command to build the required go binaries.

## Test Plan
### Tested Action
* Github Action Link: https://github.com/faisalill/neosync/actions/runs/7383280341/job/20084223065
* Docker Hub: https://hub.docker.com/repositories/burnerjhon

## Related PRs and Issues

- #1004 

