### PR TITLE
Updates GetUserAccounts to support account-scoped API Keys

### DIFF
--- a/backend/gen/go/db/mock_Querier.go
+++ b/backend/gen/go/db/mock_Querier.go
@@ -1164,6 +1164,66 @@ func (_c *MockQuerier_GetAccountApiKeys_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
+// GetAccountByApiKeyUserId provides a mock function with given fields: ctx, db, id
+func (_m *MockQuerier) GetAccountByApiKeyUserId(ctx context.Context, db DBTX, id pgtype.UUID) ([]NeosyncApiAccount, error) {
+	ret := _m.Called(ctx, db, id)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetAccountByApiKeyUserId")
+	}
+
+	var r0 []NeosyncApiAccount
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) ([]NeosyncApiAccount, error)); ok {
+		return rf(ctx, db, id)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, pgtype.UUID) []NeosyncApiAccount); ok {
+		r0 = rf(ctx, db, id)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]NeosyncApiAccount)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX, pgtype.UUID) error); ok {
+		r1 = rf(ctx, db, id)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockQuerier_GetAccountByApiKeyUserId_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetAccountByApiKeyUserId'
+type MockQuerier_GetAccountByApiKeyUserId_Call struct {
+	*mock.Call
+}
+
+// GetAccountByApiKeyUserId is a helper method to define mock.On call
+//   - ctx context.Context
+//   - db DBTX
+//   - id pgtype.UUID
+func (_e *MockQuerier_Expecter) GetAccountByApiKeyUserId(ctx interface{}, db interface{}, id interface{}) *MockQuerier_GetAccountByApiKeyUserId_Call {
+	return &MockQuerier_GetAccountByApiKeyUserId_Call{Call: _e.mock.On("GetAccountByApiKeyUserId", ctx, db, id)}
+}
+
+func (_c *MockQuerier_GetAccountByApiKeyUserId_Call) Run(run func(ctx context.Context, db DBTX, id pgtype.UUID)) *MockQuerier_GetAccountByApiKeyUserId_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(DBTX), args[2].(pgtype.UUID))
+	})
+	return _c
+}
+
+func (_c *MockQuerier_GetAccountByApiKeyUserId_Call) Return(_a0 []NeosyncApiAccount, _a1 error) *MockQuerier_GetAccountByApiKeyUserId_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockQuerier_GetAccountByApiKeyUserId_Call) RunAndReturn(run func(context.Context, DBTX, pgtype.UUID) ([]NeosyncApiAccount, error)) *MockQuerier_GetAccountByApiKeyUserId_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetAccountInvite provides a mock function with given fields: ctx, db, id
 func (_m *MockQuerier) GetAccountInvite(ctx context.Context, db DBTX, id pgtype.UUID) (NeosyncApiAccountInvite, error) {
 	ret := _m.Called(ctx, db, id)

--- a/backend/gen/go/db/users.sql.go
+++ b/backend/gen/go/db/users.sql.go
@@ -281,7 +281,16 @@ func (q *Queries) GetAccountUserAssociation(ctx context.Context, db DBTX, arg Ge
 }
 
 const getAccountsByUser = `-- name: GetAccountsByUser :many
-SELECT a.id, a.created_at, a.updated_at, a.account_type, a.account_slug, a.temporal_config from neosync_api.accounts a
+SELECT a.id, a.created_at, a.updated_at, a.account_type, a.account_slug, a.temporal_config
+FROM neosync_api.accounts a
+INNER JOIN neosync_api.account_api_keys aak ON aak.account_id = a.id
+INNER JOIN neosync_api.users u ON u.id = aak.user_id
+WHERE u.id = $1
+
+UNION
+
+SELECT a.id, a.created_at, a.updated_at, a.account_type, a.account_slug, a.temporal_config
+FROM neosync_api.accounts a
 INNER JOIN neosync_api.account_user_associations aua ON aua.account_id = a.id
 INNER JOIN neosync_api.users u ON u.id = aua.user_id
 WHERE u.id = $1

--- a/backend/sql/postgresql/queries/users.sql
+++ b/backend/sql/postgresql/queries/users.sql
@@ -82,10 +82,20 @@ INSERT INTO neosync_api.accounts (
 RETURNING *;
 
 -- name: GetAccountsByUser :many
-SELECT a.* from neosync_api.accounts a
+SELECT a.*
+FROM neosync_api.accounts a
+INNER JOIN neosync_api.account_api_keys aak ON aak.account_id = a.id
+INNER JOIN neosync_api.users u ON u.id = aak.user_id
+WHERE u.id = $1
+
+UNION
+
+SELECT a.*
+FROM neosync_api.accounts a
 INNER JOIN neosync_api.account_user_associations aua ON aua.account_id = a.id
 INNER JOIN neosync_api.users u ON u.id = aua.user_id
 WHERE u.id = $1;
+
 
 -- name: CreateAccountUserAssociation :one
 INSERT INTO neosync_api.account_user_associations (


### PR DESCRIPTION
Fetching GetUserAccounts with an API key as the auth mechanism will now properly return the account that the API key is associated with.