### PR TITLE
[Docs] fix transformers links

### DIFF
--- a/docs/docs/overview/core-features.mdx
+++ b/docs/docs/overview/core-features.mdx
@@ -12,7 +12,7 @@ Neosync ships with a number of features but there are four core features that dr
 
 ## Anonymization
 
-Neosync provides the core anonymization functionality through [transformers](/platform#transformers). Transformers anonymize or mask source data in any way you'd like. Neosync ships with a number of pre-built transformers to help you get started or you can write your own user defined transformer.
+Neosync provides the core anonymization functionality through [transformers](/transformers/introduction). Transformers anonymize or mask source data in any way you'd like. Neosync ships with a number of pre-built transformers to help you get started or you can write your own user defined transformer.
 
 You can use the prebuilt Neosync transformers in order to anonymize your sensitive data or generate new data that looks just like your production data. The Schema page is where you can select, at the column level, how you want to anonymize your data.
 
@@ -22,7 +22,7 @@ You have full control over how you configure your schema and can even create you
 
 ## Synthetic Data Generation
 
-Synthetic data can be useful for testing applications and services in unsecure development and stage environments where you don't want your sensitive data to be floating around. Neosync helps teams create high-quality synthetic data from their production data that is representative of that production data using our [transformers](/platform#transformers). There are multiple ways to generate high quality synthetic data that can be useful depending on the use-case.
+Synthetic data can be useful for testing applications and services in unsecure development and stage environments where you don't want your sensitive data to be floating around. Neosync helps teams create high-quality synthetic data from their production data that is representative of that production data using our [transformers](/transformers/introduction). There are multiple ways to generate high quality synthetic data that can be useful depending on the use-case.
 
 Neosync can generate synthetic data from scratch, making it easy to test new features that don't already have generated data or when the current production data is to sensitive to work with. We give you different options to be able to generate synthetic data so that it fits your schema and works with your applications. These options are transformer specific and will depend on the data being generated. You can easily seed an entire database with synthetic data using Neosync to get started or create synthetic data for just a given column.
 


### PR DESCRIPTION
The old link to `/platform#transformers` lands on a page with no information about transformers: 
<img width="1445" alt="Screenshot 2024-05-25 at 5 49 07 PM" src="https://github.com/nucleuscloud/neosync/assets/9806015/e8d56b2c-0acd-4499-9630-65724fe8ad44">

Updates the links to point to https://docs.neosync.dev/transformers/introduction 