### PR TITLE
updates dual list box header search and sort states

### DIFF
--- a/frontend/apps/web/components/DualListBox/ColumnHeader.tsx
+++ b/frontend/apps/web/components/DualListBox/ColumnHeader.tsx
@@ -1,10 +1,3 @@
-import { Button } from '@/components/ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuTrigger,
-} from '@/components/ui/dropdown-menu';
 import { Input } from '@/components/ui/input';
 import { cn } from '@/libs/utils';
 import {
@@ -13,6 +6,7 @@ import {
   CaretSortIcon,
 } from '@radix-ui/react-icons';
 import { Column } from '@tanstack/react-table';
+import { Button } from '../ui/button';
 interface DataTableColumnHeaderProps<TData, TValue>
   extends React.HTMLAttributes<HTMLDivElement> {
   column: Column<TData, TValue>;
@@ -24,46 +18,43 @@ export default function ColumnHeader<TData, TValue>({
   title,
   className,
 }: DataTableColumnHeaderProps<TData, TValue>) {
-  if (!column.getCanSort()) {
-    return <span className={cn(className, 'text-xs')}>{title}</span>;
-  }
   return (
-    <div className={cn('flex items-center space-x-2', className)}>
-      <DropdownMenu>
-        <DropdownMenuTrigger asChild>
-          <Button
-            variant="ghost"
-            size="sm"
-            className="-ml-3 data-[state=open]:bg-accent hover:border hover:border-gray-400 text-nowrap"
-          >
-            <span>{title}</span>
-            {column.getIsSorted() === 'desc' ? (
-              <ArrowDownIcon className="ml-2 h-4 w-4" />
-            ) : column.getIsSorted() === 'asc' ? (
-              <ArrowUpIcon className="ml-2 h-4 w-4" />
-            ) : (
-              <CaretSortIcon className="ml-2 h-4 w-4" />
-            )}
-          </Button>
-        </DropdownMenuTrigger>
-        <DropdownMenuContent align="start">
+    <div className="flex flex-row gap-2 items-center">
+      {column.getCanFilter() && (
+        <div>
           <Input
             type="text"
             value={(column.getFilterValue() ?? '') as string}
             onChange={(e) => column.setFilterValue(e.target.value)}
             placeholder={`Search...`}
-            className="w-36 border rounded"
+            className="border border-gray-400 rounded bg-transparent"
           />
-          <DropdownMenuItem onClick={() => column.toggleSorting(false)}>
-            <ArrowUpIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
-            Asc
-          </DropdownMenuItem>
-          <DropdownMenuItem onClick={() => column.toggleSorting(true)}>
-            <ArrowDownIcon className="mr-2 h-3.5 w-3.5 text-muted-foreground/70" />
-            Desc
-          </DropdownMenuItem>
-        </DropdownMenuContent>
-      </DropdownMenu>
+        </div>
+      )}
+      {!column.getCanFilter() && (
+        <span className={cn(className, 'text-xs')}>{title}</span>
+      )}
+      {column.getCanSort() && (
+        <div>
+          <Button
+            type="button"
+            onClick={() => {
+              const sorted = column.getIsSorted();
+              column.toggleSorting(sorted ? sorted === 'asc' : false);
+            }}
+            variant="ghost"
+            className="px-1"
+          >
+            {column.getIsSorted() === 'desc' ? (
+              <ArrowDownIcon className="h-4 w-4" />
+            ) : column.getIsSorted() === 'asc' ? (
+              <ArrowUpIcon className="h-4 w-4" />
+            ) : (
+              <CaretSortIcon className="h-4 w-4" />
+            )}
+          </Button>
+        </div>
+      )}
     </div>
   );
 }


### PR DESCRIPTION
![image](https://github.com/nucleuscloud/neosync/assets/2420177/f53c97a2-680f-4650-88de-752fc488dc4b)

gets rid of the popup menu in favor of it all just being inline for faster searching,filtering and less pops ups to click away