### PR TITLE
Nick/neos 1042 disable init table schema for generate jobs if fk connection

### DIFF
--- a/backend/gen/go/db/jobs.sql.go
+++ b/backend/gen/go/db/jobs.sql.go
@@ -193,6 +193,7 @@ const getJobConnectionDestinations = `-- name: GetJobConnectionDestinations :man
 SELECT jdca.id, jdca.created_at, jdca.updated_at, jdca.job_id, jdca.connection_id, jdca.options from neosync_api.job_destination_connection_associations jdca
 INNER JOIN neosync_api.jobs j ON j.id = jdca.job_id
 WHERE j.id = $1
+ORDER BY jdca.created_at
 `
 
 func (q *Queries) GetJobConnectionDestinations(ctx context.Context, db DBTX, id pgtype.UUID) ([]NeosyncApiJobDestinationConnectionAssociation, error) {
@@ -226,6 +227,7 @@ const getJobConnectionDestinationsByJobIds = `-- name: GetJobConnectionDestinati
 SELECT jdca.id, jdca.created_at, jdca.updated_at, jdca.job_id, jdca.connection_id, jdca.options from neosync_api.job_destination_connection_associations jdca
 INNER JOIN neosync_api.jobs j ON j.id = jdca.job_id
 WHERE j.id = ANY($1::uuid[])
+ORDER BY j.created_at, jdca.created_at
 `
 
 func (q *Queries) GetJobConnectionDestinationsByJobIds(ctx context.Context, db DBTX, jobids []pgtype.UUID) ([]NeosyncApiJobDestinationConnectionAssociation, error) {

--- a/backend/sql/postgresql/queries/jobs.sql
+++ b/backend/sql/postgresql/queries/jobs.sql
@@ -91,12 +91,14 @@ WHERE jdca.id = $1;
 -- name: GetJobConnectionDestinations :many
 SELECT jdca.* from neosync_api.job_destination_connection_associations jdca
 INNER JOIN neosync_api.jobs j ON j.id = jdca.job_id
-WHERE j.id = $1;
+WHERE j.id = $1
+ORDER BY jdca.created_at;
 
 -- name: GetJobConnectionDestinationsByJobIds :many
 SELECT jdca.* from neosync_api.job_destination_connection_associations jdca
 INNER JOIN neosync_api.jobs j ON j.id = jdca.job_id
-WHERE j.id = ANY(sqlc.arg('jobIds')::uuid[]);
+WHERE j.id = ANY(sqlc.arg('jobIds')::uuid[])
+ORDER BY j.created_at, jdca.created_at;
 
 -- name: RemoveJobConnectionDestinations :exec
 DELETE FROM neosync_api.job_destination_connection_associations

--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/destinations/components/DestinationConnectionCard.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/destinations/components/DestinationConnectionCard.tsx
@@ -33,7 +33,7 @@ import {
   UpdateJobDestinationConnectionResponse,
 } from '@neosync/sdk';
 import { ReactElement } from 'react';
-import { useForm } from 'react-hook-form';
+import { Control, useForm, useWatch } from 'react-hook-form';
 import * as Yup from 'yup';
 
 const FORM_SCHEMA = DESTINATION_FORM_SCHEMA;
@@ -41,6 +41,7 @@ type FormValues = Yup.InferType<typeof FORM_SCHEMA>;
 
 interface Props {
   jobId: string;
+  jobSourceId: string;
   destination: JobDestination;
   connections: Connection[];
   availableConnections: Connection[];
@@ -55,6 +56,7 @@ export default function DestinationConnectionCard({
   availableConnections,
   mutate,
   isDeleteDisabled,
+  jobSourceId,
 }: Props): ReactElement {
   const { toast } = useToast();
   const { account } = useAccount();
@@ -111,6 +113,10 @@ export default function DestinationConnectionCard({
     (item) => item.id === destination.connectionId
   );
   const destOpts = form.watch('destinationOptions');
+  const shouldHideInitTableSchema = useShouldHideInitConnectionSchema(
+    form.control,
+    jobSourceId
+  );
   return (
     <Card>
       <Form {...form}>
@@ -192,6 +198,7 @@ export default function DestinationConnectionCard({
                     }
                   );
                 }}
+                hideInitTableSchema={shouldHideInitTableSchema}
               />
             </div>
           </CardContent>
@@ -296,4 +303,15 @@ function getDefaultValues(d: JobDestination): FormValues {
         destinationOptions: {},
       };
   }
+}
+
+function useShouldHideInitConnectionSchema(
+  control: Control<FormValues>,
+  sourceId: string
+): boolean {
+  const [destinationConnectionid] = useWatch({
+    control,
+    name: ['connectionId'],
+  });
+  return destinationConnectionid === sourceId;
 }

--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/destinations/components/DestinationConnectionCard.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/destinations/components/DestinationConnectionCard.tsx
@@ -110,6 +110,7 @@ export default function DestinationConnectionCard({
   const dest = availableConnections.find(
     (item) => item.id === destination.connectionId
   );
+  const destOpts = form.watch('destinationOptions');
   return (
     <Card>
       <Form {...form}>
@@ -125,12 +126,20 @@ export default function DestinationConnectionCard({
                       <Select
                         onValueChange={(value: string) => {
                           field.onChange(value);
-                          form.setValue(`destinationOptions`, {
-                            truncateBeforeInsert: false,
-                            truncateCascade: false,
-                            initTableSchema: false,
-                            onConflictDoNothing: false,
-                          });
+                          form.setValue(
+                            `destinationOptions`,
+                            {
+                              truncateBeforeInsert: false,
+                              truncateCascade: false,
+                              initTableSchema: false,
+                              onConflictDoNothing: false,
+                            },
+                            {
+                              shouldDirty: true,
+                              shouldTouch: true,
+                              shouldValidate: true,
+                            }
+                          );
                         }}
                         value={field.value}
                       >
@@ -161,6 +170,28 @@ export default function DestinationConnectionCard({
                 connection={connections.find(
                   (c) => c.id === form.getValues().connectionId
                 )}
+                value={{
+                  initTableSchema: destOpts.initTableSchema ?? false,
+                  onConflictDoNothing: destOpts.onConflictDoNothing ?? false,
+                  truncateBeforeInsert: destOpts.truncateBeforeInsert ?? false,
+                  truncateCascade: destOpts.truncateCascade ?? false,
+                }}
+                setValue={(newOpts) => {
+                  form.setValue(
+                    'destinationOptions',
+                    {
+                      initTableSchema: newOpts.initTableSchema,
+                      onConflictDoNothing: newOpts.onConflictDoNothing,
+                      truncateBeforeInsert: newOpts.truncateBeforeInsert,
+                      truncateCascade: newOpts.truncateCascade,
+                    },
+                    {
+                      shouldDirty: true,
+                      shouldTouch: true,
+                      shouldValidate: true,
+                    }
+                  );
+                }}
               />
             </div>
           </CardContent>

--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/destinations/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/destinations/page.tsx
@@ -51,6 +51,13 @@ export default function Page({ params }: PageProps): ReactElement {
             return (
               <DestinationConnectionCard
                 key={destination.id}
+                jobSourceId={
+                  fkConnectionId
+                    ? fkConnectionId
+                    : sourceConnectionId
+                      ? sourceConnectionId
+                      : ''
+                }
                 jobId={id}
                 destination={destination}
                 mutate={mutate}

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/[id]/destination/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/[id]/destination/page.tsx
@@ -122,6 +122,9 @@ export default function Page({ params }: PageProps): ReactElement {
           <form onSubmit={form.handleSubmit(onSubmit)}>
             <div className="space-y-12">
               {fields.map((_, index) => {
+                const destOpts = form.watch(
+                  `destinations.${index}.destinationOptions`
+                );
                 return (
                   <div key={index} className="space-y-4">
                     <div className="flex flex-row space-x-8">
@@ -192,8 +195,31 @@ export default function Page({ params }: PageProps): ReactElement {
                     </div>
 
                     <DestinationOptionsForm
-                      index={index}
                       connection={currConnection}
+                      value={{
+                        initTableSchema: destOpts.initTableSchema ?? false,
+                        onConflictDoNothing:
+                          destOpts.onConflictDoNothing ?? false,
+                        truncateBeforeInsert:
+                          destOpts.truncateBeforeInsert ?? false,
+                        truncateCascade: destOpts.truncateCascade ?? false,
+                      }}
+                      setValue={(newOpts) => {
+                        form.setValue(
+                          `destinations.${index}.destinationOptions`,
+                          {
+                            initTableSchema: newOpts.initTableSchema,
+                            onConflictDoNothing: newOpts.onConflictDoNothing,
+                            truncateBeforeInsert: newOpts.truncateBeforeInsert,
+                            truncateCascade: newOpts.truncateCascade,
+                          },
+                          {
+                            shouldDirty: true,
+                            shouldTouch: true,
+                            shouldValidate: true,
+                          }
+                        );
+                      }}
                     />
                   </div>
                 );

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/aigenerate/single/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/aigenerate/single/connect/page.tsx
@@ -28,7 +28,7 @@ import { yupResolver } from '@hookform/resolvers/yup';
 import { ConnectionConfig } from '@neosync/sdk';
 import { useRouter } from 'next/navigation';
 import { ReactElement, useEffect } from 'react';
-import { useForm } from 'react-hook-form';
+import { Control, useForm, useWatch } from 'react-hook-form';
 import useFormPersist from 'react-hook-form-persist';
 import { useSessionStorage } from 'usehooks-ts';
 import JobsProgressSteps, {
@@ -62,7 +62,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
     }
   );
 
-  const form = useForm({
+  const form = useForm<SingleTableAiConnectFormValues>({
     resolver: yupResolver<SingleTableAiConnectFormValues>(
       SingleTableAiConnectFormValues
     ),
@@ -87,6 +87,9 @@ export default function Page({ searchParams }: PageProps): ReactElement {
   const { mysql, postgres, openai } = splitConnections(connections);
 
   const destOpts = form.watch('destination.destinationOptions');
+  const shouldHideInitTableSchema = useShouldHideInitConnectionSchema(
+    form.control
+  );
 
   return (
     <div
@@ -336,6 +339,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                               initTableSchema: false,
                               truncateBeforeInsert: false,
                               truncateCascade: false,
+                              onConflictDoNothing: false,
                             });
                           }}
                           value={field.value}
@@ -362,6 +366,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 connection={connections.find(
                   (c) => c.id === form.getValues().destination.connectionId
                 )}
+                hideInitTableSchema={shouldHideInitTableSchema}
                 value={{
                   initTableSchema: destOpts.initTableSchema ?? false,
                   onConflictDoNothing: destOpts.onConflictDoNothing ?? false,
@@ -410,4 +415,14 @@ export default function Page({ searchParams }: PageProps): ReactElement {
       </Form>
     </div>
   );
+}
+
+function useShouldHideInitConnectionSchema(
+  control: Control<SingleTableAiConnectFormValues>
+): boolean {
+  const [destinationConnectionid, fkSourceConnectionId] = useWatch({
+    control,
+    name: ['destination.connectionId', 'fkSourceConnectionId'],
+  });
+  return destinationConnectionid === fkSourceConnectionId;
 }

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/aigenerate/single/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/aigenerate/single/connect/page.tsx
@@ -86,6 +86,8 @@ export default function Page({ searchParams }: PageProps): ReactElement {
 
   const { mysql, postgres, openai } = splitConnections(connections);
 
+  const destOpts = form.watch('destination.destinationOptions');
+
   return (
     <div
       id="newjobflowcontainer"
@@ -360,6 +362,28 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 connection={connections.find(
                   (c) => c.id === form.getValues().destination.connectionId
                 )}
+                value={{
+                  initTableSchema: destOpts.initTableSchema ?? false,
+                  onConflictDoNothing: destOpts.onConflictDoNothing ?? false,
+                  truncateBeforeInsert: destOpts.truncateBeforeInsert ?? false,
+                  truncateCascade: destOpts.truncateCascade ?? false,
+                }}
+                setValue={(newOpts) => {
+                  form.setValue(
+                    'destination.destinationOptions',
+                    {
+                      initTableSchema: newOpts.initTableSchema,
+                      onConflictDoNothing: newOpts.onConflictDoNothing,
+                      truncateBeforeInsert: newOpts.truncateBeforeInsert,
+                      truncateCascade: newOpts.truncateCascade,
+                    },
+                    {
+                      shouldDirty: true,
+                      shouldTouch: true,
+                      shouldValidate: true,
+                    }
+                  );
+                }}
               />
             </div>
           </div>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/connect/page.tsx
@@ -239,6 +239,9 @@ export default function Page({ searchParams }: PageProps): ReactElement {
             </div>
             <div className="space-y-12 col-span-2">
               {fields.map((val, index) => {
+                const destOpts = form.watch(
+                  `destinations.${index}.destinationOptions`
+                );
                 return (
                   <div className="space-y-4 col-span-2" key={val.id}>
                     <div className="flex flew-row space-x-4">
@@ -358,12 +361,35 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                       </div>
                     </div>
                     <DestinationOptionsForm
-                      index={index}
                       connection={connections.find(
                         (c) =>
                           c.id ==
                           form.getValues().destinations[index].connectionId
                       )}
+                      value={{
+                        initTableSchema: destOpts.initTableSchema ?? false,
+                        onConflictDoNothing:
+                          destOpts.onConflictDoNothing ?? false,
+                        truncateBeforeInsert:
+                          destOpts.truncateBeforeInsert ?? false,
+                        truncateCascade: destOpts.truncateCascade ?? false,
+                      }}
+                      setValue={(newOpts) => {
+                        form.setValue(
+                          `destinations.${index}.destinationOptions`,
+                          {
+                            initTableSchema: newOpts.initTableSchema,
+                            onConflictDoNothing: newOpts.onConflictDoNothing,
+                            truncateBeforeInsert: newOpts.truncateBeforeInsert,
+                            truncateCascade: newOpts.truncateCascade,
+                          },
+                          {
+                            shouldDirty: true,
+                            shouldTouch: true,
+                            shouldValidate: true,
+                          }
+                        );
+                      }}
                     />
                   </div>
                 );

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/connect/page.tsx
@@ -92,6 +92,8 @@ export default function Page({ searchParams }: PageProps): ReactElement {
     (c) => c.connectionConfig?.config.case === 'pgConfig'
   );
 
+  const destOpts = form.watch('destinationOptions');
+
   return (
     <div
       id="newjobflowcontainer"
@@ -219,6 +221,28 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 connection={connections.find(
                   (c) => c.id === form.getValues().connectionId
                 )}
+                value={{
+                  initTableSchema: destOpts.initTableSchema ?? false,
+                  onConflictDoNothing: destOpts.onConflictDoNothing ?? false,
+                  truncateBeforeInsert: destOpts.truncateBeforeInsert ?? false,
+                  truncateCascade: destOpts.truncateCascade ?? false,
+                }}
+                setValue={(newOpts) => {
+                  form.setValue(
+                    'destinationOptions',
+                    {
+                      initTableSchema: newOpts.initTableSchema,
+                      onConflictDoNothing: newOpts.onConflictDoNothing,
+                      truncateBeforeInsert: newOpts.truncateBeforeInsert,
+                      truncateCascade: newOpts.truncateCascade,
+                    },
+                    {
+                      shouldDirty: true,
+                      shouldTouch: true,
+                      shouldValidate: true,
+                    }
+                  );
+                }}
               />
             </div>
           </div>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/connect/page.tsx
@@ -221,6 +221,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 connection={connections.find(
                   (c) => c.id === form.getValues().connectionId
                 )}
+                hideInitTableSchema={true} // true until NEOS-1043
                 value={{
                   initTableSchema: destOpts.initTableSchema ?? false,
                   onConflictDoNothing: destOpts.onConflictDoNothing ?? false,

--- a/frontend/apps/web/components/jobs/Form/DestinationOptionsForm.tsx
+++ b/frontend/apps/web/components/jobs/Form/DestinationOptionsForm.tsx
@@ -4,7 +4,7 @@ import { Badge } from '@/components/ui/badge';
 import { Connection } from '@neosync/sdk';
 import { ReactElement } from 'react';
 
-export interface DestinationOptions {
+interface DestinationOptions {
   truncateBeforeInsert: boolean;
   truncateCascade: boolean;
   initTableSchema: boolean;

--- a/frontend/apps/web/components/jobs/Form/DestinationOptionsForm.tsx
+++ b/frontend/apps/web/components/jobs/Form/DestinationOptionsForm.tsx
@@ -1,24 +1,26 @@
 'use client';
 import SwitchCard from '@/components/switches/SwitchCard';
-import {
-  FormControl,
-  FormField,
-  FormItem,
-  FormMessage,
-} from '@/components/ui/form';
 import { Connection } from '@neosync/sdk';
 import { ReactElement } from 'react';
-import { useFormContext } from 'react-hook-form';
+
+export interface DestinationOptions {
+  truncateBeforeInsert: boolean;
+  truncateCascade: boolean;
+  initTableSchema: boolean;
+  onConflictDoNothing: boolean;
+}
 
 interface DestinationOptionsProps {
   connection?: Connection;
-  index?: number;
+
+  value: DestinationOptions;
+  setValue(newVal: DestinationOptions): void;
 }
+
 export default function DestinationOptionsForm(
   props: DestinationOptionsProps
 ): ReactElement {
-  const { connection, index } = props;
-  const formCtx = useFormContext();
+  const { connection, value, setValue } = props;
 
   if (!connection) {
     return <></>;
@@ -26,186 +28,96 @@ export default function DestinationOptionsForm(
 
   switch (connection?.connectionConfig?.config?.case) {
     case 'pgConfig':
-      const truncateBeforeInsertName =
-        index != null
-          ? `destinations.${index}.destinationOptions.truncateBeforeInsert`
-          : `destinationOptions.truncateBeforeInsert`;
-      const truncateCascadeName =
-        index != null
-          ? `destinations.${index}.destinationOptions.truncateCascade`
-          : `destinationOptions.truncateCascade`;
       return (
         <div className="flex flex-col gap-2">
           <div>
-            <FormField
-              name={truncateBeforeInsertName}
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <SwitchCard
-                      isChecked={field.value || false}
-                      onCheckedChange={(newVal) => {
-                        field.onChange(newVal);
-                        if (!newVal) {
-                          formCtx.setValue(truncateCascadeName, false);
-                        }
-                      }}
-                      title="Truncate Before Insert"
-                      description="Truncates table before inserting data"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+            <SwitchCard
+              isChecked={value.truncateBeforeInsert}
+              onCheckedChange={(newVal) => {
+                setValue({
+                  ...value,
+                  truncateBeforeInsert: newVal,
+                  truncateCascade: newVal ? value.truncateCascade : false,
+                });
+              }}
+              title="Truncate Before Insert"
+              description="Truncates table before inserting data"
             />
           </div>
           <div>
-            <FormField
-              name={truncateCascadeName}
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <SwitchCard
-                      isChecked={field.value || false}
-                      onCheckedChange={(newVal) => {
-                        field.onChange(newVal);
-                        if (newVal) {
-                          formCtx.setValue(truncateBeforeInsertName, true);
-                        }
-                      }}
-                      title="Truncate Cascade"
-                      description="TRUNCATE CASCADE to all tables"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+            <SwitchCard
+              isChecked={value.truncateCascade}
+              onCheckedChange={(newVal) => {
+                setValue({
+                  ...value,
+                  truncateBeforeInsert:
+                    newVal && !value.truncateBeforeInsert
+                      ? true
+                      : value.truncateBeforeInsert,
+                  truncateCascade: newVal,
+                });
+              }}
+              title="Truncate Cascade"
+              description="TRUNCATE CASCADE to all tables"
             />
           </div>
           <div>
-            <FormField
-              name={
-                index != null
-                  ? `destinations.${index}.destinationOptions.initTableSchema`
-                  : `destinationOptions.initTableSchema`
-              }
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <SwitchCard
-                      isChecked={field.value || false}
-                      onCheckedChange={field.onChange}
-                      title="Init Table Schema"
-                      description="Creates table(s) and their constraints. The database schema must already exist. "
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+            <SwitchCard
+              isChecked={value.initTableSchema}
+              onCheckedChange={(newVal) => {
+                setValue({ ...value, initTableSchema: newVal });
+              }}
+              title="Init Table Schema"
+              description="Creates table(s) and their constraints. The database schema must already exist. "
             />
           </div>
           <div>
-            <FormField
-              name={
-                index != null
-                  ? `destinations.${index}.destinationOptions.onConflictDoNothing`
-                  : `destinationOptions.onConflictDoNothing`
-              }
-              render={({ field }) => (
-                <FormItem>
-                  <FormControl>
-                    <SwitchCard
-                      isChecked={field.value || false}
-                      onCheckedChange={field.onChange}
-                      title="On Conflict Do Nothing"
-                      description="If there is a conflict when inserting data do not insert"
-                    />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
+            <SwitchCard
+              isChecked={value.onConflictDoNothing}
+              onCheckedChange={(newVal) => {
+                setValue({ ...value, onConflictDoNothing: newVal });
+              }}
+              title="On Conflict Do Nothing"
+              description="If there is a conflict when inserting data do not insert"
             />
           </div>
         </div>
       );
     case 'mysqlConfig':
-      const mysqlValue = connection.connectionConfig.config.value;
-      const mysqltruncateBeforeInsertName =
-        index != null
-          ? `destinations.${index}.destinationOptions.truncateBeforeInsert`
-          : `destinationOptions.truncateBeforeInsert`;
-      switch (mysqlValue.connectionConfig.case) {
-        case 'connection':
-          return (
-            <div className="flex flex-col gap-2">
-              <div>
-                <FormField
-                  name={mysqltruncateBeforeInsertName}
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <SwitchCard
-                          isChecked={field.value || false}
-                          onCheckedChange={(newVal) => {
-                            field.onChange(newVal);
-                          }}
-                          title="Truncate Before Insert"
-                          description="Truncates table before inserting data"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <div>
-                <FormField
-                  name={
-                    index != null
-                      ? `destinations.${index}.destinationOptions.initTableSchema`
-                      : `destinationOptions.initTableSchema`
-                  }
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <SwitchCard
-                          isChecked={field.value || false}
-                          onCheckedChange={field.onChange}
-                          title="Init Table Schema"
-                          description="Creates table(s) and their constraints. The database schema must already exist. "
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-              <div>
-                <FormField
-                  name={
-                    index != null
-                      ? `destinations.${index}.destinationOptions.onConflictDoNothing`
-                      : `destinationOptions.onConflictDoNothing`
-                  }
-                  render={({ field }) => (
-                    <FormItem>
-                      <FormControl>
-                        <SwitchCard
-                          isChecked={field.value || false}
-                          onCheckedChange={field.onChange}
-                          title="On Conflict Do Nothing"
-                          description="If there is a conflict when inserting data do not insert"
-                        />
-                      </FormControl>
-                      <FormMessage />
-                    </FormItem>
-                  )}
-                />
-              </div>
-            </div>
-          );
-      }
-      return <></>;
+      return (
+        <div className="flex flex-col gap-2">
+          <div>
+            <SwitchCard
+              isChecked={value.truncateBeforeInsert}
+              onCheckedChange={(newVal) => {
+                setValue({ ...value, truncateBeforeInsert: newVal });
+              }}
+              title="Truncate Before Insert"
+              description="Truncates table before inserting data"
+            />
+          </div>
+          <div>
+            <SwitchCard
+              isChecked={value.initTableSchema}
+              onCheckedChange={(newVal) => {
+                setValue({ ...value, initTableSchema: newVal });
+              }}
+              title="Init Table Schema"
+              description="Creates table(s) and their constraints. The database schema must already exist. "
+            />
+          </div>
+          <div>
+            <SwitchCard
+              isChecked={value.onConflictDoNothing}
+              onCheckedChange={(newVal) => {
+                setValue({ ...value, onConflictDoNothing: newVal });
+              }}
+              title="On Conflict Do Nothing"
+              description="If there is a conflict when inserting data do not insert"
+            />
+          </div>
+        </div>
+      );
     case 'awsS3Config':
       return <></>;
     default:

--- a/frontend/apps/web/components/jobs/Form/DestinationOptionsForm.tsx
+++ b/frontend/apps/web/components/jobs/Form/DestinationOptionsForm.tsx
@@ -15,12 +15,14 @@ interface DestinationOptionsProps {
 
   value: DestinationOptions;
   setValue(newVal: DestinationOptions): void;
+
+  hideInitTableSchema?: boolean;
 }
 
 export default function DestinationOptionsForm(
   props: DestinationOptionsProps
 ): ReactElement {
-  const { connection, value, setValue } = props;
+  const { connection, value, setValue, hideInitTableSchema } = props;
 
   if (!connection) {
     return <></>;
@@ -61,16 +63,18 @@ export default function DestinationOptionsForm(
               description="TRUNCATE CASCADE to all tables"
             />
           </div>
-          <div>
-            <SwitchCard
-              isChecked={value.initTableSchema}
-              onCheckedChange={(newVal) => {
-                setValue({ ...value, initTableSchema: newVal });
-              }}
-              title="Init Table Schema"
-              description="Creates table(s) and their constraints. The database schema must already exist. "
-            />
-          </div>
+          {!hideInitTableSchema && (
+            <div>
+              <SwitchCard
+                isChecked={value.initTableSchema}
+                onCheckedChange={(newVal) => {
+                  setValue({ ...value, initTableSchema: newVal });
+                }}
+                title="Init Table Schema"
+                description="Creates table(s) and their constraints. The database schema must already exist. "
+              />
+            </div>
+          )}
           <div>
             <SwitchCard
               isChecked={value.onConflictDoNothing}

--- a/frontend/apps/web/components/jobs/Form/DestinationOptionsForm.tsx
+++ b/frontend/apps/web/components/jobs/Form/DestinationOptionsForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 import SwitchCard from '@/components/switches/SwitchCard';
+import { Badge } from '@/components/ui/badge';
 import { Connection } from '@neosync/sdk';
 import { ReactElement } from 'react';
 
@@ -71,6 +72,7 @@ export default function DestinationOptionsForm(
                   setValue({ ...value, initTableSchema: newVal });
                 }}
                 title="Init Table Schema"
+                postTitle={<Badge>Experimental</Badge>}
                 description="Creates table(s) and their constraints. The database schema must already exist. "
               />
             </div>

--- a/frontend/apps/web/components/switches/SwitchCard.tsx
+++ b/frontend/apps/web/components/switches/SwitchCard.tsx
@@ -6,15 +6,21 @@ interface Props {
   isChecked: boolean;
   onCheckedChange: (value: boolean) => void;
   title: string;
+  // provide a component that will show up to the right of the title
+  postTitle?: ReactElement;
+
   description?: string;
 }
 
 export default function SwitchCard(props: Props): ReactElement {
-  const { isChecked, onCheckedChange, title, description } = props;
+  const { isChecked, onCheckedChange, title, description, postTitle } = props;
   return (
     <div className="flex flex-row items-center justify-between rounded-lg border p-4 dark:border dark:border-gray-700 shadow-sm">
       <div className="space-y-0.5">
-        <Label className="text-sm">{title}</Label>
+        <div className="flex flex-col md:flex-row gap-2 items-center">
+          <Label className="text-sm">{title}</Label>
+          {postTitle}
+        </div>
         {description && (
           <p className="text-xs text-muted-foreground">{description}</p>
         )}


### PR DESCRIPTION
* Refactors DestinationOptionsForm to no longer require form hook
* Dynamically hides init table schema if the source and destination are the same (used for generate jobs)
* Adds experimental badge to init table schema as it is not fully featured