### PR TITLE
adding more tests to generate random string, removes extra max length…

### DIFF
--- a/backend/services/mgmt/v1alpha1/transformers-service/system_transformers.go
+++ b/backend/services/mgmt/v1alpha1/transformers-service/system_transformers.go
@@ -299,7 +299,7 @@ var (
 		},
 		{
 			Name:        "Generate Random String",
-			Description: "Creates a randomly ordered alphanumeric string with a default length of 10 unless the String Length parameter are defined.",
+			Description: "Creates a randomly ordered alphanumeric string between the specified range",
 			DataType:    "string",
 			Source:      string(GenerateString),
 			Config: &mgmtv1alpha1.TransformerConfig{

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/schema.ts
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/schema.ts
@@ -71,6 +71,10 @@ const generateStringConfig = Yup.object().shape({
     }),
   max: Yup.number()
     .min(1, 'The value must be greater than or equal to 1.')
+    .max(
+      Number.MAX_SAFE_INTEGER,
+      `The value must be less than or equal to ${Number.MAX_SAFE_INTEGER}`
+    )
     .required('This field is required.')
     .test(
       'is-greater-than-min',

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
@@ -160,7 +160,7 @@ function handleTransformerForm(
       );
     case 'generate_int64':
       return <GenerateIntForm index={index} setIsSheetOpen={setIsSheetOpen} />;
-    case 'generate_random_string':
+    case 'generate_string':
       return (
         <GenerateStringForm index={index} setIsSheetOpen={setIsSheetOpen} />
       );

--- a/frontend/apps/web/components/jobs/SchemaTable/SchemaColumns.tsx
+++ b/frontend/apps/web/components/jobs/SchemaTable/SchemaColumns.tsx
@@ -340,7 +340,7 @@ arrIncludesSome.autoRemove = (val: any) => testFalsey(val) || !val?.length
 
 *******
 
-This filter function does an exact match to avoid unnecessary values. 
+This filter function does an exact match to avoid unnecessary values.
 */
 // eslint-disable-next-line
 const exactMatchFilterFn: FilterFn<any> = (

--- a/worker/internal/benthos/transformers/generate_random_string.go
+++ b/worker/internal/benthos/transformers/generate_random_string.go
@@ -1,18 +1,14 @@
 package transformers
 
 import (
-	"fmt"
-
 	"github.com/benthosdev/benthos/v4/public/bloblang"
-	_ "github.com/benthosdev/benthos/v4/public/components/io"
 	transformer_utils "github.com/nucleuscloud/neosync/worker/internal/benthos/transformers/utils"
 )
 
 func init() {
 	spec := bloblang.NewPluginSpec().
 		Param(bloblang.NewInt64Param("min")).
-		Param(bloblang.NewInt64Param("max")).
-		Param(bloblang.NewInt64Param("max_length"))
+		Param(bloblang.NewInt64Param("max"))
 
 	err := bloblang.RegisterFunctionV2("generate_string", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		min, err := args.GetInt64("min")
@@ -25,46 +21,12 @@ func init() {
 			return nil, err
 		}
 
-		maxLength, err := args.GetInt64("max_length")
-		if err != nil {
-			return nil, err
-		}
-
 		return func() (any, error) {
-			res, err := GenerateRandomString(min, max, maxLength)
-			return res, err
+			return transformer_utils.GenerateRandomStringWithInclusiveBounds(min, max)
 		}, nil
 	})
 
 	if err != nil {
 		panic(err)
-	}
-}
-
-// generate a random string with length between min and max
-func GenerateRandomString(min, max, maxLength int64) (string, error) {
-	if max > maxLength && min > maxLength {
-		val, err := transformer_utils.GenerateRandomStringWithDefinedLength(maxLength)
-
-		if err != nil {
-			return "", fmt.Errorf("unable to generate a random string with length")
-		}
-
-		return val, nil
-	} else if max > maxLength && min < maxLength {
-		val, err := transformer_utils.GenerateRandomStringWithInclusiveBounds(min, maxLength)
-
-		if err != nil {
-			return "", fmt.Errorf("unable to generate a random string with length")
-		}
-
-		return val, nil
-	} else {
-		val, err := transformer_utils.GenerateRandomStringWithInclusiveBounds(min, max)
-
-		if err != nil {
-			return "", fmt.Errorf("unable to generate a random string with length")
-		}
-		return val, nil
 	}
 }

--- a/worker/internal/benthos/transformers/generate_random_string_test.go
+++ b/worker/internal/benthos/transformers/generate_random_string_test.go
@@ -8,45 +8,11 @@ import (
 	"github.com/stretchr/testify/assert"
 )
 
-func Test_GenerateRandomStringInRange(t *testing.T) {
-	min := int64(2)
-	max := int64(5)
-
-	res, err := GenerateRandomString(min, max, maxCharacterLimit)
-
-	assert.NoError(t, err)
-	assert.GreaterOrEqual(t, int64(len(res)), min, "The output string should be greater than or equal to the min")
-	assert.LessOrEqual(t, int64(len(res)), max, "The output string should be less than or equal to the max")
-}
-
-func Test_GenerateRandomStringInRangeLongMaxAndMin(t *testing.T) {
-	min := int64(23)
-	max := int64(24)
-
-	res, err := GenerateRandomString(min, max, maxCharacterLimit)
-
-	assert.NoError(t, err)
-	assert.LessOrEqual(t, int64(len(res)), min, "The output string should be greater than or equal to the min")
-	assert.LessOrEqual(t, int64(len(res)), max, "The output string should be less than or equal to the max")
-	assert.Equal(t, int64(len(res)), maxCharacterLimit, "The output string should be less than or equal to the max")
-}
-
-func Test_GenerateRandomStringInRangeLongMaxOnly(t *testing.T) {
-	min := int64(4)
-	max := int64(24)
-
-	res, err := GenerateRandomString(min, max, maxCharacterLimit)
-
-	assert.NoError(t, err)
-	assert.GreaterOrEqual(t, int64(len(res)), min, "The output string should be greater than or equal to the min")
-	assert.LessOrEqual(t, int64(len(res)), maxCharacterLimit, "The output string should be less than or equal to the max")
-}
-
 func Test_GenerateRandomStringTransformerWithValue(t *testing.T) {
 	min := int64(2)
 	max := int64(5)
 
-	mapping := fmt.Sprintf(`root = generate_string(min:%d,max:%d,max_length:%d)`, min, max, maxCharacterLimit)
+	mapping := fmt.Sprintf(`root = generate_string(min:%d,max:%d)`, min, max)
 	ex, err := bloblang.Parse(mapping)
 	assert.NoError(t, err, "failed to parse the generate random string transformer")
 

--- a/worker/internal/benthos/transformers/transform_float.go
+++ b/worker/internal/benthos/transformers/transform_float.go
@@ -61,7 +61,7 @@ func TransformFloat(value, rMin, rMax float64) (*float64, error) {
 
 	val, err := transformer_utils.GenerateRandomFloat64WithInclusiveBounds(minRange, maxRange)
 	if err != nil {
-		return nil, fmt.Errorf("unable to generate a random string with length")
+		return nil, fmt.Errorf("unable to generate a random float64 with inclusive bounds with length [%f:%f]: %w", minRange, maxRange, err)
 	}
 
 	return &val, nil

--- a/worker/internal/benthos/transformers/transform_int64.go
+++ b/worker/internal/benthos/transformers/transform_int64.go
@@ -63,8 +63,7 @@ func TransformInt(value, rMin, rMax int64) (*int64, error) {
 
 	val, err := transformer_utils.GenerateRandomInt64InValueRange(minRange, maxRange)
 	if err != nil {
-		return nil, fmt.Errorf("unable to generate a random string with length")
+		return nil, fmt.Errorf("unable to generate a random int64 with length [%d:%d]:%w", minRange, maxRange, err)
 	}
-
 	return &val, nil
 }

--- a/worker/internal/benthos/transformers/transform_string.go
+++ b/worker/internal/benthos/transformers/transform_string.go
@@ -11,7 +11,9 @@ import (
 func init() {
 	spec := bloblang.NewPluginSpec().
 		Param(bloblang.NewAnyParam("value").Optional()).
-		Param(bloblang.NewBoolParam("preserve_length")).Param(bloblang.NewInt64Param("max_length"))
+		Param(bloblang.NewBoolParam("preserve_length")).
+		Param(bloblang.NewInt64Param("min_length")).
+		Param(bloblang.NewInt64Param("max_length"))
 
 	err := bloblang.RegisterFunctionV2("transform_string", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		valuePtr, err := args.GetOptionalString("value")

--- a/worker/internal/benthos/transformers/transform_string.go
+++ b/worker/internal/benthos/transformers/transform_string.go
@@ -58,20 +58,18 @@ func TransformString(value string, preserveLength bool, maxLength int64) (*strin
 		val, err := transformer_utils.GenerateRandomStringWithDefinedLength(l)
 
 		if err != nil {
-			return nil, fmt.Errorf("unable to generate a random string with length")
+			return nil, fmt.Errorf("unable to generate a random string with preserved length: %d: %w", l, err)
 		}
 
 		returnValue = val
 	} else {
+		// todo: this is a bug and we need to read in the min length based on the constraints
 		min := int64(3)
 		val, err := transformer_utils.GenerateRandomStringWithInclusiveBounds(min, maxLength)
-
 		if err != nil {
-			return nil, fmt.Errorf("unable to generate a random string with length")
+			return nil, fmt.Errorf("unable to transform a random string with length: [%d:%d]: %w", min, maxLength, err)
 		}
-
 		returnValue = val
 	}
-
 	return &returnValue, nil
 }

--- a/worker/internal/benthos/transformers/transform_string_test.go
+++ b/worker/internal/benthos/transformers/transform_string_test.go
@@ -59,7 +59,7 @@ func Test_TransformStringTransformer(t *testing.T) {
 
 func Test_TransformStringTransformerWithEmptyValue(t *testing.T) {
 	nilString := ""
-	mapping := fmt.Sprintf(`root = transform_string(value:%q,preserve_length:true,min_length:%dmax_length:%d)`, nilString, 3, maxCharacterLimit)
+	mapping := fmt.Sprintf(`root = transform_string(value:%q,preserve_length:true,min_length:%d,max_length:%d)`, nilString, 3, maxCharacterLimit)
 	ex, err := bloblang.Parse(mapping)
 	assert.NoError(t, err, "failed to parse the email transformer")
 

--- a/worker/internal/benthos/transformers/transform_string_test.go
+++ b/worker/internal/benthos/transformers/transform_string_test.go
@@ -11,14 +11,14 @@ import (
 var testStringValue = "hello"
 
 func Test_TransformStringPreserveLengthTrue(t *testing.T) {
-	res, err := TransformString(testStringValue, true, maxCharacterLimit)
+	res, err := TransformString(testStringValue, true, 3, maxCharacterLimit)
 
 	assert.NoError(t, err)
 	assert.Equal(t, len(testStringValue), len(*res), "The output string should be as long as the input string")
 }
 
 func Test_TransformStringPreserveLengthFalse(t *testing.T) {
-	res, err := TransformString(testStringValue, false, maxCharacterLimit)
+	res, err := TransformString(testStringValue, false, 3, maxCharacterLimit)
 
 	assert.NoError(t, err)
 	assert.GreaterOrEqual(t, len(*res), 3, "The expected value should be greater than or equal to 3")
@@ -26,7 +26,7 @@ func Test_TransformStringPreserveLengthFalse(t *testing.T) {
 }
 
 func Test_TransformStringMaxLength(t *testing.T) {
-	res, err := TransformString(testStringValue, false, maxCharacterLimit)
+	res, err := TransformString(testStringValue, false, 3, maxCharacterLimit)
 
 	assert.NoError(t, err)
 	assert.GreaterOrEqual(t, len(*res), 3, "The expected value should be greater than or equal to 3")
@@ -34,7 +34,7 @@ func Test_TransformStringMaxLength(t *testing.T) {
 }
 
 func Test_TransformStringTransformer(t *testing.T) {
-	mapping := fmt.Sprintf(`root = transform_string(value:%q,preserve_length:true,max_length:%d)`, testStringValue, maxCharacterLimit)
+	mapping := fmt.Sprintf(`root = transform_string(value:%q,preserve_length:true,min_length:%d,max_length:%d)`, testStringValue, 3, maxCharacterLimit)
 	ex, err := bloblang.Parse(mapping)
 	assert.NoError(t, err, "failed to parse the random string transformer")
 
@@ -59,7 +59,7 @@ func Test_TransformStringTransformer(t *testing.T) {
 
 func Test_TransformStringTransformerWithEmptyValue(t *testing.T) {
 	nilString := ""
-	mapping := fmt.Sprintf(`root = transform_string(value:%q,preserve_length:true,max_length:%d)`, nilString, maxCharacterLimit)
+	mapping := fmt.Sprintf(`root = transform_string(value:%q,preserve_length:true,min_length:%dmax_length:%d)`, nilString, 3, maxCharacterLimit)
 	ex, err := bloblang.Parse(mapping)
 	assert.NoError(t, err, "failed to parse the email transformer")
 

--- a/worker/internal/benthos/transformers/utils/integer_utils.go
+++ b/worker/internal/benthos/transformers/utils/integer_utils.go
@@ -63,7 +63,6 @@ func GenerateRandomInt64InValueRange(min, max int64) (int64, error) {
 	}
 
 	rangeVal := max - min + 1
-
 	//nolint:gosec
 	return min + rand.Int63n(rangeVal), nil
 }

--- a/worker/internal/benthos/transformers/utils/integer_utils_test.go
+++ b/worker/internal/benthos/transformers/utils/integer_utils_test.go
@@ -1,6 +1,7 @@
 package transformer_utils
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -40,41 +41,40 @@ func Test_GenerateRandomInt64InLengthRangeError(t *testing.T) {
 	assert.Error(t, err, "The int length is greater than 19 and too long")
 }
 
-func Test_GenerateRandomInt64WithInclusiveBoundsMinEqualMax(t *testing.T) {
-	v1 := int64(5)
-	v2 := int64(5)
-	val, err := GenerateRandomInt64InValueRange(v1, v2)
-	assert.NoError(t, err, "Did not expect an error when min == max")
-	assert.Equal(t, v1, val, "actual value to be equal to min/max")
+func Test_GenerateRandomInt64InValueRange(t *testing.T) {
+	type testcase struct {
+		min int64
+		max int64
+	}
+	testcases := []testcase{
+		{min: int64(2), max: int64(5)},
+		{min: int64(23), max: int64(24)},
+		{min: int64(4), max: int64(24)},
+		{min: int64(2), max: int64(2)},
+		{min: int64(2), max: int64(4)},
+		{min: int64(1), max: int64(1)},
+		{min: int64(0), max: int64(0)},
+		{min: int64(-9), max: int64(-2)},
+		{min: int64(-2), max: int64(9)},
+	}
+	for _, tc := range testcases {
+		name := fmt.Sprintf("%s_%d_%d", t.Name(), tc.min, tc.max)
+		t.Run(name, func(t *testing.T) {
+			output, err := GenerateRandomInt64InValueRange(tc.min, tc.max)
+			assert.NoError(t, err)
+			assert.GreaterOrEqual(t, output, tc.min, "%d>=%d was not true. output should be greater than or equal to the min. output: %s", output, tc.min, output)
+			assert.LessOrEqual(t, output, tc.max, "%d<=%d was not true. output should be less than or equal to the max. output: %s", output, tc.max, output)
+		})
+	}
 }
 
-func Test_GenerateRandomInt64WithInclusiveBoundsPositive(t *testing.T) {
-	v1 := int64(2)
-	v2 := int64(9)
-
-	val, err := GenerateRandomInt64InValueRange(v1, v2)
-	assert.NoError(t, err, "Did not expect an error for valid range")
-	assert.True(t, val >= v1 && val <= v2, "actual value to be within the range")
-}
-
-func Test_GenerateRandomInt64WithInclusiveBoundsNegative(t *testing.T) {
-	v1 := int64(-2)
-	v2 := int64(-9)
-
-	val, err := GenerateRandomInt64InValueRange(v1, v2)
-
-	assert.NoError(t, err, "Did not expect an error for valid range")
-	assert.True(t, val <= v1 && val >= v2, "actual value to be within the range")
-}
-
-func Test_GenerateRandomInt64WithInclusiveBoundsNegativeToPositive(t *testing.T) {
-	v1 := int64(-2)
-	v2 := int64(9)
-
-	val, err := GenerateRandomInt64InValueRange(v1, v2)
-
-	assert.NoError(t, err, "Did not expect an error for valid range")
-	assert.True(t, val >= v1 && val <= v2, "actual value to be within the range")
+func Test_GenerateRandomInt64InValueRange_Swapped_MinMax(t *testing.T) {
+	min := int64(2)
+	max := int64(1)
+	output, err := GenerateRandomInt64InValueRange(min, max)
+	assert.NoError(t, err)
+	assert.GreaterOrEqual(t, output, max)
+	assert.LessOrEqual(t, output, min)
 }
 
 func Test_FirstDigitIsNineTrue(t *testing.T) {

--- a/worker/internal/benthos/transformers/utils/string_utils.go
+++ b/worker/internal/benthos/transformers/utils/string_utils.go
@@ -54,29 +54,23 @@ func GenerateRandomStringWithInclusiveBounds(min, max int64) (string, error) {
 	}
 
 	var length int64
-
 	if min == max {
 		length = min
 	} else {
 		randlength, err := GenerateRandomInt64InValueRange(min, max)
 		if err != nil {
-			return "", fmt.Errorf("unable to generate a random length for the string")
+			return "", fmt.Errorf("unable to generate a random length for the string within range [%d:%d]: %w", min, max, err)
 		}
-
 		length = randlength
 	}
 
 	result := make([]byte, length)
-
 	for i := int64(0); i < length; i++ {
 		// Generate a random index in the range [0, len(alphabet))
-		//nolint:all
-		index := rand.Intn(len(alphanumeric))
-
+		index := rand.Intn(len(alphanumeric)) //nolint:gosec
 		// Get the character at the generated index and append it to the result
 		result[i] = alphanumeric[index]
 	}
-
 	return strings.ToLower(string(result)), nil
 }
 

--- a/worker/internal/benthos/transformers/utils/string_utils_test.go
+++ b/worker/internal/benthos/transformers/utils/string_utils_test.go
@@ -1,6 +1,7 @@
 package transformer_utils
 
 import (
+	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -41,23 +42,30 @@ func Test_SliceStringValidSlice(t *testing.T) {
 	assert.Equal(t, expected, res, "Expected result to be a substring of the input string with the specified length")
 }
 
-func Test_GenerateRandomStringEqualMinMax(t *testing.T) {
-	min := int64(4)
-	max := int64(4)
-	res, err := GenerateRandomStringWithInclusiveBounds(min, max)
-
-	assert.NoError(t, err)
-	assert.Equal(t, int64(len(res)), min, "The output string should be as long as the min or max since they're equal")
-}
-
-func Test_GenerateRandomStringRange(t *testing.T) {
-	min := int64(2)
-	max := int64(4)
-
-	res, err := GenerateRandomStringWithInclusiveBounds(min, max)
-	assert.NoError(t, err)
-	assert.GreaterOrEqual(t, int64(len(res)), min, "the string should be greater than or equal to the min value")
-	assert.LessOrEqual(t, int64(len(res)), max, "the string should be less than or equal to the max value")
+func Test_GenerateRandomStringBounds(t *testing.T) {
+	type testcase struct {
+		min int64
+		max int64
+	}
+	testcases := []testcase{
+		{min: int64(2), max: int64(5)},
+		{min: int64(23), max: int64(24)},
+		{min: int64(4), max: int64(24)},
+		{min: int64(2), max: int64(2)},
+		{min: int64(2), max: int64(4)},
+		{min: int64(1), max: int64(1)},
+		{min: int64(0), max: int64(0)},
+	}
+	for _, tc := range testcases {
+		name := fmt.Sprintf("%s_%d_%d", t.Name(), tc.min, tc.max)
+		t.Run(name, func(t *testing.T) {
+			output, err := GenerateRandomStringWithInclusiveBounds(tc.min, tc.max)
+			assert.NoError(t, err)
+			length := int64(len(output))
+			assert.GreaterOrEqual(t, length, tc.min, "%d>=%d was not true. output should be greater than or equal to the min. output: %s", length, tc.min, output)
+			assert.LessOrEqual(t, length, tc.max, "%d<=%d was not true. output should be less than or equal to the max. output: %s", length, tc.max, output)
+		})
+	}
 }
 
 func Test_GenerateRandomStringError(t *testing.T) {

--- a/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder.go
+++ b/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder.go
@@ -1638,6 +1638,7 @@ func computeMutationFunction(col *mgmtv1alpha1.JobMapping, colInfo *dbschemas_ut
 		min := col.Transformer.Config.GetGenerateStringConfig().Min
 		max := col.Transformer.Config.GetGenerateStringConfig().Max
 		max = computeMinInt(max, maxLen)
+		// todo: we need to pull in the min from the database schema
 		return fmt.Sprintf(`generate_string(min:%d,max:%d)`, min, max), nil
 	case "generate_unixtimestamp":
 		return "generate_unixtimestamp()", nil
@@ -1678,7 +1679,8 @@ func computeMutationFunction(col *mgmtv1alpha1.JobMapping, colInfo *dbschemas_ut
 		return fmt.Sprintf("transform_phone_number(value:this.%q,preserve_length:%t,max_length:%d)", col.Column, pl, maxLen), nil
 	case "transform_string":
 		pl := col.Transformer.Config.GetTransformStringConfig().PreserveLength
-		return fmt.Sprintf(`transform_string(value:this.%q,preserve_length:%t,max_length:%d)`, col.Column, pl, maxLen), nil
+		minLength := int64(3) // todo: we need to pull in this value from the database schema
+		return fmt.Sprintf(`transform_string(value:this.%q,preserve_length:%t,min_length:%d,max_length:%d)`, col.Column, pl, minLength, maxLen), nil
 	case shared.NullString:
 		return shared.NullString, nil
 	case generateDefault:

--- a/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder.go
+++ b/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder.go
@@ -1637,6 +1637,7 @@ func computeMutationFunction(col *mgmtv1alpha1.JobMapping, colInfo *dbschemas_ut
 	case "generate_string":
 		min := col.Transformer.Config.GetGenerateStringConfig().Min
 		max := col.Transformer.Config.GetGenerateStringConfig().Max
+		min = computeMinInt(min, maxLen) // ensure the min is not larger than the max allowed length
 		max = computeMinInt(max, maxLen)
 		// todo: we need to pull in the min from the database schema
 		return fmt.Sprintf(`generate_string(min:%d,max:%d)`, min, max), nil
@@ -1702,6 +1703,13 @@ func computeMutationFunction(col *mgmtv1alpha1.JobMapping, colInfo *dbschemas_ut
 
 func computeMinInt[T int | int64 | int32](a, b T) T {
 	if a < b {
+		return a
+	}
+	return b
+}
+
+func computeMaxInt[T int | int64 | int32](a, b T) T {
+	if a > b {
 		return a
 	}
 	return b

--- a/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder_test.go
+++ b/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder_test.go
@@ -5286,3 +5286,11 @@ func Test_buildBranchCacheConfigs_self_referencing(t *testing.T) {
 	assert.NoError(t, err)
 	assert.Len(t, resp, 0)
 }
+
+func Test_computeMinInt(t *testing.T) {
+	assert.Equal(t, 1, computeMinInt(1, 2))
+	assert.Equal(t, 1, computeMinInt(2, 1))
+	assert.Equal(t, 1, computeMinInt(1, 1))
+	assert.Equal(t, -1, computeMinInt(-1, 1))
+	assert.Equal(t, -1, computeMinInt(1, -1))
+}

--- a/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder_test.go
+++ b/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder_test.go
@@ -5294,3 +5294,11 @@ func Test_computeMinInt(t *testing.T) {
 	assert.Equal(t, -1, computeMinInt(-1, 1))
 	assert.Equal(t, -1, computeMinInt(1, -1))
 }
+
+func Test_computeMaxInt(t *testing.T) {
+	assert.Equal(t, 2, computeMaxInt(1, 2))
+	assert.Equal(t, 2, computeMaxInt(2, 1))
+	assert.Equal(t, 1, computeMaxInt(1, 1))
+	assert.Equal(t, 1, computeMaxInt(-1, 1))
+	assert.Equal(t, 1, computeMaxInt(1, -1))
+}


### PR DESCRIPTION
Updating this PR mostly to remove the duplicate and incorrect error strings.
Seeing a lot of this error in datadog but it's unclear where it is coming from due to this:
![image](https://github.com/nucleuscloud/neosync/assets/2420177/9d1b0adc-56e5-4919-8071-41a07c61bacb)

Also took the opportunity to update some of the string transformers along the way.

This PR also fixes the generate string form on the frontend as it was not rendering correctly.