### PR TITLE
fix update job source bug

### DIFF
--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataSyncConnectionCard.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataSyncConnectionCard.tsx
@@ -146,7 +146,7 @@ export default function DataSyncConnectionCard({ jobId }: Props): ReactElement {
   }
 
   async function onSubmit(values: SourceFormValues) {
-    const connection = connections.find((c) => (c.id = values.sourceId));
+    const connection = connections.find((c) => c.id == values.sourceId);
     const job = data?.job;
     if (!job || !connection) {
       return;


### PR DESCRIPTION
there was frontend bug when updating job source. It was finding the wrong source connection. updated backend to check job source option config type matches job source connection type.