### PR TITLE
Updates job run status to use unknown instead of archive

### DIFF
--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/components/RecentRuns.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/components/RecentRuns.tsx
@@ -40,17 +40,18 @@ export default function JobRecentRuns({ jobId }: Props): ReactElement {
     isValidating: jobRunsValidating,
   } = useGetJobRunsByJob(account?.id ?? '', jobId);
 
-  const recentRuns = recentRunsData?.recentRuns ?? [];
+  const recentRuns = (recentRunsData?.recentRuns ?? []).toReversed();
+  const jobRunsIdMap = new Map(
+    (jobRunsData?.jobRuns ?? []).map((jr) => [jr.id, jr])
+  );
+
+  if (isLoading || jobRunsLoading) {
+    return <Skeleton className="w-full h-full" />;
+  }
 
   function onRefreshClick(): void {
     recentRunsMutate();
     jobsRunsMutate();
-  }
-
-  const jobRunsIdMap = new Map(jobRunsData?.jobRuns.map((jr) => [jr.id, jr]));
-
-  if (isLoading || jobRunsLoading) {
-    return <Skeleton className="w-full h-full" />;
   }
 
   return (
@@ -86,7 +87,7 @@ export default function JobRecentRuns({ jobId }: Props): ReactElement {
               </TableRow>
             </TableHeader>
             <TableBody>
-              {recentRuns.reverse().map((r) => {
+              {recentRuns.map((r) => {
                 const jobRun = jobRunsIdMap.get(r.jobRunId);
                 return (
                   <TableRow key={r.jobRunId}>

--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/components/RecentRuns.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/components/RecentRuns.tsx
@@ -16,7 +16,6 @@ import {
 import { useGetJobRecentRuns } from '@/libs/hooks/useGetJobRecentRuns';
 import { useGetJobRunsByJob } from '@/libs/hooks/useGetJobRunsByJob';
 import { formatDateTime } from '@/util/util';
-import { JobRun } from '@neosync/sdk';
 import { ArrowRightIcon, ReloadIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
 import { ReactElement } from 'react';
@@ -35,7 +34,7 @@ export default function JobRecentRuns({ jobId }: Props): ReactElement {
     isValidating,
   } = useGetJobRecentRuns(account?.id ?? '', jobId);
   const {
-    data: jobRuns,
+    data: jobRunsData,
     isLoading: jobRunsLoading,
     mutate: jobsRunsMutate,
     isValidating: jobRunsValidating,
@@ -48,13 +47,7 @@ export default function JobRecentRuns({ jobId }: Props): ReactElement {
     jobsRunsMutate();
   }
 
-  const jobRunsIdMap =
-    jobRuns?.jobRuns.reduce(
-      (prev, curr) => {
-        return { ...prev, [curr.id]: curr };
-      },
-      {} as Record<string, JobRun>
-    ) || {};
+  const jobRunsIdMap = new Map(jobRunsData?.jobRuns.map((jr) => [jr.id, jr]));
 
   if (isLoading || jobRunsLoading) {
     return <Skeleton className="w-full h-full" />;
@@ -94,7 +87,7 @@ export default function JobRecentRuns({ jobId }: Props): ReactElement {
             </TableHeader>
             <TableBody>
               {recentRuns.reverse().map((r) => {
-                const jobRun: JobRun | undefined = jobRunsIdMap[r.jobRunId];
+                const jobRun = jobRunsIdMap.get(r.jobRunId);
                 return (
                   <TableRow key={r.jobRunId}>
                     <TableCell className="pl-6">

--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/layout.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/layout.tsx
@@ -11,6 +11,8 @@ import { Alert, AlertTitle } from '@/components/ui/alert';
 import { Button, buttonVariants } from '@/components/ui/button';
 import { toast } from '@/components/ui/use-toast';
 import { useGetJob } from '@/libs/hooks/useGetJob';
+import { useGetJobRecentRuns } from '@/libs/hooks/useGetJobRecentRuns';
+import { useGetJobRunsByJob } from '@/libs/hooks/useGetJobRunsByJob';
 import { useGetJobStatus } from '@/libs/hooks/useGetJobStatus';
 import { cn } from '@/libs/utils';
 import { getErrorMessage } from '@/util/util';
@@ -30,6 +32,14 @@ export default function JobIdLayout({ children, params }: LayoutProps) {
     account?.id ?? '',
     id
   );
+  const { mutate: mutateRecentRuns } = useGetJobRecentRuns(
+    account?.id ?? '',
+    id
+  );
+  const { mutate: mutateJobRunsByJob } = useGetJobRunsByJob(
+    account?.id ?? '',
+    id
+  );
 
   async function onTriggerJobRun(): Promise<void> {
     try {
@@ -38,7 +48,10 @@ export default function JobIdLayout({ children, params }: LayoutProps) {
         title: 'Job run triggered successfully!',
         variant: 'success',
       });
-      router.push(`/${account?.name}/jobs/${id}`);
+      setTimeout(() => {
+        mutateRecentRuns();
+        mutateJobRunsByJob();
+      }, 3000); // delay briefly as there can sometimes be a trigger delay in temporal
     } catch (err) {
       console.error(err);
       toast({

--- a/frontend/apps/web/app/(mgmt)/[account]/runs/components/JobRunStatus.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/runs/components/JobRunStatus.tsx
@@ -52,7 +52,8 @@ export default function JobRunStatus(props: Props): ReactElement {
             </TooltipTrigger>
             <TooltipContent>
               <p>
-                This run has been archived by the system or manually deleted
+                This run is un-started, archived by the system, or has been
+                deleted.
               </p>
             </TooltipContent>
           </Tooltip>

--- a/frontend/apps/web/app/(mgmt)/[account]/runs/components/JobRunStatus.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/runs/components/JobRunStatus.tsx
@@ -1,4 +1,10 @@
 import { Badge } from '@/components/ui/badge';
+import {
+  Tooltip,
+  TooltipContent,
+  TooltipProvider,
+  TooltipTrigger,
+} from '@/components/ui/tooltip';
 import { cn } from '@/libs/utils';
 import { JobRunStatus as JobRunStatusEnum } from '@neosync/sdk';
 import { ReactElement } from 'react';
@@ -10,9 +16,6 @@ interface Props {
 
 export default function JobRunStatus(props: Props): ReactElement {
   const { status, className } = props;
-  if (!status) {
-    return <Badge variant="outline">Unknown</Badge>;
-  }
   switch (status) {
     case JobRunStatusEnum.ERROR:
       return (
@@ -31,16 +34,29 @@ export default function JobRunStatus(props: Props): ReactElement {
     case JobRunStatusEnum.RUNNING:
       return <Badge className={cn('bg-blue-600', className)}>Running</Badge>;
     case JobRunStatusEnum.PENDING:
-      return <Badge className={cn('bg-purple-600', className)}>Running</Badge>;
+      return <Badge className={cn('bg-purple-600', className)}>Pending</Badge>;
     case JobRunStatusEnum.TERMINATED:
       return <Badge className={cn('bg-gray-600', className)}>Terminated</Badge>;
     case JobRunStatusEnum.CANCELED:
       return <Badge className={cn('bg-gray-600', className)}>Canceled</Badge>;
     default:
       return (
-        <Badge variant="outline" className={cn(className)}>
-          Unknown
-        </Badge>
+        <TooltipProvider>
+          <Tooltip delayDuration={500}>
+            <TooltipTrigger asChild>
+              <div>
+                <Badge variant="outline" className={cn(className)}>
+                  Unknown
+                </Badge>
+              </div>
+            </TooltipTrigger>
+            <TooltipContent>
+              <p>
+                This run has been archived by the system or manually deleted
+              </p>
+            </TooltipContent>
+          </Tooltip>
+        </TooltipProvider>
       );
   }
 }


### PR DESCRIPTION
Also changes the recent job run refresh to happen on the trigger button

triggering a job no longer routes you back to the home page and keeps you on the page you were currently on.

adds tooltip to unknown status explaining what it means.