### PR TITLE
Helm chart fixes

### DIFF
--- a/backend/charts/api/templates/api-env-vars.yaml
+++ b/backend/charts/api/templates/api-env-vars.yaml
@@ -26,7 +26,9 @@ stringData:
     NUCLEUS_ENV: {{ .Values.nucleusEnv }}
     {{- end }}
 
+    {{- if .Values.shutdownTimeoutSeconds }}
     SHUTDOWN_TIMEOUT_SECONDS: {{ .Values.shutdownTimeoutSeconds | quote }}
+    {{- end }}
 
     {{- if and .Values.auth .Values.auth.enabled }}
     AUTH_ENABLED: {{ .Values.auth.enabled | default "false" | quote }}
@@ -48,15 +50,15 @@ stringData:
     AUTH_CLIENTID_SECRET: {{ .Values.auth.clientMap | toJson | quote }}
     {{- end }}
 
-   {{- if and .Values.auth .Values.auth.cliClientId }}
+    {{- if and .Values.auth .Values.auth.cliClientId }}
     AUTH_CLI_CLIENT_ID: {{ .Values.auth.cliClientId }}
     {{- end }}
 
-   {{- if and .Values.auth .Values.auth.cliAudience }}
+    {{- if and .Values.auth .Values.auth.cliAudience }}
     AUTH_CLI_AUDIENCE: {{ .Values.auth.cliAudience }}
     {{- end }}
 
-   {{- if and .Values.auth .Values.auth.signatureAlgorithm }}
+    {{- if and .Values.auth .Values.auth.signatureAlgorithm }}
     AUTH_SIGNATURE_ALGORITHM: {{ .Values.auth.signatureAlgorithm }}
     {{- end }}
 
@@ -101,7 +103,9 @@ stringData:
     {{- end }}
 
     NEOSYNC_CLOUD: {{ .Values.neosyncCloud.enabled | default "false" | quote }}
+    {{- if .Values.neosyncCloud.enabled }}
     NEOSYNC_CLOUD_ALLOWED_WORKER_API_KEYS: {{ join "," .Values.neosyncCloud.workerApiKeys }}
+    {{- end }}
 
     KUBERNETES_ENABLED: {{ .Values.kubernetes.enabled | default "true" | quote }}
     KUBERNETES_NAMESPACE: {{ .Values.kubernetes.namespace | default .Release.Namespace }}

--- a/backend/charts/api/templates/deployment.yaml
+++ b/backend/charts/api/templates/deployment.yaml
@@ -45,7 +45,9 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "neosync-api.serviceAccountName" . }}
       {{- end }}
+      {{- if .Values.terminationGracePeriod }}
       terminationGracePeriod: {{ .Values.terminationGracePeriod }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations: 
         {{- toYaml .Values.tolerations | nindent 8 }}

--- a/backend/charts/api/templates/role-binding.yaml
+++ b/backend/charts/api/templates/role-binding.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: RoleBinding
 metadata:
-  namespace: neosync
+  namespace: {{ .Release.Namespace }}
   name: {{ template "neosync-api.fullname" . }}-rolebinding
 roleRef:
   apiGroup: rbac.authorization.k8s.io

--- a/backend/charts/api/templates/role.yaml
+++ b/backend/charts/api/templates/role.yaml
@@ -1,7 +1,7 @@
 apiVersion: rbac.authorization.k8s.io/v1
 kind: Role
 metadata:
-  namespace: neosync
+  namespace: {{ .Release.Namespace }}
   name: {{ template "neosync-api.fullname" . }}-role
 rules:
   - apiGroups: [""]

--- a/frontend/apps/web/charts/app/templates/app-env-vars.yaml
+++ b/frontend/apps/web/charts/app/templates/app-env-vars.yaml
@@ -19,9 +19,13 @@ stringData:
     NUCLEUS_ENV: {{ .Values.nucleusEnv }}
     {{- end }}
 
+    {{- if .Values.shutdownTimeoutSeconds }}
     SHUTDOWN_TIMEOUT_SECONDS: {{ .Values.shutdownTimeoutSeconds | quote }}
+    {{- end }}
 
+    {{- if .Values.neosyncApi.url }}
     NEOSYNC_API_BASE_URL: {{ .Values.neosyncApi.url }}
+    {{- end }}
 
     NEXTAUTH_SECRET: {{ .Values.nextAuthSecret }}
 

--- a/frontend/apps/web/charts/app/templates/deployment.yaml
+++ b/frontend/apps/web/charts/app/templates/deployment.yaml
@@ -44,7 +44,9 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "neosync-app.serviceAccountName" . }}
       {{- end }}
+      {{- if .Values.terminationGracePeriod }}
       terminationGracePeriod: {{ .Values.terminationGracePeriod }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations: 
         {{- toYaml .Values.tolerations | nindent 8 }}

--- a/worker/charts/worker/templates/deployment.yaml
+++ b/worker/charts/worker/templates/deployment.yaml
@@ -45,7 +45,9 @@ spec:
       {{- if .Values.serviceAccount.create }}
       serviceAccountName: {{ include "neosync-worker.serviceAccountName" . }}
       {{- end }}
+      {{- if .Values.terminationGracePeriod }}
       terminationGracePeriod: {{ .Values.terminationGracePeriod }}
+      {{- end }}
       {{- if .Values.tolerations }}
       tolerations: 
         {{- toYaml .Values.tolerations | nindent 8 }}

--- a/worker/charts/worker/templates/env-vars.yaml
+++ b/worker/charts/worker/templates/env-vars.yaml
@@ -21,7 +21,9 @@ stringData:
     NUCLEUS_ENV: {{ .Values.nucleusEnv }}
     {{- end }}
 
+    {{- if .Values.shutdownTimeoutSeconds }}
     SHUTDOWN_TIMEOUT_SECONDS: {{ .Values.shutdownTimeoutSeconds | quote }}
+    {{- end }}
 
     {{- if .Values.temporal.url }}
     TEMPORAL_URL: {{ .Values.temporal.url }}


### PR DESCRIPTION
- [all] Made `shutdownTimeoutSeconds` an optional field
- [all] Made `terminationGracePeriod` an optional field
- [api] Made `neosyncCloud.workerApiKeys` an optional field
- [api] Fixed the `namespace` for the role and role-binding so it's based on the chart release
- [app] Made `neosyncApi.url` an optional field