### PR TITLE
NEOS-1126 fix(compose): pin admin-tools version to v1.23

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -96,7 +96,7 @@ services:
 
   temporal-seed:
     container_name: neosync-temporal-seed
-    image: temporalio/admin-tools:latest
+    image: temporalio/admin-tools:1.23
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
     entrypoint: /bin/sh -c "/create_schedules.sh"


### PR DESCRIPTION
This addresses the common issue of flag incompatibility between latest `temporalio/admin-tools` setup.

ISSUE REF: https://github.com/nucleuscloud/neosync/issues/2046