### PR TITLE
fixes transformer seeds that resulted in them being the same

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -79,10 +79,3 @@ compose-dev-auth-up:
 compose-dev-auth-down:
 	docker compose -f $(DEV_COMPOSE_FILE) -f $(DEV_AUTH_COMPOSE_FILE) down
 .PHONY: compose-dev-auth-down
-
-goworksync:
-	go work sync
-	cd worker && go mod tidy
-	cd cli && go mod tidy
-	cd backend && go mod tidy
-.PHONY: goworksync

--- a/worker/internal/benthos/transformers/transform_first_name.go
+++ b/worker/internal/benthos/transformers/transform_first_name.go
@@ -2,7 +2,6 @@ package transformers
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/benthosdev/benthos/v4/public/bloblang"
 	transformer_utils "github.com/nucleuscloud/neosync/worker/internal/benthos/transformers/utils"
@@ -14,7 +13,7 @@ func init() {
 		Param(bloblang.NewInt64Param("max_length").Default(10000)).
 		Param(bloblang.NewAnyParam("value").Optional()).
 		Param(bloblang.NewBoolParam("preserve_length").Default(false)).
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()))
+		Param(bloblang.NewInt64Param("seed").Optional())
 
 	err := bloblang.RegisterFunctionV2("transform_first_name", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		valuePtr, err := args.GetOptionalString("value")
@@ -37,10 +36,22 @@ func init() {
 			return nil, err
 		}
 
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
 		if err != nil {
 			return nil, err
 		}
+		var seed int64
+		if seedArg != nil {
+			seed = *seedArg
+		} else {
+			// we want a bit more randomness here with generate_email so using something that isn't time based
+			var err error
+			seed, err = transformer_utils.GenerateCryptoSeed()
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		randomizer := rng.New(seed)
 
 		return func() (any, error) {

--- a/worker/internal/benthos/transformers/transform_lastname.go
+++ b/worker/internal/benthos/transformers/transform_lastname.go
@@ -2,7 +2,6 @@ package transformers
 
 import (
 	"fmt"
-	"time"
 
 	"github.com/benthosdev/benthos/v4/public/bloblang"
 	transformer_utils "github.com/nucleuscloud/neosync/worker/internal/benthos/transformers/utils"
@@ -14,7 +13,7 @@ func init() {
 		Param(bloblang.NewInt64Param("max_length").Default(10000)).
 		Param(bloblang.NewAnyParam("value").Optional()).
 		Param(bloblang.NewBoolParam("preserve_length").Default(false)).
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()))
+		Param(bloblang.NewInt64Param("seed").Optional())
 
 	err := bloblang.RegisterFunctionV2("transform_last_name", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		valuePtr, err := args.GetOptionalString("value")
@@ -36,10 +35,22 @@ func init() {
 			return nil, err
 		}
 
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
 		if err != nil {
 			return nil, err
 		}
+		var seed int64
+		if seedArg != nil {
+			seed = *seedArg
+		} else {
+			// we want a bit more randomness here with generate_email so using something that isn't time based
+			var err error
+			seed, err = transformer_utils.GenerateCryptoSeed()
+			if err != nil {
+				return nil, err
+			}
+		}
+
 		randomizer := rng.New(seed)
 
 		return func() (any, error) {


### PR DESCRIPTION
misunderstood how the functions were calculated. functions in benthos are memoized by their inputs.
for transformers, this may be different every time due to us passing in values. 

updated it to work with defaults better. this will still pose an issue if the seed value is present.