### PR TITLE
[Helm] Support for tolerations and nodeSelector

### DIFF
--- a/backend/charts/api/templates/deployment.yaml
+++ b/backend/charts/api/templates/deployment.yaml
@@ -46,6 +46,14 @@ spec:
       serviceAccountName: {{ include "neosync-api.serviceAccountName" . }}
       {{- end }}
       terminationGracePeriod: {{ .Values.terminationGracePeriod }}
+      {{- if .Values.tolerations }}
+      tolerations: 
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
 
       initContainers:
         - name: db-migration

--- a/backend/charts/api/values.yaml
+++ b/backend/charts/api/values.yaml
@@ -89,5 +89,8 @@ temporal:
     keyContents:
     certContents:
 
+tolerations: []
+nodeSelector: {}
+
 volumes: []
 volumeMounts: []

--- a/backend/dev/helm/db/helmfile.yaml
+++ b/backend/dev/helm/db/helmfile.yaml
@@ -15,4 +15,5 @@ releases:
           database: nucleus
       - primary:
           persistence:
+            mountPath: "/neosync/neosync-postgres"
             existingClaim: neosync-postgres # see pvc in ../yaml/neosync-postgres-pvc.yaml

--- a/frontend/apps/web/charts/app/templates/deployment.yaml
+++ b/frontend/apps/web/charts/app/templates/deployment.yaml
@@ -45,6 +45,14 @@ spec:
       serviceAccountName: {{ include "neosync-app.serviceAccountName" . }}
       {{- end }}
       terminationGracePeriod: {{ .Values.terminationGracePeriod }}
+      {{- if .Values.tolerations }}
+      tolerations: 
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
 
       containers:
         - name: user-container

--- a/frontend/apps/web/charts/app/values.yaml
+++ b/frontend/apps/web/charts/app/values.yaml
@@ -59,3 +59,6 @@ analytics:
 posthog:
   key: phc_qju45RhNvCDwYVdRyUjtWuWsOmLFaQZi3fmztMBaJip
   # host:
+
+tolerations: []
+nodeSelector: {}

--- a/worker/charts/worker/templates/deployment.yaml
+++ b/worker/charts/worker/templates/deployment.yaml
@@ -46,6 +46,14 @@ spec:
       serviceAccountName: {{ include "neosync-worker.serviceAccountName" . }}
       {{- end }}
       terminationGracePeriod: {{ .Values.terminationGracePeriod }}
+      {{- if .Values.tolerations }}
+      tolerations: 
+        {{- toYaml .Values.tolerations | nindent 8 }}
+      {{- end }}
+      {{- if .Values.nodeSelector }}
+      nodeSelector:
+        {{- toYaml .Values.nodeSelector | nindent 8 }}
+      {{- end }}
 
       {{- with .Values.volumes }}
       volumes:

--- a/worker/charts/worker/values.yaml
+++ b/worker/charts/worker/values.yaml
@@ -63,5 +63,8 @@ host: 0.0.0.0
 servicePort: 80
 containerPort: 8080
 
+tolerations: []
+nodeSelector: {}
+
 volumes: []
 volumeMounts: []


### PR DESCRIPTION
## Changelog
- Adds support for tolerations and nodeSelector values in all 3 helm charts
- Fixes an issue I was having with mountPath in the bitnami postgres container that Tilt brings online for local development

## Testing
I was able to successfully test the following use-cases locally, using a kind cluster with 3 nodes.

### Test Setup (kind nodes):
1x control-plane
1x worker untainted (worker1)
1x worker tainted (worker2)

---
### Test Results:
- No tolerations or nodeSelectors specified.
  - Result: Neosync pods were scheduled only on the untainted node (worker1).
- Tolerations specified for given taint, no nodeSelector.
  - Result: Neosync pods distributed evenly between both worker nodes (worker1 + worker2).
- Tolerations and nodeSelector specified
  - Result: Neosync pods scheduled exclusively on to tainted node only (worker2).

## Additional Context
The Postgres container error I was getting when I ran `tilt up` was the following:
```
 mkdir: cannot create directory ‘/bitnami/postgresql/data’: Permission denied
 ```
After some Googling, I discovered we need to set the mountPath in the Bitnami/Postgresql helm chart values to match the PVC we're creating. I'm not sure why I didn't run into this issue last week when I tested the HPA changes, but alas, I was not able to move forward until I resolved this.