### PR TITLE
Nick/neos 1077 sticky tables arent sticky in firefox

### DIFF
--- a/frontend/apps/web/components/jobs/SchemaTable/SchemaPageTable.tsx
+++ b/frontend/apps/web/components/jobs/SchemaTable/SchemaPageTable.tsx
@@ -103,7 +103,7 @@ export default function SchemaPageTable<TData, TValue>({
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow
                 key={headerGroup.id}
-                className="flex flex-row items-center justify-between"
+                className="flex flex-row items-center justify-between px-2"
                 id="table-header-row"
               >
                 {headerGroup.headers.map((header) => {

--- a/frontend/apps/web/components/jobs/SchemaTable/SchemaPageTable.tsx
+++ b/frontend/apps/web/components/jobs/SchemaTable/SchemaPageTable.tsx
@@ -99,11 +99,11 @@ export default function SchemaPageTable<TData, TValue>({
         ref={tableContainerRef}
       >
         <StickyHeaderTable>
-          <TableHeader className="bg-gray-100 dark:bg-gray-800 sticky top-0 z-10 flex w-full px-2">
+          <TableHeader className="bg-gray-100 dark:bg-gray-800 sticky top-0 z-10 px-2">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow
                 key={headerGroup.id}
-                className="flex flex-row items-center justify-between w-full"
+                className="flex flex-row items-center justify-between"
                 id="table-header-row"
               >
                 {headerGroup.headers.map((header) => {

--- a/frontend/apps/web/components/jobs/subsets/subset-table/data-table.tsx
+++ b/frontend/apps/web/components/jobs/subsets/subset-table/data-table.tsx
@@ -83,11 +83,11 @@ export function DataTable<TData, TValue>({
         ref={tableContainerRef}
       >
         <StickyHeaderTable>
-          <TableHeader className="bg-gray-100 dark:bg-gray-800 sticky top-0 z-10 flex w-full px-2">
+          <TableHeader className="bg-gray-100 dark:bg-gray-800 sticky top-0 z-10 px-2">
             {table.getHeaderGroups().map((headerGroup) => (
               <TableRow
                 key={headerGroup.id}
-                className="flex flex-row items-center justify-between w-full"
+                className="flex flex-row items-center justify-between px-2"
                 id="table-header-row"
               >
                 {headerGroup.headers.map((header) => {


### PR DESCRIPTION
Fixes the tables not rendering properly in Firefox. Safari is still an issue however. It's not immediately clear to me why this is happening. We may need to totally revisit the concept of how we are making the tables sticky because it feels really brittle right now anyways.