### PR TITLE
NEOS-1129 add support for initing PG custom data types, etc

### DIFF
--- a/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
@@ -320,66 +320,6 @@ func (_c *MockQuerier_GetDatabaseSchema_Call) RunAndReturn(run func(context.Cont
 	return _c
 }
 
-// GetDatabaseTableSchema provides a mock function with given fields: ctx, db, arg
-func (_m *MockQuerier) GetDatabaseTableSchema(ctx context.Context, db DBTX, arg *GetDatabaseTableSchemaParams) ([]*GetDatabaseTableSchemaRow, error) {
-	ret := _m.Called(ctx, db, arg)
-
-	if len(ret) == 0 {
-		panic("no return value specified for GetDatabaseTableSchema")
-	}
-
-	var r0 []*GetDatabaseTableSchemaRow
-	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX, *GetDatabaseTableSchemaParams) ([]*GetDatabaseTableSchemaRow, error)); ok {
-		return rf(ctx, db, arg)
-	}
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX, *GetDatabaseTableSchemaParams) []*GetDatabaseTableSchemaRow); ok {
-		r0 = rf(ctx, db, arg)
-	} else {
-		if ret.Get(0) != nil {
-			r0 = ret.Get(0).([]*GetDatabaseTableSchemaRow)
-		}
-	}
-
-	if rf, ok := ret.Get(1).(func(context.Context, DBTX, *GetDatabaseTableSchemaParams) error); ok {
-		r1 = rf(ctx, db, arg)
-	} else {
-		r1 = ret.Error(1)
-	}
-
-	return r0, r1
-}
-
-// MockQuerier_GetDatabaseTableSchema_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDatabaseTableSchema'
-type MockQuerier_GetDatabaseTableSchema_Call struct {
-	*mock.Call
-}
-
-// GetDatabaseTableSchema is a helper method to define mock.On call
-//   - ctx context.Context
-//   - db DBTX
-//   - arg *GetDatabaseTableSchemaParams
-func (_e *MockQuerier_Expecter) GetDatabaseTableSchema(ctx interface{}, db interface{}, arg interface{}) *MockQuerier_GetDatabaseTableSchema_Call {
-	return &MockQuerier_GetDatabaseTableSchema_Call{Call: _e.mock.On("GetDatabaseTableSchema", ctx, db, arg)}
-}
-
-func (_c *MockQuerier_GetDatabaseTableSchema_Call) Run(run func(ctx context.Context, db DBTX, arg *GetDatabaseTableSchemaParams)) *MockQuerier_GetDatabaseTableSchema_Call {
-	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(DBTX), args[2].(*GetDatabaseTableSchemaParams))
-	})
-	return _c
-}
-
-func (_c *MockQuerier_GetDatabaseTableSchema_Call) Return(_a0 []*GetDatabaseTableSchemaRow, _a1 error) *MockQuerier_GetDatabaseTableSchema_Call {
-	_c.Call.Return(_a0, _a1)
-	return _c
-}
-
-func (_c *MockQuerier_GetDatabaseTableSchema_Call) RunAndReturn(run func(context.Context, DBTX, *GetDatabaseTableSchemaParams) ([]*GetDatabaseTableSchemaRow, error)) *MockQuerier_GetDatabaseTableSchema_Call {
-	_c.Call.Return(run)
-	return _c
-}
-
 // GetDatabaseTableSchemasBySchemasAndTables provides a mock function with given fields: ctx, db, schematables
 func (_m *MockQuerier) GetDatabaseTableSchemasBySchemasAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetDatabaseTableSchemasBySchemasAndTablesRow, error) {
 	ret := _m.Called(ctx, db, schematables)

--- a/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
@@ -21,6 +21,183 @@ func (_m *MockQuerier) EXPECT() *MockQuerier_Expecter {
 	return &MockQuerier_Expecter{mock: &_m.Mock}
 }
 
+// GetCustomFunctionsBySchemaAndTables provides a mock function with given fields: ctx, db
+func (_m *MockQuerier) GetCustomFunctionsBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomFunctionsBySchemaAndTablesRow, error) {
+	ret := _m.Called(ctx, db)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCustomFunctionsBySchemaAndTables")
+	}
+
+	var r0 []*GetCustomFunctionsBySchemaAndTablesRow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)); ok {
+		return rf(ctx, db)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetCustomFunctionsBySchemaAndTablesRow); ok {
+		r0 = rf(ctx, db)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*GetCustomFunctionsBySchemaAndTablesRow)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
+		r1 = rf(ctx, db)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockQuerier_GetCustomFunctionsBySchemaAndTables_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCustomFunctionsBySchemaAndTables'
+type MockQuerier_GetCustomFunctionsBySchemaAndTables_Call struct {
+	*mock.Call
+}
+
+// GetCustomFunctionsBySchemaAndTables is a helper method to define mock.On call
+//   - ctx context.Context
+//   - db DBTX
+func (_e *MockQuerier_Expecter) GetCustomFunctionsBySchemaAndTables(ctx interface{}, db interface{}) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
+	return &MockQuerier_GetCustomFunctionsBySchemaAndTables_Call{Call: _e.mock.On("GetCustomFunctionsBySchemaAndTables", ctx, db)}
+}
+
+func (_c *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(DBTX))
+	})
+	return _c
+}
+
+func (_c *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call) Return(_a0 []*GetCustomFunctionsBySchemaAndTablesRow, _a1 error) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetCustomSequencesBySchemaAndTables provides a mock function with given fields: ctx, db
+func (_m *MockQuerier) GetCustomSequencesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomSequencesBySchemaAndTablesRow, error) {
+	ret := _m.Called(ctx, db)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCustomSequencesBySchemaAndTables")
+	}
+
+	var r0 []*GetCustomSequencesBySchemaAndTablesRow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetCustomSequencesBySchemaAndTablesRow, error)); ok {
+		return rf(ctx, db)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetCustomSequencesBySchemaAndTablesRow); ok {
+		r0 = rf(ctx, db)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*GetCustomSequencesBySchemaAndTablesRow)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
+		r1 = rf(ctx, db)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockQuerier_GetCustomSequencesBySchemaAndTables_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCustomSequencesBySchemaAndTables'
+type MockQuerier_GetCustomSequencesBySchemaAndTables_Call struct {
+	*mock.Call
+}
+
+// GetCustomSequencesBySchemaAndTables is a helper method to define mock.On call
+//   - ctx context.Context
+//   - db DBTX
+func (_e *MockQuerier_Expecter) GetCustomSequencesBySchemaAndTables(ctx interface{}, db interface{}) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
+	return &MockQuerier_GetCustomSequencesBySchemaAndTables_Call{Call: _e.mock.On("GetCustomSequencesBySchemaAndTables", ctx, db)}
+}
+
+func (_c *MockQuerier_GetCustomSequencesBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(DBTX))
+	})
+	return _c
+}
+
+func (_c *MockQuerier_GetCustomSequencesBySchemaAndTables_Call) Return(_a0 []*GetCustomSequencesBySchemaAndTablesRow, _a1 error) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockQuerier_GetCustomSequencesBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetCustomSequencesBySchemaAndTablesRow, error)) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetCustomTriggersBySchemaAndTables provides a mock function with given fields: ctx, db
+func (_m *MockQuerier) GetCustomTriggersBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomTriggersBySchemaAndTablesRow, error) {
+	ret := _m.Called(ctx, db)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetCustomTriggersBySchemaAndTables")
+	}
+
+	var r0 []*GetCustomTriggersBySchemaAndTablesRow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetCustomTriggersBySchemaAndTablesRow, error)); ok {
+		return rf(ctx, db)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetCustomTriggersBySchemaAndTablesRow); ok {
+		r0 = rf(ctx, db)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*GetCustomTriggersBySchemaAndTablesRow)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
+		r1 = rf(ctx, db)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockQuerier_GetCustomTriggersBySchemaAndTables_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetCustomTriggersBySchemaAndTables'
+type MockQuerier_GetCustomTriggersBySchemaAndTables_Call struct {
+	*mock.Call
+}
+
+// GetCustomTriggersBySchemaAndTables is a helper method to define mock.On call
+//   - ctx context.Context
+//   - db DBTX
+func (_e *MockQuerier_Expecter) GetCustomTriggersBySchemaAndTables(ctx interface{}, db interface{}) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
+	return &MockQuerier_GetCustomTriggersBySchemaAndTables_Call{Call: _e.mock.On("GetCustomTriggersBySchemaAndTables", ctx, db)}
+}
+
+func (_c *MockQuerier_GetCustomTriggersBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(DBTX))
+	})
+	return _c
+}
+
+func (_c *MockQuerier_GetCustomTriggersBySchemaAndTables_Call) Return(_a0 []*GetCustomTriggersBySchemaAndTablesRow, _a1 error) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockQuerier_GetCustomTriggersBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetCustomTriggersBySchemaAndTablesRow, error)) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetDataTypesBySchemaAndTables provides a mock function with given fields: ctx, db
 func (_m *MockQuerier) GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error) {
 	ret := _m.Called(ctx, db)

--- a/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
@@ -21,9 +21,9 @@ func (_m *MockQuerier) EXPECT() *MockQuerier_Expecter {
 	return &MockQuerier_Expecter{mock: &_m.Mock}
 }
 
-// GetCustomFunctionsBySchemaAndTables provides a mock function with given fields: ctx, db
-func (_m *MockQuerier) GetCustomFunctionsBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomFunctionsBySchemaAndTablesRow, error) {
-	ret := _m.Called(ctx, db)
+// GetCustomFunctionsBySchemaAndTables provides a mock function with given fields: ctx, db, arg
+func (_m *MockQuerier) GetCustomFunctionsBySchemaAndTables(ctx context.Context, db DBTX, arg *GetCustomFunctionsBySchemaAndTablesParams) ([]*GetCustomFunctionsBySchemaAndTablesRow, error) {
+	ret := _m.Called(ctx, db, arg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCustomFunctionsBySchemaAndTables")
@@ -31,19 +31,19 @@ func (_m *MockQuerier) GetCustomFunctionsBySchemaAndTables(ctx context.Context, 
 
 	var r0 []*GetCustomFunctionsBySchemaAndTablesRow
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)); ok {
-		return rf(ctx, db)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, *GetCustomFunctionsBySchemaAndTablesParams) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)); ok {
+		return rf(ctx, db, arg)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetCustomFunctionsBySchemaAndTablesRow); ok {
-		r0 = rf(ctx, db)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, *GetCustomFunctionsBySchemaAndTablesParams) []*GetCustomFunctionsBySchemaAndTablesRow); ok {
+		r0 = rf(ctx, db, arg)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*GetCustomFunctionsBySchemaAndTablesRow)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
-		r1 = rf(ctx, db)
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX, *GetCustomFunctionsBySchemaAndTablesParams) error); ok {
+		r1 = rf(ctx, db, arg)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -59,13 +59,14 @@ type MockQuerier_GetCustomFunctionsBySchemaAndTables_Call struct {
 // GetCustomFunctionsBySchemaAndTables is a helper method to define mock.On call
 //   - ctx context.Context
 //   - db DBTX
-func (_e *MockQuerier_Expecter) GetCustomFunctionsBySchemaAndTables(ctx interface{}, db interface{}) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
-	return &MockQuerier_GetCustomFunctionsBySchemaAndTables_Call{Call: _e.mock.On("GetCustomFunctionsBySchemaAndTables", ctx, db)}
+//   - arg *GetCustomFunctionsBySchemaAndTablesParams
+func (_e *MockQuerier_Expecter) GetCustomFunctionsBySchemaAndTables(ctx interface{}, db interface{}, arg interface{}) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
+	return &MockQuerier_GetCustomFunctionsBySchemaAndTables_Call{Call: _e.mock.On("GetCustomFunctionsBySchemaAndTables", ctx, db, arg)}
 }
 
-func (_c *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
+func (_c *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX, arg *GetCustomFunctionsBySchemaAndTablesParams)) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(DBTX))
+		run(args[0].(context.Context), args[1].(DBTX), args[2].(*GetCustomFunctionsBySchemaAndTablesParams))
 	})
 	return _c
 }
@@ -75,14 +76,14 @@ func (_c *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call) Return(_a0 []*Ge
 	return _c
 }
 
-func (_c *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
+func (_c *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX, *GetCustomFunctionsBySchemaAndTablesParams) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)) *MockQuerier_GetCustomFunctionsBySchemaAndTables_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetCustomSequencesBySchemaAndTables provides a mock function with given fields: ctx, db
-func (_m *MockQuerier) GetCustomSequencesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomSequencesBySchemaAndTablesRow, error) {
-	ret := _m.Called(ctx, db)
+// GetCustomSequencesBySchemaAndTables provides a mock function with given fields: ctx, db, arg
+func (_m *MockQuerier) GetCustomSequencesBySchemaAndTables(ctx context.Context, db DBTX, arg *GetCustomSequencesBySchemaAndTablesParams) ([]*GetCustomSequencesBySchemaAndTablesRow, error) {
+	ret := _m.Called(ctx, db, arg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCustomSequencesBySchemaAndTables")
@@ -90,19 +91,19 @@ func (_m *MockQuerier) GetCustomSequencesBySchemaAndTables(ctx context.Context, 
 
 	var r0 []*GetCustomSequencesBySchemaAndTablesRow
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetCustomSequencesBySchemaAndTablesRow, error)); ok {
-		return rf(ctx, db)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, *GetCustomSequencesBySchemaAndTablesParams) ([]*GetCustomSequencesBySchemaAndTablesRow, error)); ok {
+		return rf(ctx, db, arg)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetCustomSequencesBySchemaAndTablesRow); ok {
-		r0 = rf(ctx, db)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, *GetCustomSequencesBySchemaAndTablesParams) []*GetCustomSequencesBySchemaAndTablesRow); ok {
+		r0 = rf(ctx, db, arg)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*GetCustomSequencesBySchemaAndTablesRow)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
-		r1 = rf(ctx, db)
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX, *GetCustomSequencesBySchemaAndTablesParams) error); ok {
+		r1 = rf(ctx, db, arg)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -118,13 +119,14 @@ type MockQuerier_GetCustomSequencesBySchemaAndTables_Call struct {
 // GetCustomSequencesBySchemaAndTables is a helper method to define mock.On call
 //   - ctx context.Context
 //   - db DBTX
-func (_e *MockQuerier_Expecter) GetCustomSequencesBySchemaAndTables(ctx interface{}, db interface{}) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
-	return &MockQuerier_GetCustomSequencesBySchemaAndTables_Call{Call: _e.mock.On("GetCustomSequencesBySchemaAndTables", ctx, db)}
+//   - arg *GetCustomSequencesBySchemaAndTablesParams
+func (_e *MockQuerier_Expecter) GetCustomSequencesBySchemaAndTables(ctx interface{}, db interface{}, arg interface{}) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
+	return &MockQuerier_GetCustomSequencesBySchemaAndTables_Call{Call: _e.mock.On("GetCustomSequencesBySchemaAndTables", ctx, db, arg)}
 }
 
-func (_c *MockQuerier_GetCustomSequencesBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
+func (_c *MockQuerier_GetCustomSequencesBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX, arg *GetCustomSequencesBySchemaAndTablesParams)) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(DBTX))
+		run(args[0].(context.Context), args[1].(DBTX), args[2].(*GetCustomSequencesBySchemaAndTablesParams))
 	})
 	return _c
 }
@@ -134,14 +136,14 @@ func (_c *MockQuerier_GetCustomSequencesBySchemaAndTables_Call) Return(_a0 []*Ge
 	return _c
 }
 
-func (_c *MockQuerier_GetCustomSequencesBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetCustomSequencesBySchemaAndTablesRow, error)) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
+func (_c *MockQuerier_GetCustomSequencesBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX, *GetCustomSequencesBySchemaAndTablesParams) ([]*GetCustomSequencesBySchemaAndTablesRow, error)) *MockQuerier_GetCustomSequencesBySchemaAndTables_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetCustomTriggersBySchemaAndTables provides a mock function with given fields: ctx, db
-func (_m *MockQuerier) GetCustomTriggersBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomTriggersBySchemaAndTablesRow, error) {
-	ret := _m.Called(ctx, db)
+// GetCustomTriggersBySchemaAndTables provides a mock function with given fields: ctx, db, schematables
+func (_m *MockQuerier) GetCustomTriggersBySchemaAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetCustomTriggersBySchemaAndTablesRow, error) {
+	ret := _m.Called(ctx, db, schematables)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetCustomTriggersBySchemaAndTables")
@@ -149,19 +151,19 @@ func (_m *MockQuerier) GetCustomTriggersBySchemaAndTables(ctx context.Context, d
 
 	var r0 []*GetCustomTriggersBySchemaAndTablesRow
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetCustomTriggersBySchemaAndTablesRow, error)); ok {
-		return rf(ctx, db)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, []string) ([]*GetCustomTriggersBySchemaAndTablesRow, error)); ok {
+		return rf(ctx, db, schematables)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetCustomTriggersBySchemaAndTablesRow); ok {
-		r0 = rf(ctx, db)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, []string) []*GetCustomTriggersBySchemaAndTablesRow); ok {
+		r0 = rf(ctx, db, schematables)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*GetCustomTriggersBySchemaAndTablesRow)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
-		r1 = rf(ctx, db)
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX, []string) error); ok {
+		r1 = rf(ctx, db, schematables)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -177,13 +179,14 @@ type MockQuerier_GetCustomTriggersBySchemaAndTables_Call struct {
 // GetCustomTriggersBySchemaAndTables is a helper method to define mock.On call
 //   - ctx context.Context
 //   - db DBTX
-func (_e *MockQuerier_Expecter) GetCustomTriggersBySchemaAndTables(ctx interface{}, db interface{}) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
-	return &MockQuerier_GetCustomTriggersBySchemaAndTables_Call{Call: _e.mock.On("GetCustomTriggersBySchemaAndTables", ctx, db)}
+//   - schematables []string
+func (_e *MockQuerier_Expecter) GetCustomTriggersBySchemaAndTables(ctx interface{}, db interface{}, schematables interface{}) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
+	return &MockQuerier_GetCustomTriggersBySchemaAndTables_Call{Call: _e.mock.On("GetCustomTriggersBySchemaAndTables", ctx, db, schematables)}
 }
 
-func (_c *MockQuerier_GetCustomTriggersBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
+func (_c *MockQuerier_GetCustomTriggersBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX, schematables []string)) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(DBTX))
+		run(args[0].(context.Context), args[1].(DBTX), args[2].([]string))
 	})
 	return _c
 }
@@ -193,14 +196,14 @@ func (_c *MockQuerier_GetCustomTriggersBySchemaAndTables_Call) Return(_a0 []*Get
 	return _c
 }
 
-func (_c *MockQuerier_GetCustomTriggersBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetCustomTriggersBySchemaAndTablesRow, error)) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
+func (_c *MockQuerier_GetCustomTriggersBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX, []string) ([]*GetCustomTriggersBySchemaAndTablesRow, error)) *MockQuerier_GetCustomTriggersBySchemaAndTables_Call {
 	_c.Call.Return(run)
 	return _c
 }
 
-// GetDataTypesBySchemaAndTables provides a mock function with given fields: ctx, db
-func (_m *MockQuerier) GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error) {
-	ret := _m.Called(ctx, db)
+// GetDataTypesBySchemaAndTables provides a mock function with given fields: ctx, db, arg
+func (_m *MockQuerier) GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX, arg *GetDataTypesBySchemaAndTablesParams) ([]*GetDataTypesBySchemaAndTablesRow, error) {
+	ret := _m.Called(ctx, db, arg)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetDataTypesBySchemaAndTables")
@@ -208,19 +211,19 @@ func (_m *MockQuerier) GetDataTypesBySchemaAndTables(ctx context.Context, db DBT
 
 	var r0 []*GetDataTypesBySchemaAndTablesRow
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error)); ok {
-		return rf(ctx, db)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, *GetDataTypesBySchemaAndTablesParams) ([]*GetDataTypesBySchemaAndTablesRow, error)); ok {
+		return rf(ctx, db, arg)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetDataTypesBySchemaAndTablesRow); ok {
-		r0 = rf(ctx, db)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX, *GetDataTypesBySchemaAndTablesParams) []*GetDataTypesBySchemaAndTablesRow); ok {
+		r0 = rf(ctx, db, arg)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*GetDataTypesBySchemaAndTablesRow)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
-		r1 = rf(ctx, db)
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX, *GetDataTypesBySchemaAndTablesParams) error); ok {
+		r1 = rf(ctx, db, arg)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -236,13 +239,14 @@ type MockQuerier_GetDataTypesBySchemaAndTables_Call struct {
 // GetDataTypesBySchemaAndTables is a helper method to define mock.On call
 //   - ctx context.Context
 //   - db DBTX
-func (_e *MockQuerier_Expecter) GetDataTypesBySchemaAndTables(ctx interface{}, db interface{}) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
-	return &MockQuerier_GetDataTypesBySchemaAndTables_Call{Call: _e.mock.On("GetDataTypesBySchemaAndTables", ctx, db)}
+//   - arg *GetDataTypesBySchemaAndTablesParams
+func (_e *MockQuerier_Expecter) GetDataTypesBySchemaAndTables(ctx interface{}, db interface{}, arg interface{}) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
+	return &MockQuerier_GetDataTypesBySchemaAndTables_Call{Call: _e.mock.On("GetDataTypesBySchemaAndTables", ctx, db, arg)}
 }
 
-func (_c *MockQuerier_GetDataTypesBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
+func (_c *MockQuerier_GetDataTypesBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX, arg *GetDataTypesBySchemaAndTablesParams)) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(DBTX))
+		run(args[0].(context.Context), args[1].(DBTX), args[2].(*GetDataTypesBySchemaAndTablesParams))
 	})
 	return _c
 }
@@ -252,7 +256,7 @@ func (_c *MockQuerier_GetDataTypesBySchemaAndTables_Call) Return(_a0 []*GetDataT
 	return _c
 }
 
-func (_c *MockQuerier_GetDataTypesBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error)) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
+func (_c *MockQuerier_GetDataTypesBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX, *GetDataTypesBySchemaAndTablesParams) ([]*GetDataTypesBySchemaAndTablesRow, error)) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
@@ -21,6 +21,65 @@ func (_m *MockQuerier) EXPECT() *MockQuerier_Expecter {
 	return &MockQuerier_Expecter{mock: &_m.Mock}
 }
 
+// GetDataTypesBySchemaAndTables provides a mock function with given fields: ctx, db
+func (_m *MockQuerier) GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error) {
+	ret := _m.Called(ctx, db)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetDataTypesBySchemaAndTables")
+	}
+
+	var r0 []*GetDataTypesBySchemaAndTablesRow
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error)); ok {
+		return rf(ctx, db)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetDataTypesBySchemaAndTablesRow); ok {
+		r0 = rf(ctx, db)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*GetDataTypesBySchemaAndTablesRow)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
+		r1 = rf(ctx, db)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockQuerier_GetDataTypesBySchemaAndTables_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetDataTypesBySchemaAndTables'
+type MockQuerier_GetDataTypesBySchemaAndTables_Call struct {
+	*mock.Call
+}
+
+// GetDataTypesBySchemaAndTables is a helper method to define mock.On call
+//   - ctx context.Context
+//   - db DBTX
+func (_e *MockQuerier_Expecter) GetDataTypesBySchemaAndTables(ctx interface{}, db interface{}) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
+	return &MockQuerier_GetDataTypesBySchemaAndTables_Call{Call: _e.mock.On("GetDataTypesBySchemaAndTables", ctx, db)}
+}
+
+func (_c *MockQuerier_GetDataTypesBySchemaAndTables_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].(DBTX))
+	})
+	return _c
+}
+
+func (_c *MockQuerier_GetDataTypesBySchemaAndTables_Call) Return(_a0 []*GetDataTypesBySchemaAndTablesRow, _a1 error) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockQuerier_GetDataTypesBySchemaAndTables_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error)) *MockQuerier_GetDataTypesBySchemaAndTables_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetDatabaseSchema provides a mock function with given fields: ctx, db
 func (_m *MockQuerier) GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error) {
 	ret := _m.Called(ctx, db)

--- a/backend/gen/go/db/dbschemas/postgresql/querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/querier.go
@@ -9,10 +9,10 @@ import (
 )
 
 type Querier interface {
-	GetCustomFunctionsBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)
-	GetCustomSequencesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomSequencesBySchemaAndTablesRow, error)
-	GetCustomTriggersBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomTriggersBySchemaAndTablesRow, error)
-	GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error)
+	GetCustomFunctionsBySchemaAndTables(ctx context.Context, db DBTX, arg *GetCustomFunctionsBySchemaAndTablesParams) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)
+	GetCustomSequencesBySchemaAndTables(ctx context.Context, db DBTX, arg *GetCustomSequencesBySchemaAndTablesParams) ([]*GetCustomSequencesBySchemaAndTablesRow, error)
+	GetCustomTriggersBySchemaAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetCustomTriggersBySchemaAndTablesRow, error)
+	GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX, arg *GetDataTypesBySchemaAndTablesParams) ([]*GetDataTypesBySchemaAndTablesRow, error)
 	GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error)
 	GetDatabaseTableSchema(ctx context.Context, db DBTX, arg *GetDatabaseTableSchemaParams) ([]*GetDatabaseTableSchemaRow, error)
 	GetDatabaseTableSchemasBySchemasAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetDatabaseTableSchemasBySchemasAndTablesRow, error)

--- a/backend/gen/go/db/dbschemas/postgresql/querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/querier.go
@@ -9,6 +9,8 @@ import (
 )
 
 type Querier interface {
+	GetCustomFunctionsBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)
+	GetCustomTriggersBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomTriggersBySchemaAndTablesRow, error)
 	GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error)
 	GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error)
 	GetDatabaseTableSchema(ctx context.Context, db DBTX, arg *GetDatabaseTableSchemaParams) ([]*GetDatabaseTableSchemaRow, error)

--- a/backend/gen/go/db/dbschemas/postgresql/querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/querier.go
@@ -9,6 +9,7 @@ import (
 )
 
 type Querier interface {
+	GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error)
 	GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error)
 	GetDatabaseTableSchema(ctx context.Context, db DBTX, arg *GetDatabaseTableSchemaParams) ([]*GetDatabaseTableSchemaRow, error)
 	GetDatabaseTableSchemasBySchemasAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetDatabaseTableSchemasBySchemasAndTablesRow, error)

--- a/backend/gen/go/db/dbschemas/postgresql/querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/querier.go
@@ -10,6 +10,7 @@ import (
 
 type Querier interface {
 	GetCustomFunctionsBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomFunctionsBySchemaAndTablesRow, error)
+	GetCustomSequencesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomSequencesBySchemaAndTablesRow, error)
 	GetCustomTriggersBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomTriggersBySchemaAndTablesRow, error)
 	GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetDataTypesBySchemaAndTablesRow, error)
 	GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error)

--- a/backend/gen/go/db/dbschemas/postgresql/querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/querier.go
@@ -14,7 +14,6 @@ type Querier interface {
 	GetCustomTriggersBySchemaAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetCustomTriggersBySchemaAndTablesRow, error)
 	GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX, arg *GetDataTypesBySchemaAndTablesParams) ([]*GetDataTypesBySchemaAndTablesRow, error)
 	GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error)
-	GetDatabaseTableSchema(ctx context.Context, db DBTX, arg *GetDatabaseTableSchemaParams) ([]*GetDatabaseTableSchemaRow, error)
 	GetDatabaseTableSchemasBySchemasAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetDatabaseTableSchemasBySchemasAndTablesRow, error)
 	GetIndicesBySchemasAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetIndicesBySchemasAndTablesRow, error)
 	GetPostgresRolePermissions(ctx context.Context, db DBTX, role interface{}) ([]*GetPostgresRolePermissionsRow, error)

--- a/backend/gen/go/db/dbschemas/postgresql/system.sql.go
+++ b/backend/gen/go/db/dbschemas/postgresql/system.sql.go
@@ -7,6 +7,8 @@ package pg_queries
 
 import (
 	"context"
+
+	"github.com/jackc/pgx/v5/pgtype"
 )
 
 const getCustomFunctionsBySchemaAndTables = `-- name: GetCustomFunctionsBySchemaAndTables :many
@@ -15,7 +17,7 @@ WITH relevant_schemas_tables AS (
     FROM pg_catalog.pg_class c
     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname = $1
-    AND c.relname IN ($2::TEXT[])
+    AND c.relname = ANY($2::TEXT[])
 ),
 trigger_functions AS (
     SELECT DISTINCT
@@ -76,7 +78,7 @@ WITH relevant_schemas_tables AS (
     FROM pg_catalog.pg_class c
     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname = $1
-    AND c.relname IN ($2::TEXT[])
+    AND c.relname = ANY($2::TEXT[])
 ),
 all_sequences AS (
     SELECT
@@ -237,7 +239,7 @@ WITH custom_types AS (
     JOIN
         pg_catalog.pg_namespace n ON n.oid = t.typnamespace
     WHERE
-        n.nspname = 'public'
+        n.nspname = $1
         AND t.typtype IN ('d', 'e', 'c')
 ),
 table_columns AS (
@@ -252,7 +254,7 @@ table_columns AS (
         pg_catalog.pg_attribute a ON a.attrelid = c.oid
     WHERE
         n.nspname = $1
-        AND c.relname IN ($2::TEXT[])
+        AND c.relname = ANY($2::TEXT[])
         AND a.attnum > 0
         AND NOT a.attisdropped
 ),
@@ -390,76 +392,109 @@ func (q *Queries) GetDataTypesBySchemaAndTables(ctx context.Context, db DBTX, ar
 }
 
 const getDatabaseSchema = `-- name: GetDatabaseSchema :many
-SELECT
-    n.nspname AS table_schema,
-    c.relname AS table_name,
-    a.attname AS column_name,
-    pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type, -- This formats the type into something that should always be a valid postgres type. It also includes constraints if there are any
- COALESCE(
-        pg_catalog.pg_get_expr(d.adbin, d.adrelid),
-        ''
-    )::text AS column_default,
-    CASE
-        WHEN a.attnotnull THEN 'NO'
-        ELSE 'YES'
-    END AS is_nullable,
-    CASE
-        WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
-            a.atttypmod - 4 -- The -4 removes the extra bits that postgres uses for internal use
-        ELSE
-            -1
-    END AS character_maximum_length,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            (a.atttypmod - 4) >> 16
-        -- Precision is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the precision column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            16
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            32
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            64
-        ELSE
-            -1
-    END AS numeric_precision,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            CASE
-                -- If scale is not explicitly set, return -1 (meaning arbitrary scale)
-                WHEN (a.atttypmod) = -1 THEN -1
-                ELSE (a.atttypmod - 4) & 65535
-            END
-        -- Scale is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the scake column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            0
-        ELSE
-            -1
-    END AS numeric_scale,
-    a.attnum AS ordinal_position,
-    a.attgenerated::text as generated_type
-FROM
-    pg_catalog.pg_attribute a
+WITH all_sequences AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    WHERE
+        seq.relkind = 'S'
+),
+linked_to_serial AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid,
+        ad.adrelid,
+        ad.adnum
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    JOIN
+        pg_catalog.pg_depend dep ON dep.objid = seq.oid AND dep.classid = 'pg_catalog.pg_class'::regclass
+    JOIN
+        pg_catalog.pg_attrdef ad ON dep.refobjid = ad.adrelid AND dep.refobjsubid = ad.adnum
+    WHERE
+        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%'
+),
+column_defaults AS (
+    SELECT
+        n.nspname AS schema_name,
+        c.relname AS table_name,
+        a.attname AS column_name,
+        pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+        COALESCE(pg_catalog.pg_get_expr(d.adbin, d.adrelid), '')::text AS column_default,
+        CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+        CASE
+            WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
+                a.atttypmod - 4
+            ELSE
+                -1
+        END AS character_maximum_length,
+        CASE
+            WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
+                (a.atttypmod - 4) >> 16
+            WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
+                16
+            WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
+                32
+            WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
+                64
+            ELSE
+                -1
+        END AS numeric_precision,
+        CASE
+            WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
+                CASE
+                    WHEN (a.atttypmod) = -1 THEN -1
+                    ELSE (a.atttypmod - 4) & 65535
+                END
+            WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
+                0
+            WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
+                0
+            WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
+                0
+            ELSE
+                -1
+        END AS numeric_scale,
+        a.attnum AS ordinal_position,
+        a.attgenerated::text as generated_type,
+        c.oid AS table_oid
+    FROM
+        pg_catalog.pg_attribute a
     INNER JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
     INNER JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-    INNER JOIN pg_catalog.pg_type pgt ON pgt.oid = a.atttypid
     LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
-WHERE
-    n.nspname NOT IN('pg_catalog', 'pg_toast', 'information_schema')
-    AND a.attnum > 0
-    AND NOT a.attisdropped
-    AND c.relkind = 'r' -- ensures only tables are present
+    WHERE
+        n.nspname NOT IN('pg_catalog', 'pg_toast', 'information_schema')
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+        AND c.relkind = 'r'
+)
+SELECT
+    cd.schema_name, cd.table_name, cd.column_name, cd.data_type, cd.column_default, cd.is_nullable, cd.character_maximum_length, cd.numeric_precision, cd.numeric_scale, cd.ordinal_position, cd.generated_type, cd.table_oid,
+    CASE
+        WHEN ls.sequence_oid IS NOT NULL THEN 'SERIAL'
+        WHEN cd.column_default LIKE 'nextval(%::regclass)' THEN 'USER-DEFINED SEQUENCE'
+        ELSE ''
+    END AS sequence_type
+FROM
+    column_defaults cd
+LEFT JOIN linked_to_serial ls
+    ON cd.table_oid = ls.adrelid
+    AND cd.ordinal_position = ls.adnum
 ORDER BY
-    a.attnum
+    cd.ordinal_position
 `
 
 type GetDatabaseSchemaRow struct {
-	TableSchema            string
+	SchemaName             string
 	TableName              string
 	ColumnName             string
 	DataType               string
@@ -470,6 +505,8 @@ type GetDatabaseSchemaRow struct {
 	NumericScale           int32
 	OrdinalPosition        int16
 	GeneratedType          string
+	TableOid               pgtype.Uint32
+	SequenceType           string
 }
 
 func (q *Queries) GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error) {
@@ -482,127 +519,6 @@ func (q *Queries) GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabas
 	for rows.Next() {
 		var i GetDatabaseSchemaRow
 		if err := rows.Scan(
-			&i.TableSchema,
-			&i.TableName,
-			&i.ColumnName,
-			&i.DataType,
-			&i.ColumnDefault,
-			&i.IsNullable,
-			&i.CharacterMaximumLength,
-			&i.NumericPrecision,
-			&i.NumericScale,
-			&i.OrdinalPosition,
-			&i.GeneratedType,
-		); err != nil {
-			return nil, err
-		}
-		items = append(items, &i)
-	}
-	if err := rows.Err(); err != nil {
-		return nil, err
-	}
-	return items, nil
-}
-
-const getDatabaseTableSchema = `-- name: GetDatabaseTableSchema :many
-SELECT
-    n.nspname AS schema_name,
-    c.relname AS table_name,
-    a.attname AS column_name,
-    pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,  -- This formats the type into something that should always be a valid postgres type. It also includes constraints if there are any
- COALESCE(
-        pg_catalog.pg_get_expr(d.adbin, d.adrelid),
-        ''
-    )::text AS column_default,
-    CASE
-        WHEN a.attnotnull THEN 'NO'
-        ELSE 'YES'
-    END AS is_nullable,
-    CASE
-        WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
-            a.atttypmod - 4 -- The -4 removes the extra bits that postgres uses for internal use
-        ELSE
-            -1
-    END AS character_maximum_length,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            (a.atttypmod - 4) >> 16
-        -- Precision is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the precision column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            16
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            32
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            64
-        ELSE
-            -1
-    END AS numeric_precision,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            CASE
-                -- If scale is not explicitly set, return -1 (meaning arbitrary scale)
-                WHEN (a.atttypmod) = -1 THEN -1
-                ELSE (a.atttypmod - 4) & 65535
-            END
-        -- Scale is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the scake column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            0
-        ELSE
-            -1
-    END AS numeric_scale,
-    a.attnum AS ordinal_position,
-    a.attgenerated::text as generated_type
-FROM
-    pg_catalog.pg_attribute a
-    INNER JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
-    INNER JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-    INNER JOIN pg_catalog.pg_type pgt ON pgt.oid = a.atttypid
-    LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
-WHERE
-    c.relname = $1
-    AND n.nspname = $2
-    AND a.attnum > 0
-    AND NOT a.attisdropped
-    AND c.relkind = 'r' -- ensures only tables are present
-ORDER BY
-    a.attnum
-`
-
-type GetDatabaseTableSchemaParams struct {
-	Table  string
-	Schema string
-}
-
-type GetDatabaseTableSchemaRow struct {
-	SchemaName             string
-	TableName              string
-	ColumnName             string
-	DataType               string
-	ColumnDefault          string
-	IsNullable             string
-	CharacterMaximumLength int32
-	NumericPrecision       int32
-	NumericScale           int32
-	OrdinalPosition        int16
-	GeneratedType          string
-}
-
-func (q *Queries) GetDatabaseTableSchema(ctx context.Context, db DBTX, arg *GetDatabaseTableSchemaParams) ([]*GetDatabaseTableSchemaRow, error) {
-	rows, err := db.Query(ctx, getDatabaseTableSchema, arg.Table, arg.Schema)
-	if err != nil {
-		return nil, err
-	}
-	defer rows.Close()
-	var items []*GetDatabaseTableSchemaRow
-	for rows.Next() {
-		var i GetDatabaseTableSchemaRow
-		if err := rows.Scan(
 			&i.SchemaName,
 			&i.TableName,
 			&i.ColumnName,
@@ -614,6 +530,8 @@ func (q *Queries) GetDatabaseTableSchema(ctx context.Context, db DBTX, arg *GetD
 			&i.NumericScale,
 			&i.OrdinalPosition,
 			&i.GeneratedType,
+			&i.TableOid,
+			&i.SequenceType,
 		); err != nil {
 			return nil, err
 		}
@@ -626,72 +544,105 @@ func (q *Queries) GetDatabaseTableSchema(ctx context.Context, db DBTX, arg *GetD
 }
 
 const getDatabaseTableSchemasBySchemasAndTables = `-- name: GetDatabaseTableSchemasBySchemasAndTables :many
-SELECT
-    n.nspname AS schema_name,
-    c.relname AS table_name,
-    a.attname AS column_name,
-    pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,  -- This formats the type into something that should always be a valid postgres type. It also includes constraints if there are any
- COALESCE(
-        pg_catalog.pg_get_expr(d.adbin, d.adrelid),
-        ''
-    )::text AS column_default,
-    CASE
-        WHEN a.attnotnull THEN 'NO'
-        ELSE 'YES'
-    END AS is_nullable,
-    CASE
-        WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
-            a.atttypmod - 4 -- The -4 removes the extra bits that postgres uses for internal use
-        ELSE
-            -1
-    END AS character_maximum_length,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            (a.atttypmod - 4) >> 16
-        -- Precision is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the precision column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            16
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            32
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            64
-        ELSE
-            -1
-    END AS numeric_precision,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            CASE
-                -- If scale is not explicitly set, return -1 (meaning arbitrary scale)
-                WHEN (a.atttypmod) = -1 THEN -1
-                ELSE (a.atttypmod - 4) & 65535
-            END
-        -- Scale is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the scake column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            0
-        ELSE
-            -1
-    END AS numeric_scale,
-    a.attnum AS ordinal_position,
-    a.attgenerated::text as generated_type
-FROM
-    pg_catalog.pg_attribute a
+WITH all_sequences AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    WHERE
+        seq.relkind = 'S'
+),
+linked_to_serial AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid,
+        ad.adrelid,
+        ad.adnum
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    JOIN
+        pg_catalog.pg_depend dep ON dep.objid = seq.oid AND dep.classid = 'pg_catalog.pg_class'::regclass
+    JOIN
+        pg_catalog.pg_attrdef ad ON dep.refobjid = ad.adrelid AND dep.refobjsubid = ad.adnum
+    WHERE
+        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%'
+),
+column_defaults AS (
+    SELECT
+        n.nspname AS schema_name,
+        c.relname AS table_name,
+        a.attname AS column_name,
+        pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+        COALESCE(pg_catalog.pg_get_expr(d.adbin, d.adrelid), '')::text AS column_default,
+        CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+        CASE
+            WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
+                a.atttypmod - 4
+            ELSE
+                -1
+        END AS character_maximum_length,
+        CASE
+            WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
+                (a.atttypmod - 4) >> 16
+            WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
+                16
+            WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
+                32
+            WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
+                64
+            ELSE
+                -1
+        END AS numeric_precision,
+        CASE
+            WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
+                CASE
+                    WHEN (a.atttypmod) = -1 THEN -1
+                    ELSE (a.atttypmod - 4) & 65535
+                END
+            WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
+                0
+            WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
+                0
+            WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
+                0
+            ELSE
+                -1
+        END AS numeric_scale,
+        a.attnum AS ordinal_position,
+        a.attgenerated::text as generated_type,
+        c.oid AS table_oid
+    FROM
+        pg_catalog.pg_attribute a
     INNER JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
     INNER JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-    INNER JOIN pg_catalog.pg_type pgt ON pgt.oid = a.atttypid
     LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
-WHERE
-    (n.nspname || '.' || c.relname) = ANY($1::TEXT[])
-    AND a.attnum > 0
-    AND NOT a.attisdropped
-    AND c.relkind = 'r' -- ensures only tables are present
+    WHERE
+        (n.nspname || '.' || c.relname) = ANY($1::TEXT[])
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+        AND c.relkind = 'r'
+)
+SELECT
+    cd.schema_name, cd.table_name, cd.column_name, cd.data_type, cd.column_default, cd.is_nullable, cd.character_maximum_length, cd.numeric_precision, cd.numeric_scale, cd.ordinal_position, cd.generated_type, cd.table_oid,
+    CASE
+        WHEN ls.sequence_oid IS NOT NULL THEN 'SERIAL'
+        WHEN cd.column_default LIKE 'nextval(%::regclass)' THEN 'USER-DEFINED SEQUENCE'
+        ELSE ''
+    END AS sequence_type
+FROM
+    column_defaults cd
+LEFT JOIN linked_to_serial ls
+    ON cd.table_oid = ls.adrelid
+    AND cd.ordinal_position = ls.adnum
 ORDER BY
-    a.attnum
+    cd.ordinal_position
 `
 
 type GetDatabaseTableSchemasBySchemasAndTablesRow struct {
@@ -706,6 +657,8 @@ type GetDatabaseTableSchemasBySchemasAndTablesRow struct {
 	NumericScale           int32
 	OrdinalPosition        int16
 	GeneratedType          string
+	TableOid               pgtype.Uint32
+	SequenceType           string
 }
 
 func (q *Queries) GetDatabaseTableSchemasBySchemasAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetDatabaseTableSchemasBySchemasAndTablesRow, error) {
@@ -729,6 +682,8 @@ func (q *Queries) GetDatabaseTableSchemasBySchemasAndTables(ctx context.Context,
 			&i.NumericScale,
 			&i.OrdinalPosition,
 			&i.GeneratedType,
+			&i.TableOid,
+			&i.SequenceType,
 		); err != nil {
 			return nil, err
 		}

--- a/backend/gen/go/db/dbschemas/postgresql/system.sql.go
+++ b/backend/gen/go/db/dbschemas/postgresql/system.sql.go
@@ -65,6 +65,103 @@ func (q *Queries) GetCustomFunctionsBySchemaAndTables(ctx context.Context, db DB
 	return items, nil
 }
 
+const getCustomSequencesBySchemaAndTables = `-- name: GetCustomSequencesBySchemaAndTables :many
+WITH relevant_schemas_tables AS (
+    SELECT c.oid, n.nspname AS schema_name, c.relname AS table_name
+    FROM pg_catalog.pg_class c
+    JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    WHERE n.nspname = 'public'  -- replace with your schema name
+    AND c.relname IN ('test_table')  -- replace with your table names
+),
+all_sequences AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    WHERE
+        seq.relkind = 'S'
+),
+linked_to_serial AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    JOIN
+        pg_catalog.pg_depend dep ON dep.objid = seq.oid AND dep.classid = 'pg_catalog.pg_class'::regclass
+    JOIN
+        pg_catalog.pg_attrdef ad ON dep.refobjid = ad.adrelid AND dep.refobjsubid = ad.adnum
+    WHERE
+        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%'
+),
+custom_sequences AS (
+    SELECT
+        seq.sequence_name,
+        seq.schema_name,
+        seq.sequence_oid
+    FROM
+        all_sequences seq
+    LEFT JOIN
+        linked_to_serial serial ON seq.sequence_oid = serial.sequence_oid
+    WHERE
+        serial.sequence_oid IS NULL
+)
+SELECT DISTINCT
+    cs.schema_name,
+    cs.sequence_name,
+    (
+        'CREATE SEQUENCE ' || cs.schema_name || '.' || cs.sequence_name ||
+        ' START WITH ' || seqs.start_value ||
+        ' INCREMENT BY ' || seqs.increment_by ||
+        ' MINVALUE ' || seqs.min_value ||
+        ' MAXVALUE ' || seqs.max_value ||
+        ' CACHE ' || seqs.cache_size ||
+        CASE WHEN seqs.cycle THEN ' CYCLE' ELSE ' NO CYCLE' END || ';'
+    )::text AS "definition"
+FROM
+    custom_sequences cs
+JOIN
+    relevant_schemas_tables rst ON cs.schema_name = rst.schema_name
+JOIN
+    pg_catalog.pg_sequences seqs ON seqs.schemaname = cs.schema_name AND seqs.sequencename = cs.sequence_name
+ORDER BY
+    cs.schema_name,
+    cs.sequence_name
+`
+
+type GetCustomSequencesBySchemaAndTablesRow struct {
+	SchemaName   string
+	SequenceName string
+	Definition   string
+}
+
+func (q *Queries) GetCustomSequencesBySchemaAndTables(ctx context.Context, db DBTX) ([]*GetCustomSequencesBySchemaAndTablesRow, error) {
+	rows, err := db.Query(ctx, getCustomSequencesBySchemaAndTables)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var items []*GetCustomSequencesBySchemaAndTablesRow
+	for rows.Next() {
+		var i GetCustomSequencesBySchemaAndTablesRow
+		if err := rows.Scan(&i.SchemaName, &i.SequenceName, &i.Definition); err != nil {
+			return nil, err
+		}
+		items = append(items, &i)
+	}
+	if err := rows.Err(); err != nil {
+		return nil, err
+	}
+	return items, nil
+}
+
 const getCustomTriggersBySchemaAndTables = `-- name: GetCustomTriggersBySchemaAndTables :many
 WITH relevant_schemas_tables AS (
     SELECT c.oid, n.nspname AS schema_name, c.relname AS table_name

--- a/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
@@ -1,207 +1,204 @@
 -- name: GetDatabaseSchema :many
-SELECT
-    n.nspname AS table_schema,
-    c.relname AS table_name,
-    a.attname AS column_name,
-    pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type, -- This formats the type into something that should always be a valid postgres type. It also includes constraints if there are any
- COALESCE(
-        pg_catalog.pg_get_expr(d.adbin, d.adrelid),
-        ''
-    )::text AS column_default,
-    CASE
-        WHEN a.attnotnull THEN 'NO'
-        ELSE 'YES'
-    END AS is_nullable,
-    CASE
-        WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
-            a.atttypmod - 4 -- The -4 removes the extra bits that postgres uses for internal use
-        ELSE
-            -1
-    END AS character_maximum_length,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            (a.atttypmod - 4) >> 16
-        -- Precision is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the precision column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            16
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            32
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            64
-        ELSE
-            -1
-    END AS numeric_precision,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            CASE
-                -- If scale is not explicitly set, return -1 (meaning arbitrary scale)
-                WHEN (a.atttypmod) = -1 THEN -1
-                ELSE (a.atttypmod - 4) & 65535
-            END
-        -- Scale is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the scake column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            0
-        ELSE
-            -1
-    END AS numeric_scale,
-    a.attnum AS ordinal_position,
-    a.attgenerated::text as generated_type
-FROM
-    pg_catalog.pg_attribute a
+WITH all_sequences AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    WHERE
+        seq.relkind = 'S'
+),
+linked_to_serial AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid,
+        ad.adrelid,
+        ad.adnum
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    JOIN
+        pg_catalog.pg_depend dep ON dep.objid = seq.oid AND dep.classid = 'pg_catalog.pg_class'::regclass
+    JOIN
+        pg_catalog.pg_attrdef ad ON dep.refobjid = ad.adrelid AND dep.refobjsubid = ad.adnum
+    WHERE
+        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%'
+),
+column_defaults AS (
+    SELECT
+        n.nspname AS schema_name,
+        c.relname AS table_name,
+        a.attname AS column_name,
+        pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+        COALESCE(pg_catalog.pg_get_expr(d.adbin, d.adrelid), '')::text AS column_default,
+        CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+        CASE
+            WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
+                a.atttypmod - 4
+            ELSE
+                -1
+        END AS character_maximum_length,
+        CASE
+            WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
+                (a.atttypmod - 4) >> 16
+            WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
+                16
+            WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
+                32
+            WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
+                64
+            ELSE
+                -1
+        END AS numeric_precision,
+        CASE
+            WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
+                CASE
+                    WHEN (a.atttypmod) = -1 THEN -1
+                    ELSE (a.atttypmod - 4) & 65535
+                END
+            WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
+                0
+            WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
+                0
+            WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
+                0
+            ELSE
+                -1
+        END AS numeric_scale,
+        a.attnum AS ordinal_position,
+        a.attgenerated::text as generated_type,
+        c.oid AS table_oid
+    FROM
+        pg_catalog.pg_attribute a
     INNER JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
     INNER JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-    INNER JOIN pg_catalog.pg_type pgt ON pgt.oid = a.atttypid
     LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
-WHERE
-    n.nspname NOT IN('pg_catalog', 'pg_toast', 'information_schema')
-    AND a.attnum > 0
-    AND NOT a.attisdropped
-    AND c.relkind = 'r' -- ensures only tables are present
-ORDER BY
-    a.attnum;
-
--- name: GetDatabaseTableSchema :many
+    WHERE
+        n.nspname NOT IN('pg_catalog', 'pg_toast', 'information_schema')
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+        AND c.relkind = 'r'
+)
 SELECT
-    n.nspname AS schema_name,
-    c.relname AS table_name,
-    a.attname AS column_name,
-    pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,  -- This formats the type into something that should always be a valid postgres type. It also includes constraints if there are any
- COALESCE(
-        pg_catalog.pg_get_expr(d.adbin, d.adrelid),
-        ''
-    )::text AS column_default,
+    cd.*,
     CASE
-        WHEN a.attnotnull THEN 'NO'
-        ELSE 'YES'
-    END AS is_nullable,
-    CASE
-        WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
-            a.atttypmod - 4 -- The -4 removes the extra bits that postgres uses for internal use
-        ELSE
-            -1
-    END AS character_maximum_length,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            (a.atttypmod - 4) >> 16
-        -- Precision is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the precision column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            16
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            32
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            64
-        ELSE
-            -1
-    END AS numeric_precision,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            CASE
-                -- If scale is not explicitly set, return -1 (meaning arbitrary scale)
-                WHEN (a.atttypmod) = -1 THEN -1
-                ELSE (a.atttypmod - 4) & 65535
-            END
-        -- Scale is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the scake column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            0
-        ELSE
-            -1
-    END AS numeric_scale,
-    a.attnum AS ordinal_position,
-    a.attgenerated::text as generated_type
+        WHEN ls.sequence_oid IS NOT NULL THEN 'SERIAL'
+        WHEN cd.column_default LIKE 'nextval(%::regclass)' THEN 'USER-DEFINED SEQUENCE'
+        ELSE ''
+    END AS sequence_type
 FROM
-    pg_catalog.pg_attribute a
-    INNER JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
-    INNER JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-    INNER JOIN pg_catalog.pg_type pgt ON pgt.oid = a.atttypid
-    LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
-WHERE
-    c.relname = sqlc.arg('table')
-    AND n.nspname = sqlc.arg('schema')
-    AND a.attnum > 0
-    AND NOT a.attisdropped
-    AND c.relkind = 'r' -- ensures only tables are present
+    column_defaults cd
+LEFT JOIN linked_to_serial ls
+    ON cd.table_oid = ls.adrelid
+    AND cd.ordinal_position = ls.adnum
 ORDER BY
-    a.attnum;
+    cd.ordinal_position;
 
 -- name: GetDatabaseTableSchemasBySchemasAndTables :many
-SELECT
-    n.nspname AS schema_name,
-    c.relname AS table_name,
-    a.attname AS column_name,
-    pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,  -- This formats the type into something that should always be a valid postgres type. It also includes constraints if there are any
- COALESCE(
-        pg_catalog.pg_get_expr(d.adbin, d.adrelid),
-        ''
-    )::text AS column_default,
-    CASE
-        WHEN a.attnotnull THEN 'NO'
-        ELSE 'YES'
-    END AS is_nullable,
-    CASE
-        WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
-            a.atttypmod - 4 -- The -4 removes the extra bits that postgres uses for internal use
-        ELSE
-            -1
-    END AS character_maximum_length,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            (a.atttypmod - 4) >> 16
-        -- Precision is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the precision column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            16
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            32
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            64
-        ELSE
-            -1
-    END AS numeric_precision,
-    CASE
-        WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
-            CASE
-                -- If scale is not explicitly set, return -1 (meaning arbitrary scale)
-                WHEN (a.atttypmod) = -1 THEN -1
-                ELSE (a.atttypmod - 4) & 65535
-            END
-        -- Scale is technically only necessary for numeric values, but we are populating these here for simplicity in knowing what the type of integer is.
-        -- This operates similar to the scake column in the information_schema.columns table
-        WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
-            0
-        WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
-            0
-        ELSE
-            -1
-    END AS numeric_scale,
-    a.attnum AS ordinal_position,
-    a.attgenerated::text as generated_type
-FROM
-    pg_catalog.pg_attribute a
+WITH all_sequences AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    WHERE
+        seq.relkind = 'S'
+),
+linked_to_serial AS (
+    SELECT
+        seq.relname AS sequence_name,
+        nsp.nspname AS schema_name,
+        seq.oid AS sequence_oid,
+        ad.adrelid,
+        ad.adnum
+    FROM
+        pg_catalog.pg_class seq
+    JOIN
+        pg_catalog.pg_namespace nsp ON seq.relnamespace = nsp.oid
+    JOIN
+        pg_catalog.pg_depend dep ON dep.objid = seq.oid AND dep.classid = 'pg_catalog.pg_class'::regclass
+    JOIN
+        pg_catalog.pg_attrdef ad ON dep.refobjid = ad.adrelid AND dep.refobjsubid = ad.adnum
+    WHERE
+        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%'
+),
+column_defaults AS (
+    SELECT
+        n.nspname AS schema_name,
+        c.relname AS table_name,
+        a.attname AS column_name,
+        pg_catalog.format_type(a.atttypid, a.atttypmod) AS data_type,
+        COALESCE(pg_catalog.pg_get_expr(d.adbin, d.adrelid), '')::text AS column_default,
+        CASE WHEN a.attnotnull THEN 'NO' ELSE 'YES' END AS is_nullable,
+        CASE
+            WHEN pg_catalog.format_type(a.atttypid, a.atttypmod) LIKE 'character varying%' THEN
+                a.atttypmod - 4
+            ELSE
+                -1
+        END AS character_maximum_length,
+        CASE
+            WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
+                (a.atttypmod - 4) >> 16
+            WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
+                16
+            WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
+                32
+            WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
+                64
+            ELSE
+                -1
+        END AS numeric_precision,
+        CASE
+            WHEN a.atttypid = pg_catalog.regtype 'numeric'::regtype THEN
+                CASE
+                    WHEN (a.atttypmod) = -1 THEN -1
+                    ELSE (a.atttypmod - 4) & 65535
+                END
+            WHEN a.atttypid = pg_catalog.regtype 'smallint'::regtype THEN
+                0
+            WHEN a.atttypid = pg_catalog.regtype 'integer'::regtype THEN
+                0
+            WHEN a.atttypid = pg_catalog.regtype 'bigint'::regtype THEN
+                0
+            ELSE
+                -1
+        END AS numeric_scale,
+        a.attnum AS ordinal_position,
+        a.attgenerated::text as generated_type,
+        c.oid AS table_oid
+    FROM
+        pg_catalog.pg_attribute a
     INNER JOIN pg_catalog.pg_class c ON a.attrelid = c.oid
     INNER JOIN pg_catalog.pg_namespace n ON c.relnamespace = n.oid
-    INNER JOIN pg_catalog.pg_type pgt ON pgt.oid = a.atttypid
     LEFT JOIN pg_catalog.pg_attrdef d ON d.adrelid = a.attrelid AND d.adnum = a.attnum
-WHERE
-    (n.nspname || '.' || c.relname) = ANY(sqlc.arg('schematables')::TEXT[])
-    AND a.attnum > 0
-    AND NOT a.attisdropped
-    AND c.relkind = 'r' -- ensures only tables are present
+    WHERE
+        (n.nspname || '.' || c.relname) = ANY(sqlc.arg('schematables')::TEXT[])
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+        AND c.relkind = 'r'
+)
+SELECT
+    cd.*,
+    CASE
+        WHEN ls.sequence_oid IS NOT NULL THEN 'SERIAL'
+        WHEN cd.column_default LIKE 'nextval(%::regclass)' THEN 'USER-DEFINED SEQUENCE'
+        ELSE ''
+    END AS sequence_type
+FROM
+    column_defaults cd
+LEFT JOIN linked_to_serial ls
+    ON cd.table_oid = ls.adrelid
+    AND cd.ordinal_position = ls.adnum
 ORDER BY
-    a.attnum;
+    cd.ordinal_position;
 
 -- name: GetTableConstraints :many
 SELECT
@@ -374,7 +371,7 @@ WITH custom_types AS (
     JOIN
         pg_catalog.pg_namespace n ON n.oid = t.typnamespace
     WHERE
-        n.nspname = 'public'
+        n.nspname = sqlc.arg('schema')
         AND t.typtype IN ('d', 'e', 'c')
 ),
 table_columns AS (
@@ -389,7 +386,7 @@ table_columns AS (
         pg_catalog.pg_attribute a ON a.attrelid = c.oid
     WHERE
         n.nspname = sqlc.arg('schema')
-        AND c.relname IN (sqlc.arg('tables')::TEXT[])
+        AND c.relname = ANY(sqlc.arg('tables')::TEXT[])
         AND a.attnum > 0
         AND NOT a.attisdropped
 ),
@@ -494,7 +491,7 @@ WITH relevant_schemas_tables AS (
     FROM pg_catalog.pg_class c
     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname = sqlc.arg('schema')
-    AND c.relname IN (sqlc.arg('tables')::TEXT[])
+    AND c.relname = ANY(sqlc.arg('tables')::TEXT[])
 ),
 trigger_functions AS (
     SELECT DISTINCT
@@ -539,7 +536,7 @@ WITH relevant_schemas_tables AS (
     FROM pg_catalog.pg_class c
     JOIN pg_catalog.pg_namespace n ON n.oid = c.relnamespace
     WHERE n.nspname = sqlc.arg('schema')
-    AND c.relname IN (sqlc.arg('tables')::TEXT[])
+    AND c.relname = ANY(sqlc.arg('tables')::TEXT[])
 ),
 all_sequences AS (
     SELECT

--- a/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
@@ -497,7 +497,8 @@ trigger_functions AS (
     SELECT DISTINCT
         n.nspname AS schema_name,
         p.proname AS function_name,
-        pg_catalog.pg_get_functiondef(p.oid) AS definition
+        pg_catalog.pg_get_functiondef(p.oid) AS definition,
+        pg_catalog.pg_get_function_identity_arguments(p.oid) AS function_signature
     FROM pg_catalog.pg_trigger t
     JOIN pg_catalog.pg_proc p ON t.tgfoid = p.oid
     JOIN pg_catalog.pg_namespace n ON n.oid = p.pronamespace
@@ -507,6 +508,7 @@ trigger_functions AS (
 SELECT
     schema_name,
     function_name,
+    function_signature,
     definition
 FROM
     trigger_functions

--- a/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
@@ -357,3 +357,133 @@ ORDER BY
     schema_name,
     table_name,
     index_name;
+
+-- name: GetDataTypesBySchemaAndTables :many
+WITH custom_types AS (
+    SELECT
+        n.nspname AS schema_name,
+        t.typname AS type_name,
+        t.oid AS type_oid,
+        CASE
+            WHEN t.typtype = 'd' THEN 'domain'
+            WHEN t.typtype = 'e' THEN 'enum'
+            WHEN t.typtype = 'c' THEN 'composite'
+        END AS type
+    FROM
+        pg_catalog.pg_type t
+    JOIN
+        pg_catalog.pg_namespace n ON n.oid = t.typnamespace
+    WHERE
+        n.nspname = 'public'
+        AND t.typtype IN ('d', 'e', 'c')
+),
+table_columns AS (
+    SELECT
+        c.oid AS table_oid,
+        a.atttypid AS type_oid
+    FROM
+        pg_catalog.pg_class c
+    JOIN
+        pg_catalog.pg_namespace n ON n.oid = c.relnamespace
+    JOIN
+        pg_catalog.pg_attribute a ON a.attrelid = c.oid
+    WHERE
+        n.nspname = 'public'
+        AND c.relname IN ('example_table') -- replace with your table names
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+),
+relevant_custom_types AS (
+    SELECT DISTINCT
+        ct.schema_name,
+        ct.type_name,
+        ct.type_oid,
+        ct.type
+    FROM
+        custom_types ct
+    JOIN
+        table_columns tc ON ct.type_oid = tc.type_oid
+),
+domain_defs AS (
+    SELECT
+        rct.schema_name,
+        rct.type_name,
+        rct.type,
+        'CREATE DOMAIN ' || rct.schema_name || '.' || rct.type_name || ' AS ' ||
+        pg_catalog.format_type(t.typbasetype, t.typtypmod) ||
+        CASE
+            WHEN t.typnotnull THEN ' NOT NULL' ELSE ''
+        END || ' ' ||
+        COALESCE('CONSTRAINT ' || conname || ' ' || pg_catalog.pg_get_constraintdef(c.oid), '') || ';' AS definition
+    FROM
+        relevant_custom_types rct
+    JOIN
+        pg_catalog.pg_type t ON rct.type_oid = t.oid
+    LEFT JOIN
+        pg_catalog.pg_constraint c ON t.oid = c.contypid
+    WHERE
+        rct.type = 'domain'
+),
+enum_defs AS (
+    SELECT
+        rct.schema_name,
+        rct.type_name,
+        rct.type,
+        'CREATE TYPE ' || rct.schema_name || '.' || rct.type_name || ' AS ENUM (' ||
+        string_agg('''' || e.enumlabel || '''', ', ') || ');' AS definition
+    FROM
+        relevant_custom_types rct
+    JOIN
+        pg_catalog.pg_type t ON rct.type_oid = t.oid
+    JOIN
+        pg_catalog.pg_enum e ON t.oid = e.enumtypid
+    WHERE
+        rct.type = 'enum'
+    GROUP BY
+        rct.schema_name, rct.type_name, rct.type
+),
+composite_defs AS (
+    SELECT
+        rct.schema_name,
+        rct.type_name,
+        rct.type,
+        'CREATE TYPE ' || rct.schema_name || '.' || rct.type_name || ' AS (' ||
+        string_agg(a.attname || ' ' || pg_catalog.format_type(a.atttypid, a.atttypmod), ', ') || ');' AS definition
+    FROM
+        relevant_custom_types rct
+    JOIN
+        pg_catalog.pg_type t ON rct.type_oid = t.oid
+    JOIN
+        pg_catalog.pg_class c ON c.oid = t.typrelid
+    JOIN
+        pg_catalog.pg_attribute a ON a.attrelid = c.oid
+    WHERE
+        rct.type = 'composite'
+        AND a.attnum > 0
+        AND NOT a.attisdropped
+    GROUP BY
+        rct.schema_name, rct.type_name, rct.type
+)
+SELECT
+    schema_name,
+    type_name,
+    "type"::text,
+    "definition"::text
+FROM
+    domain_defs
+UNION ALL
+SELECT
+    schema_name,
+    type_name,
+    "type"::text,
+    "definition"::text
+FROM
+    enum_defs
+UNION ALL
+SELECT
+    schema_name,
+    type_name,
+    "type"::text,
+    "definition"::text
+FROM
+    composite_defs;

--- a/backend/pkg/sqlmanager/mock_SqlDatabase.go
+++ b/backend/pkg/sqlmanager/mock_SqlDatabase.go
@@ -618,6 +618,124 @@ func (_c *MockSqlDatabase_GetSchemaColumnMap_Call) RunAndReturn(run func(context
 	return _c
 }
 
+// GetSchemaTableDataTypes provides a mock function with given fields: ctx, tables
+func (_m *MockSqlDatabase) GetSchemaTableDataTypes(ctx context.Context, tables []*SchemaTable) (*SchemaTableDataTypeResponse, error) {
+	ret := _m.Called(ctx, tables)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSchemaTableDataTypes")
+	}
+
+	var r0 *SchemaTableDataTypeResponse
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []*SchemaTable) (*SchemaTableDataTypeResponse, error)); ok {
+		return rf(ctx, tables)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []*SchemaTable) *SchemaTableDataTypeResponse); ok {
+		r0 = rf(ctx, tables)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).(*SchemaTableDataTypeResponse)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []*SchemaTable) error); ok {
+		r1 = rf(ctx, tables)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockSqlDatabase_GetSchemaTableDataTypes_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSchemaTableDataTypes'
+type MockSqlDatabase_GetSchemaTableDataTypes_Call struct {
+	*mock.Call
+}
+
+// GetSchemaTableDataTypes is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tables []*SchemaTable
+func (_e *MockSqlDatabase_Expecter) GetSchemaTableDataTypes(ctx interface{}, tables interface{}) *MockSqlDatabase_GetSchemaTableDataTypes_Call {
+	return &MockSqlDatabase_GetSchemaTableDataTypes_Call{Call: _e.mock.On("GetSchemaTableDataTypes", ctx, tables)}
+}
+
+func (_c *MockSqlDatabase_GetSchemaTableDataTypes_Call) Run(run func(ctx context.Context, tables []*SchemaTable)) *MockSqlDatabase_GetSchemaTableDataTypes_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]*SchemaTable))
+	})
+	return _c
+}
+
+func (_c *MockSqlDatabase_GetSchemaTableDataTypes_Call) Return(_a0 *SchemaTableDataTypeResponse, _a1 error) *MockSqlDatabase_GetSchemaTableDataTypes_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockSqlDatabase_GetSchemaTableDataTypes_Call) RunAndReturn(run func(context.Context, []*SchemaTable) (*SchemaTableDataTypeResponse, error)) *MockSqlDatabase_GetSchemaTableDataTypes_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
+// GetSchemaTableTriggers provides a mock function with given fields: ctx, tables
+func (_m *MockSqlDatabase) GetSchemaTableTriggers(ctx context.Context, tables []*SchemaTable) ([]*TableTrigger, error) {
+	ret := _m.Called(ctx, tables)
+
+	if len(ret) == 0 {
+		panic("no return value specified for GetSchemaTableTriggers")
+	}
+
+	var r0 []*TableTrigger
+	var r1 error
+	if rf, ok := ret.Get(0).(func(context.Context, []*SchemaTable) ([]*TableTrigger, error)); ok {
+		return rf(ctx, tables)
+	}
+	if rf, ok := ret.Get(0).(func(context.Context, []*SchemaTable) []*TableTrigger); ok {
+		r0 = rf(ctx, tables)
+	} else {
+		if ret.Get(0) != nil {
+			r0 = ret.Get(0).([]*TableTrigger)
+		}
+	}
+
+	if rf, ok := ret.Get(1).(func(context.Context, []*SchemaTable) error); ok {
+		r1 = rf(ctx, tables)
+	} else {
+		r1 = ret.Error(1)
+	}
+
+	return r0, r1
+}
+
+// MockSqlDatabase_GetSchemaTableTriggers_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'GetSchemaTableTriggers'
+type MockSqlDatabase_GetSchemaTableTriggers_Call struct {
+	*mock.Call
+}
+
+// GetSchemaTableTriggers is a helper method to define mock.On call
+//   - ctx context.Context
+//   - tables []*SchemaTable
+func (_e *MockSqlDatabase_Expecter) GetSchemaTableTriggers(ctx interface{}, tables interface{}) *MockSqlDatabase_GetSchemaTableTriggers_Call {
+	return &MockSqlDatabase_GetSchemaTableTriggers_Call{Call: _e.mock.On("GetSchemaTableTriggers", ctx, tables)}
+}
+
+func (_c *MockSqlDatabase_GetSchemaTableTriggers_Call) Run(run func(ctx context.Context, tables []*SchemaTable)) *MockSqlDatabase_GetSchemaTableTriggers_Call {
+	_c.Call.Run(func(args mock.Arguments) {
+		run(args[0].(context.Context), args[1].([]*SchemaTable))
+	})
+	return _c
+}
+
+func (_c *MockSqlDatabase_GetSchemaTableTriggers_Call) Return(_a0 []*TableTrigger, _a1 error) *MockSqlDatabase_GetSchemaTableTriggers_Call {
+	_c.Call.Return(_a0, _a1)
+	return _c
+}
+
+func (_c *MockSqlDatabase_GetSchemaTableTriggers_Call) RunAndReturn(run func(context.Context, []*SchemaTable) ([]*TableTrigger, error)) *MockSqlDatabase_GetSchemaTableTriggers_Call {
+	_c.Call.Return(run)
+	return _c
+}
+
 // GetTableConstraintsBySchema provides a mock function with given fields: ctx, schemas
 func (_m *MockSqlDatabase) GetTableConstraintsBySchema(ctx context.Context, schemas []string) (*TableConstraints, error) {
 	ret := _m.Called(ctx, schemas)

--- a/backend/pkg/sqlmanager/mysql-manager.go
+++ b/backend/pkg/sqlmanager/mysql-manager.go
@@ -284,6 +284,16 @@ func (m *MysqlManager) GetTableInitStatements(ctx context.Context, tables []*Sch
 	return nil, errors.ErrUnsupported
 }
 
+// todo
+func (m *MysqlManager) GetSchemaTableDataTypes(ctx context.Context, tables []*SchemaTable) (*SchemaTableDataTypeResponse, error) {
+	return nil, errors.ErrUnsupported
+}
+
+// todo
+func (m *MysqlManager) GetSchemaTableTriggers(ctx context.Context, tables []*SchemaTable) ([]*TableTrigger, error) {
+	return nil, errors.ErrUnsupported
+}
+
 func (m *MysqlManager) GetCreateTableStatement(ctx context.Context, schema, table string) (string, error) {
 	result, err := getShowTableCreate(ctx, m.pool, schema, table)
 	if err != nil {

--- a/backend/pkg/sqlmanager/postgres-manager.go
+++ b/backend/pkg/sqlmanager/postgres-manager.go
@@ -794,6 +794,7 @@ END $$;
 	return strings.TrimSpace(stmt)
 }
 
+//nolint:unparam
 func addSuffixIfNotExist(input, suffix string) string {
 	if !strings.HasSuffix(input, suffix) {
 		return fmt.Sprintf("%s%s", input, suffix)

--- a/backend/pkg/sqlmanager/postgres-manager.go
+++ b/backend/pkg/sqlmanager/postgres-manager.go
@@ -627,7 +627,7 @@ func (p *PostgresManager) GetTableInitStatements(ctx context.Context, tables []*
 				DataType:      td.DataType,
 				IsNullable:    td.IsNullable == "YES",
 				GeneratedType: td.GeneratedType,
-				IsSerial:      td.SequenceType == "SERIAL",
+				IsSerial:      td.SequenceType == "SERIAL", //nolint:goconst
 			}))
 		}
 

--- a/backend/pkg/sqlmanager/postgres-manager.go
+++ b/backend/pkg/sqlmanager/postgres-manager.go
@@ -384,6 +384,31 @@ type SchemaTableDataTypeResponse struct {
 	Domains    []*DataType
 }
 
+func (s *SchemaTableDataTypeResponse) GetStatements() []string {
+	output := []string{}
+
+	if s == nil {
+		return output
+	}
+
+	for _, seq := range s.Sequences {
+		output = append(output, seq.Definition)
+	}
+	for _, fn := range s.Functions {
+		output = append(output, fn.Definition)
+	}
+	for _, comp := range s.Composites {
+		output = append(output, comp.Definition)
+	}
+	for _, enumeration := range s.Enums {
+		output = append(output, enumeration.Definition)
+	}
+	for _, domain := range s.Domains {
+		output = append(output, domain.Definition)
+	}
+	return output
+}
+
 // Returns ansilary dependencies like sequences, datatypes, functions, etc that are used by tables, but live at the schema level
 func (p *PostgresManager) GetSchemaTableDataTypes(ctx context.Context, tables []*SchemaTable) (*SchemaTableDataTypeResponse, error) {
 	if len(tables) == 0 {

--- a/backend/pkg/sqlmanager/postgres-manager_test.go
+++ b/backend/pkg/sqlmanager/postgres-manager_test.go
@@ -506,6 +506,7 @@ func Test_GenerateCreateTableStatement(t *testing.T) {
 					OrdinalPosition: 1,
 					IsNullable:      "NO",
 					ColumnDefault:   "nextval('users_id_seq'::regclass)",
+					SequenceType:    "SERIAL",
 				},
 				{
 					ColumnName:      "id2",
@@ -513,6 +514,7 @@ func Test_GenerateCreateTableStatement(t *testing.T) {
 					OrdinalPosition: 2,
 					IsNullable:      "NO",
 					ColumnDefault:   "nextval('users_id2_seq'::regclass)",
+					SequenceType:    "SERIAL",
 				},
 				{
 					ColumnName:      "id3",
@@ -520,6 +522,7 @@ func Test_GenerateCreateTableStatement(t *testing.T) {
 					OrdinalPosition: 3,
 					IsNullable:      "NO",
 					ColumnDefault:   "nextval('users_id3_seq'::regclass)",
+					SequenceType:    "SERIAL",
 				},
 			},
 			constraints: []*pg_queries.GetTableConstraintsRow{},

--- a/backend/pkg/sqlmanager/postgres-manager_test.go
+++ b/backend/pkg/sqlmanager/postgres-manager_test.go
@@ -32,7 +32,7 @@ func Test_GetDatabaseSchema(t *testing.T) {
 	pgquerier.On("GetDatabaseSchema", mock.Anything, mockPool).Return(
 		[]*pg_queries.GetDatabaseSchemaRow{
 			{
-				TableSchema:            "public",
+				SchemaName:             "public",
 				TableName:              "users",
 				ColumnName:             "id",
 				DataType:               "varchar",
@@ -44,7 +44,7 @@ func Test_GetDatabaseSchema(t *testing.T) {
 				OrdinalPosition:        4,
 			},
 			{
-				TableSchema:            "public",
+				SchemaName:             "public",
 				TableName:              "orders",
 				ColumnName:             "buyer_id",
 				DataType:               "integer",
@@ -273,11 +273,8 @@ func Test_GetCreateTableStatement(t *testing.T) {
 		pool:    mockPool,
 	}
 
-	pgquerier.On("GetDatabaseTableSchema", mock.Anything, mockPool, &pg_queries.GetDatabaseTableSchemaParams{
-		Schema: "public",
-		Table:  "users",
-	}).Return(
-		[]*pg_queries.GetDatabaseTableSchemaRow{
+	pgquerier.On("GetDatabaseTableSchemasBySchemasAndTables", mock.Anything, mockPool, []string{"public.users"}).Return(
+		[]*pg_queries.GetDatabaseTableSchemasBySchemasAndTablesRow{
 			{
 				SchemaName:             "public",
 				TableName:              "users",
@@ -289,6 +286,7 @@ func Test_GetCreateTableStatement(t *testing.T) {
 				NumericPrecision:       -1,
 				NumericScale:           -1,
 				OrdinalPosition:        4,
+				SequenceType:           "",
 			},
 			{
 				SchemaName:             "public",
@@ -301,6 +299,7 @@ func Test_GetCreateTableStatement(t *testing.T) {
 				NumericPrecision:       32,
 				NumericScale:           0,
 				OrdinalPosition:        5,
+				SequenceType:           "",
 			},
 		}, nil,
 	)
@@ -445,7 +444,7 @@ func Test_GenerateCreateTableStatement(t *testing.T) {
 	type testcase struct {
 		schema      string
 		table       string
-		rows        []*pg_queries.GetDatabaseTableSchemaRow
+		rows        []*pg_queries.GetDatabaseTableSchemasBySchemasAndTablesRow
 		constraints []*pg_queries.GetTableConstraintsRow
 		expected    string
 	}
@@ -453,7 +452,7 @@ func Test_GenerateCreateTableStatement(t *testing.T) {
 		{
 			schema: "public",
 			table:  "users",
-			rows: []*pg_queries.GetDatabaseTableSchemaRow{
+			rows: []*pg_queries.GetDatabaseTableSchemasBySchemasAndTablesRow{
 				{
 					ColumnName:      "id",
 					DataType:        "uuid",
@@ -500,7 +499,7 @@ func Test_GenerateCreateTableStatement(t *testing.T) {
 		{
 			schema: "public",
 			table:  "users",
-			rows: []*pg_queries.GetDatabaseTableSchemaRow{
+			rows: []*pg_queries.GetDatabaseTableSchemasBySchemasAndTablesRow{
 				{
 					ColumnName:      "id",
 					DataType:        "integer",

--- a/backend/pkg/sqlmanager/sql-manager.go
+++ b/backend/pkg/sqlmanager/sql-manager.go
@@ -65,6 +65,8 @@ type SqlDatabase interface {
 	GetTableInitStatements(ctx context.Context, tables []*SchemaTable) ([]*TableInitStatement, error)
 	GetRolePermissionsMap(ctx context.Context, role string) (map[string][]string, error)
 	GetTableRowCount(ctx context.Context, schema, table string, whereClause *string) (int64, error)
+	GetSchemaTableDataTypes(ctx context.Context, tables []*SchemaTable) (*SchemaTableDataTypeResponse, error)
+	GetSchemaTableTriggers(ctx context.Context, tables []*SchemaTable) ([]*TableTrigger, error)
 	BatchExec(ctx context.Context, batchSize int, statements []string, opts *BatchExecOpts) error
 	Exec(ctx context.Context, statement string) error
 	Close()

--- a/backend/services/mgmt/v1alpha1/connection-data-service/connection-data.go
+++ b/backend/services/mgmt/v1alpha1/connection-data-service/connection-data.go
@@ -17,7 +17,6 @@ import (
 	"github.com/aws/aws-sdk-go-v2/aws"
 	"github.com/aws/aws-sdk-go-v2/service/s3"
 	"github.com/gofrs/uuid"
-	pg_queries "github.com/nucleuscloud/neosync/backend/gen/go/db/dbschemas/postgresql"
 	mgmtv1alpha1 "github.com/nucleuscloud/neosync/backend/gen/go/protos/mgmt/v1alpha1"
 	logger_interceptor "github.com/nucleuscloud/neosync/backend/internal/connect/interceptors/logger"
 	nucleuserrors "github.com/nucleuscloud/neosync/backend/internal/errors"
@@ -758,7 +757,8 @@ func (s *Service) getConnectionTableSchema(ctx context.Context, connection *mgmt
 		if err != nil {
 			return nil, err
 		}
-		dbschema, err := s.pgquerier.GetDatabaseTableSchema(ctx, db, &pg_queries.GetDatabaseTableSchemaParams{Schema: schema, Table: table})
+		schematable := sql_manager.SchemaTable{Schema: schema, Table: table}
+		dbschema, err := s.pgquerier.GetDatabaseTableSchemasBySchemasAndTables(ctx, db, []string{schematable.String()})
 		if err != nil {
 			return nil, err
 		}

--- a/backend/services/mgmt/v1alpha1/connection-data-service/connection-data_test.go
+++ b/backend/services/mgmt/v1alpha1/connection-data-service/connection-data_test.go
@@ -117,16 +117,16 @@ func Test_GetConnectionSchema_Postgres(t *testing.T) {
 
 	mockColumns := []*pg_queries.GetDatabaseSchemaRow{
 		{
-			TableSchema: "public",
-			TableName:   "users",
-			ColumnName:  "id",
-			DataType:    "integer",
+			SchemaName: "public",
+			TableName:  "users",
+			ColumnName: "id",
+			DataType:   "integer",
 		},
 		{
-			TableSchema: "public",
-			TableName:   "users",
-			ColumnName:  "name",
-			DataType:    "character varying",
+			SchemaName: "public",
+			TableName:  "users",
+			ColumnName: "name",
+			DataType:   "character varying",
 		}}
 
 	pool, _ := pgxpool.New(context.Background(), "")
@@ -151,7 +151,7 @@ func Test_GetConnectionSchema_Postgres(t *testing.T) {
 	expected := []*mgmtv1alpha1.DatabaseColumn{}
 	for _, col := range mockColumns {
 		expected = append(expected, &mgmtv1alpha1.DatabaseColumn{
-			Schema:   col.TableSchema,
+			Schema:   col.SchemaName,
 			Table:    col.TableName,
 			Column:   col.ColumnName,
 			DataType: col.DataType,
@@ -340,14 +340,14 @@ func Test_GetConnectionForeignConstraints_Postgres(t *testing.T) {
 	m.PgQueierMock.On("GetDatabaseSchema", mock.Anything, mock.Anything).
 		Return([]*pg_queries.GetDatabaseSchemaRow{
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "id",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "id",
 			},
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "name",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "name",
 			},
 		}, nil)
 	m.PgQueierMock.On("GetTableConstraintsBySchema", mock.Anything, mock.Anything, mock.Anything).
@@ -448,14 +448,14 @@ func Test_GetConnectionPrimaryConstraints_Postgres(t *testing.T) {
 	m.PgQueierMock.On("GetDatabaseSchema", mock.Anything, mock.Anything).
 		Return([]*pg_queries.GetDatabaseSchemaRow{
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "id",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "id",
 			},
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "name",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "name",
 			},
 		}, nil)
 	m.PgQueierMock.On("GetTableConstraintsBySchema", mock.Anything, mock.Anything, mock.Anything).
@@ -587,20 +587,17 @@ func Test_GetConnectionInitStatements_Postgres_Create(t *testing.T) {
 	m.PgQueierMock.On("GetDatabaseSchema", mock.Anything, mock.Anything).
 		Return([]*pg_queries.GetDatabaseSchemaRow{
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "id",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "id",
 			},
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "name",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "name",
 			},
 		}, nil)
-	m.PgQueierMock.On("GetDatabaseTableSchema", mock.Anything, mock.Anything, &pg_queries.GetDatabaseTableSchemaParams{
-		Schema: "public",
-		Table:  "users",
-	}).Return([]*pg_queries.GetDatabaseTableSchemaRow{
+	m.PgQueierMock.On("GetDatabaseTableSchemasBySchemasAndTables", mock.Anything, mock.Anything, []string{"public.users"}).Return([]*pg_queries.GetDatabaseTableSchemasBySchemasAndTablesRow{
 		{
 			ColumnName:      "id",
 			DataType:        "uuid",
@@ -661,14 +658,14 @@ func Test_GetConnectionInitStatements_Postgres_Truncate(t *testing.T) {
 	m.PgQueierMock.On("GetDatabaseSchema", mock.Anything, mock.Anything).
 		Return([]*pg_queries.GetDatabaseSchemaRow{
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "id",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "id",
 			},
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "name",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "name",
 			},
 		}, nil)
 
@@ -995,14 +992,14 @@ func Test_GetConnectionUniqueConstraints_Postgres(t *testing.T) {
 	m.PgQueierMock.On("GetDatabaseSchema", mock.Anything, mock.Anything).
 		Return([]*pg_queries.GetDatabaseSchemaRow{
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "id",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "id",
 			},
 			{
-				TableSchema: "public",
-				TableName:   "users",
-				ColumnName:  "name",
+				SchemaName: "public",
+				TableName:  "users",
+				ColumnName: "name",
 			},
 		}, nil)
 	m.PgQueierMock.On("GetTableConstraintsBySchema", mock.Anything, mock.Anything, mock.Anything).

--- a/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder.go
+++ b/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder.go
@@ -123,14 +123,13 @@ func (b *initStatementBuilder) RunSqlInitTableStatements(
 
 				datatypeCfg, err := sourcedb.Db.GetSchemaTableDataTypes(ctx, tables)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("unable to retrieve postgres schema table data types: %w", err)
 				}
-
 				dataTypeStmts := datatypeCfg.GetStatements()
 
 				tableTriggers, err := sourcedb.Db.GetSchemaTableTriggers(ctx, tables)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("unable to retrieve postgres schema table triggers: %w", err)
 				}
 
 				tableTriggerStmts := make([]string, 0, len(tableTriggers))
@@ -140,7 +139,7 @@ func (b *initStatementBuilder) RunSqlInitTableStatements(
 
 				initStatementCfgs, err := sourcedb.Db.GetTableInitStatements(ctx, tables)
 				if err != nil {
-					return nil, err
+					return nil, fmt.Errorf("unable to retrieve postgres schema table create statements: %w", err)
 				}
 				createTables := []string{}
 				nonFkAlterStmts := []string{}

--- a/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder_test.go
+++ b/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder_test.go
@@ -137,6 +137,16 @@ func Test_InitStatementBuilder_Pg_Generate_InitSchema(t *testing.T) {
 		},
 	}), nil)
 	mockSqlManager.On("NewPooledSqlDb", mock.Anything, mock.Anything, mock.Anything).Return(&sql_manager.SqlConnection{Db: mockSqlDb}, nil)
+	mockSqlDb.On("GetSchemaTableDataTypes", mock.Anything, []*sql_manager.SchemaTable{{Schema: "public", Table: "users"}}).
+		Return(&sql_manager.SchemaTableDataTypeResponse{
+			Sequences:  []*sql_manager.DataType{},
+			Functions:  []*sql_manager.DataType{},
+			Composites: []*sql_manager.DataType{},
+			Enums:      []*sql_manager.DataType{},
+			Domains:    []*sql_manager.DataType{},
+		}, nil)
+	mockSqlDb.On("GetSchemaTableTriggers", mock.Anything, []*sql_manager.SchemaTable{{Schema: "public", Table: "users"}}).
+		Return([]*sql_manager.TableTrigger{{Schema: "public", Table: "users", TriggerName: "foo_trigger", Definition: "test-trigger-statement"}}, nil)
 	mockSqlDb.On("GetTableInitStatements", mock.Anything, []*sql_manager.SchemaTable{{Schema: "public", Table: "users"}}).Return([]*sql_manager.TableInitStatement{
 		{
 			CreateTableStatement: "test-create-statement",
@@ -154,6 +164,7 @@ func Test_InitStatementBuilder_Pg_Generate_InitSchema(t *testing.T) {
 		},
 	}, nil)
 	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"TRUNCATE \"public\".\"users\" CASCADE;"}, &sql_manager.BatchExecOpts{}).Return(nil)
+	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"test-trigger-statement"}, &sql_manager.BatchExecOpts{}).Return(nil)
 	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"test-create-statement"}, &sql_manager.BatchExecOpts{}).Return(nil)
 	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"test-pk-statement"}, &sql_manager.BatchExecOpts{}).Return(nil)
 	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"test-fk-statement"}, &sql_manager.BatchExecOpts{}).Return(nil)
@@ -657,6 +668,16 @@ func Test_InitStatementBuilder_Pg_InitSchema(t *testing.T) {
 	}), nil)
 
 	mockSqlManager.On("NewPooledSqlDb", mock.Anything, mock.Anything, mock.Anything).Return(&sql_manager.SqlConnection{Db: mockSqlDb}, nil)
+	mockSqlDb.On("GetSchemaTableDataTypes", mock.Anything, mock.Anything).
+		Return(&sql_manager.SchemaTableDataTypeResponse{
+			Sequences:  []*sql_manager.DataType{},
+			Functions:  []*sql_manager.DataType{},
+			Composites: []*sql_manager.DataType{},
+			Enums:      []*sql_manager.DataType{},
+			Domains:    []*sql_manager.DataType{},
+		}, nil)
+	mockSqlDb.On("GetSchemaTableTriggers", mock.Anything, mock.Anything).
+		Return([]*sql_manager.TableTrigger{{Schema: "public", Table: "users", TriggerName: "foo_trigger", Definition: "test-trigger-statement"}}, nil)
 	mockSqlDb.On("GetTableInitStatements", mock.Anything, mock.Anything).Return([]*sql_manager.TableInitStatement{
 		{
 			CreateTableStatement: "test-create-statement",
@@ -675,6 +696,7 @@ func Test_InitStatementBuilder_Pg_InitSchema(t *testing.T) {
 	}, nil)
 
 	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"test-create-statement"}, &sql_manager.BatchExecOpts{}).Return(nil)
+	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"test-trigger-statement"}, &sql_manager.BatchExecOpts{}).Return(nil)
 	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"test-pk-statement"}, &sql_manager.BatchExecOpts{}).Return(nil)
 	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"test-fk-statement"}, &sql_manager.BatchExecOpts{}).Return(nil)
 	mockSqlDb.On("BatchExec", mock.Anything, mock.Anything, []string{"test-idx-statement"}, &sql_manager.BatchExecOpts{}).Return(nil)


### PR DESCRIPTION
This PRs adds Postgres support for init tables:
1. custom data types
2. custom functions
3. custom triggers
4. custom sequences

This will be specific to job mappings selected, so it will only contextually bring over anything that is relevant to the mapped tables in a specific job.
