### PR TITLE
[Docs] Remove extra semicolon from docs page

### DIFF
--- a/docs/docs/overview/introduction.mdx
+++ b/docs/docs/overview/introduction.mdx
@@ -45,7 +45,6 @@ testing, debugging and developer experience.
     dark: 'https://assets.nucleuscloud.com/neosync/docs/neosync-header-dark.svg',
   }}
 />
-;
 
 ## Core Features
 


### PR DESCRIPTION
Removes errant semicolon on the docs introduction page at the end of the first section (below the image). 

Before: 
<img width="1444" alt="Screenshot 2024-05-25 at 5 18 59 PM" src="https://github.com/nucleuscloud/neosync/assets/9806015/d386174f-3619-4150-8b4d-0698aebf5093">

After: 
<img width="1444" alt="Screenshot 2024-05-25 at 5 19 12 PM" src="https://github.com/nucleuscloud/neosync/assets/9806015/32fd9fd0-5fb3-44dc-aaf2-55ba18800d3b">
