### PR TITLE
Adds fix for character max length check

### DIFF
--- a/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder.go
+++ b/worker/pkg/workflows/datasync/activities/gen-benthos-configs/benthos-builder.go
@@ -1565,7 +1565,7 @@ root.{destination_col} = transformerfunction(args)
 
 func computeMutationFunction(col *mgmtv1alpha1.JobMapping, colInfo *dbschemas_utils.ColumnInfo) (string, error) {
 	var maxLen int64 = 10000
-	if colInfo != nil && colInfo.CharacterMaximumLength != nil {
+	if colInfo != nil && colInfo.CharacterMaximumLength != nil && *colInfo.CharacterMaximumLength > 0 {
 		maxLen = int64(*colInfo.CharacterMaximumLength)
 	}
 


### PR DESCRIPTION
If there is no max length, it defaults to -1, which was bugging out the min/max length constraint checks