### PR TITLE
NEOS-1177 Fixes role check query to use current_user

### DIFF
--- a/backend/gen/go/db/dbschemas/mysql/mock_Querier.go
+++ b/backend/gen/go/db/dbschemas/mysql/mock_Querier.go
@@ -140,9 +140,9 @@ func (_c *MockQuerier_GetForeignKeyConstraints_Call) RunAndReturn(run func(conte
 	return _c
 }
 
-// GetMysqlRolePermissions provides a mock function with given fields: ctx, db, role
-func (_m *MockQuerier) GetMysqlRolePermissions(ctx context.Context, db DBTX, role string) ([]*GetMysqlRolePermissionsRow, error) {
-	ret := _m.Called(ctx, db, role)
+// GetMysqlRolePermissions provides a mock function with given fields: ctx, db
+func (_m *MockQuerier) GetMysqlRolePermissions(ctx context.Context, db DBTX) ([]*GetMysqlRolePermissionsRow, error) {
+	ret := _m.Called(ctx, db)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetMysqlRolePermissions")
@@ -150,19 +150,19 @@ func (_m *MockQuerier) GetMysqlRolePermissions(ctx context.Context, db DBTX, rol
 
 	var r0 []*GetMysqlRolePermissionsRow
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX, string) ([]*GetMysqlRolePermissionsRow, error)); ok {
-		return rf(ctx, db, role)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetMysqlRolePermissionsRow, error)); ok {
+		return rf(ctx, db)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX, string) []*GetMysqlRolePermissionsRow); ok {
-		r0 = rf(ctx, db, role)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetMysqlRolePermissionsRow); ok {
+		r0 = rf(ctx, db)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*GetMysqlRolePermissionsRow)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, DBTX, string) error); ok {
-		r1 = rf(ctx, db, role)
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
+		r1 = rf(ctx, db)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -178,14 +178,13 @@ type MockQuerier_GetMysqlRolePermissions_Call struct {
 // GetMysqlRolePermissions is a helper method to define mock.On call
 //   - ctx context.Context
 //   - db DBTX
-//   - role string
-func (_e *MockQuerier_Expecter) GetMysqlRolePermissions(ctx interface{}, db interface{}, role interface{}) *MockQuerier_GetMysqlRolePermissions_Call {
-	return &MockQuerier_GetMysqlRolePermissions_Call{Call: _e.mock.On("GetMysqlRolePermissions", ctx, db, role)}
+func (_e *MockQuerier_Expecter) GetMysqlRolePermissions(ctx interface{}, db interface{}) *MockQuerier_GetMysqlRolePermissions_Call {
+	return &MockQuerier_GetMysqlRolePermissions_Call{Call: _e.mock.On("GetMysqlRolePermissions", ctx, db)}
 }
 
-func (_c *MockQuerier_GetMysqlRolePermissions_Call) Run(run func(ctx context.Context, db DBTX, role string)) *MockQuerier_GetMysqlRolePermissions_Call {
+func (_c *MockQuerier_GetMysqlRolePermissions_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetMysqlRolePermissions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(DBTX), args[2].(string))
+		run(args[0].(context.Context), args[1].(DBTX))
 	})
 	return _c
 }
@@ -195,7 +194,7 @@ func (_c *MockQuerier_GetMysqlRolePermissions_Call) Return(_a0 []*GetMysqlRolePe
 	return _c
 }
 
-func (_c *MockQuerier_GetMysqlRolePermissions_Call) RunAndReturn(run func(context.Context, DBTX, string) ([]*GetMysqlRolePermissionsRow, error)) *MockQuerier_GetMysqlRolePermissions_Call {
+func (_c *MockQuerier_GetMysqlRolePermissions_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetMysqlRolePermissionsRow, error)) *MockQuerier_GetMysqlRolePermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/gen/go/db/dbschemas/mysql/querier.go
+++ b/backend/gen/go/db/dbschemas/mysql/querier.go
@@ -11,7 +11,7 @@ import (
 type Querier interface {
 	GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error)
 	GetForeignKeyConstraints(ctx context.Context, db DBTX, tableSchema string) ([]*GetForeignKeyConstraintsRow, error)
-	GetMysqlRolePermissions(ctx context.Context, db DBTX, role string) ([]*GetMysqlRolePermissionsRow, error)
+	GetMysqlRolePermissions(ctx context.Context, db DBTX) ([]*GetMysqlRolePermissionsRow, error)
 	GetPrimaryKeyConstraints(ctx context.Context, db DBTX, tableSchema string) ([]*GetPrimaryKeyConstraintsRow, error)
 	GetUniqueConstraints(ctx context.Context, db DBTX, tableSchema string) ([]*GetUniqueConstraintsRow, error)
 }

--- a/backend/gen/go/db/dbschemas/mysql/system.sql.go
+++ b/backend/gen/go/db/dbschemas/mysql/system.sql.go
@@ -167,7 +167,7 @@ FROM
     information_schema.TABLE_PRIVILEGES AS tp
 WHERE
     tp.TABLE_SCHEMA NOT IN ('mysql', 'information_schema', 'performance_schema', 'sys')
-    AND (tp.GRANTEE = CONCAT("'", CURRENT_USER(), "'@'%'") OR tp.GRANTEE = "'public'@'%'")
+    AND (tp.GRANTEE = CONCAT("'", SUBSTRING_INDEX(CURRENT_USER(), '@', 1), "'@'%'"))
 ORDER BY
     tp.TABLE_SCHEMA,
     tp.TABLE_NAME

--- a/backend/gen/go/db/dbschemas/mysql/system.sql.go
+++ b/backend/gen/go/db/dbschemas/mysql/system.sql.go
@@ -160,30 +160,27 @@ func (q *Queries) GetForeignKeyConstraints(ctx context.Context, db DBTX, tableSc
 
 const getMysqlRolePermissions = `-- name: GetMysqlRolePermissions :many
 SELECT
-    t.table_schema,
-    t.table_name,
-	p.grantee,
-	p.privilege_type
+    tp.TABLE_SCHEMA AS table_schema,
+    tp.TABLE_NAME AS table_name,
+    tp.PRIVILEGE_TYPE AS privilege_type
 FROM
-    information_schema.tables t
-    JOIN information_schema.table_privileges p ON t.table_schema = p.table_schema
-    AND t.table_name = p.table_name
+    information_schema.TABLE_PRIVILEGES AS tp
 WHERE
-    t.table_schema NOT IN ('sys', 'performance_schema', 'mysql', 'information_schema')
-  AND p.GRANTEE = ?
+    tp.TABLE_SCHEMA NOT IN ('mysql', 'information_schema', 'performance_schema', 'sys')
+    AND (tp.GRANTEE = CONCAT("'", CURRENT_USER(), "'@'%'") OR tp.GRANTEE = "'public'@'%'")
 ORDER BY
-    t.table_schema, t.table_name, p.GRANTEE
+    tp.TABLE_SCHEMA,
+    tp.TABLE_NAME
 `
 
 type GetMysqlRolePermissionsRow struct {
 	TableSchema   string
 	TableName     string
-	Grantee       string
 	PrivilegeType string
 }
 
-func (q *Queries) GetMysqlRolePermissions(ctx context.Context, db DBTX, role string) ([]*GetMysqlRolePermissionsRow, error) {
-	rows, err := db.QueryContext(ctx, getMysqlRolePermissions, role)
+func (q *Queries) GetMysqlRolePermissions(ctx context.Context, db DBTX) ([]*GetMysqlRolePermissionsRow, error) {
+	rows, err := db.QueryContext(ctx, getMysqlRolePermissions)
 	if err != nil {
 		return nil, err
 	}
@@ -191,12 +188,7 @@ func (q *Queries) GetMysqlRolePermissions(ctx context.Context, db DBTX, role str
 	var items []*GetMysqlRolePermissionsRow
 	for rows.Next() {
 		var i GetMysqlRolePermissionsRow
-		if err := rows.Scan(
-			&i.TableSchema,
-			&i.TableName,
-			&i.Grantee,
-			&i.PrivilegeType,
-		); err != nil {
+		if err := rows.Scan(&i.TableSchema, &i.TableName, &i.PrivilegeType); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/mock_Querier.go
@@ -440,9 +440,9 @@ func (_c *MockQuerier_GetIndicesBySchemasAndTables_Call) RunAndReturn(run func(c
 	return _c
 }
 
-// GetPostgresRolePermissions provides a mock function with given fields: ctx, db, role
-func (_m *MockQuerier) GetPostgresRolePermissions(ctx context.Context, db DBTX, role interface{}) ([]*GetPostgresRolePermissionsRow, error) {
-	ret := _m.Called(ctx, db, role)
+// GetPostgresRolePermissions provides a mock function with given fields: ctx, db
+func (_m *MockQuerier) GetPostgresRolePermissions(ctx context.Context, db DBTX) ([]*GetPostgresRolePermissionsRow, error) {
+	ret := _m.Called(ctx, db)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetPostgresRolePermissions")
@@ -450,19 +450,19 @@ func (_m *MockQuerier) GetPostgresRolePermissions(ctx context.Context, db DBTX, 
 
 	var r0 []*GetPostgresRolePermissionsRow
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX, interface{}) ([]*GetPostgresRolePermissionsRow, error)); ok {
-		return rf(ctx, db, role)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) ([]*GetPostgresRolePermissionsRow, error)); ok {
+		return rf(ctx, db)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, DBTX, interface{}) []*GetPostgresRolePermissionsRow); ok {
-		r0 = rf(ctx, db, role)
+	if rf, ok := ret.Get(0).(func(context.Context, DBTX) []*GetPostgresRolePermissionsRow); ok {
+		r0 = rf(ctx, db)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).([]*GetPostgresRolePermissionsRow)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, DBTX, interface{}) error); ok {
-		r1 = rf(ctx, db, role)
+	if rf, ok := ret.Get(1).(func(context.Context, DBTX) error); ok {
+		r1 = rf(ctx, db)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -478,14 +478,13 @@ type MockQuerier_GetPostgresRolePermissions_Call struct {
 // GetPostgresRolePermissions is a helper method to define mock.On call
 //   - ctx context.Context
 //   - db DBTX
-//   - role interface{}
-func (_e *MockQuerier_Expecter) GetPostgresRolePermissions(ctx interface{}, db interface{}, role interface{}) *MockQuerier_GetPostgresRolePermissions_Call {
-	return &MockQuerier_GetPostgresRolePermissions_Call{Call: _e.mock.On("GetPostgresRolePermissions", ctx, db, role)}
+func (_e *MockQuerier_Expecter) GetPostgresRolePermissions(ctx interface{}, db interface{}) *MockQuerier_GetPostgresRolePermissions_Call {
+	return &MockQuerier_GetPostgresRolePermissions_Call{Call: _e.mock.On("GetPostgresRolePermissions", ctx, db)}
 }
 
-func (_c *MockQuerier_GetPostgresRolePermissions_Call) Run(run func(ctx context.Context, db DBTX, role interface{})) *MockQuerier_GetPostgresRolePermissions_Call {
+func (_c *MockQuerier_GetPostgresRolePermissions_Call) Run(run func(ctx context.Context, db DBTX)) *MockQuerier_GetPostgresRolePermissions_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(DBTX), args[2].(interface{}))
+		run(args[0].(context.Context), args[1].(DBTX))
 	})
 	return _c
 }
@@ -495,7 +494,7 @@ func (_c *MockQuerier_GetPostgresRolePermissions_Call) Return(_a0 []*GetPostgres
 	return _c
 }
 
-func (_c *MockQuerier_GetPostgresRolePermissions_Call) RunAndReturn(run func(context.Context, DBTX, interface{}) ([]*GetPostgresRolePermissionsRow, error)) *MockQuerier_GetPostgresRolePermissions_Call {
+func (_c *MockQuerier_GetPostgresRolePermissions_Call) RunAndReturn(run func(context.Context, DBTX) ([]*GetPostgresRolePermissionsRow, error)) *MockQuerier_GetPostgresRolePermissions_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/gen/go/db/dbschemas/postgresql/querier.go
+++ b/backend/gen/go/db/dbschemas/postgresql/querier.go
@@ -16,7 +16,7 @@ type Querier interface {
 	GetDatabaseSchema(ctx context.Context, db DBTX) ([]*GetDatabaseSchemaRow, error)
 	GetDatabaseTableSchemasBySchemasAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetDatabaseTableSchemasBySchemasAndTablesRow, error)
 	GetIndicesBySchemasAndTables(ctx context.Context, db DBTX, schematables []string) ([]*GetIndicesBySchemasAndTablesRow, error)
-	GetPostgresRolePermissions(ctx context.Context, db DBTX, role interface{}) ([]*GetPostgresRolePermissionsRow, error)
+	GetPostgresRolePermissions(ctx context.Context, db DBTX) ([]*GetPostgresRolePermissionsRow, error)
 	GetTableConstraints(ctx context.Context, db DBTX, arg *GetTableConstraintsParams) ([]*GetTableConstraintsRow, error)
 	GetTableConstraintsBySchema(ctx context.Context, db DBTX, schema []string) ([]*GetTableConstraintsBySchemaRow, error)
 }

--- a/backend/gen/go/db/dbschemas/postgresql/system.sql.go
+++ b/backend/gen/go/db/dbschemas/postgresql/system.sql.go
@@ -782,10 +782,9 @@ func (q *Queries) GetIndicesBySchemasAndTables(ctx context.Context, db DBTX, sch
 
 const getPostgresRolePermissions = `-- name: GetPostgresRolePermissions :many
 SELECT
-    tp.grantee,
-    tp.table_schema,
-    tp.table_name,
-    tp.privilege_type
+    tp.table_schema::text as table_schema,
+    tp.table_name::text as table_name,
+    tp.privilege_type::text as privilege_type
 FROM
     information_schema.table_privileges AS tp
 WHERE
@@ -797,10 +796,9 @@ ORDER BY
 `
 
 type GetPostgresRolePermissionsRow struct {
-	Grantee       interface{}
-	TableSchema   interface{}
-	TableName     interface{}
-	PrivilegeType interface{}
+	TableSchema   string
+	TableName     string
+	PrivilegeType string
 }
 
 func (q *Queries) GetPostgresRolePermissions(ctx context.Context, db DBTX) ([]*GetPostgresRolePermissionsRow, error) {
@@ -812,12 +810,7 @@ func (q *Queries) GetPostgresRolePermissions(ctx context.Context, db DBTX) ([]*G
 	var items []*GetPostgresRolePermissionsRow
 	for rows.Next() {
 		var i GetPostgresRolePermissionsRow
-		if err := rows.Scan(
-			&i.Grantee,
-			&i.TableSchema,
-			&i.TableName,
-			&i.PrivilegeType,
-		); err != nil {
+		if err := rows.Scan(&i.TableSchema, &i.TableName, &i.PrivilegeType); err != nil {
 			return nil, err
 		}
 		items = append(items, &i)

--- a/backend/pkg/dbschemas/sql/mysql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/mysql/queries/system.sql
@@ -91,16 +91,14 @@ ORDER BY
 
 -- name: GetMysqlRolePermissions :many
 SELECT
-    t.table_schema,
-    t.table_name,
-	p.grantee,
-	p.privilege_type
+    tp.TABLE_SCHEMA AS table_schema,
+    tp.TABLE_NAME AS table_name,
+    tp.PRIVILEGE_TYPE AS privilege_type
 FROM
-    information_schema.tables t
-    JOIN information_schema.table_privileges p ON t.table_schema = p.table_schema
-    AND t.table_name = p.table_name
+    information_schema.TABLE_PRIVILEGES AS tp
 WHERE
-    t.table_schema NOT IN ('sys', 'performance_schema', 'mysql', 'information_schema')
-  AND p.GRANTEE = sqlc.arg('role')
+    tp.TABLE_SCHEMA NOT IN ('mysql', 'information_schema', 'performance_schema', 'sys')
+    AND (tp.GRANTEE = CONCAT("'", CURRENT_USER(), "'@'%'") OR tp.GRANTEE = "'public'@'%'")
 ORDER BY
-    t.table_schema, t.table_name, p.GRANTEE;
+    tp.TABLE_SCHEMA,
+    tp.TABLE_NAME;

--- a/backend/pkg/dbschemas/sql/mysql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/mysql/queries/system.sql
@@ -98,7 +98,8 @@ FROM
     information_schema.TABLE_PRIVILEGES AS tp
 WHERE
     tp.TABLE_SCHEMA NOT IN ('mysql', 'information_schema', 'performance_schema', 'sys')
-    AND (tp.GRANTEE = CONCAT("'", CURRENT_USER(), "'@'%'") OR tp.GRANTEE = "'public'@'%'")
+    AND (tp.GRANTEE = CONCAT("'", SUBSTRING_INDEX(CURRENT_USER(), '@', 1), "'@'%'"))
 ORDER BY
     tp.TABLE_SCHEMA,
     tp.TABLE_NAME;
+

--- a/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
@@ -321,10 +321,9 @@ GROUP BY
 
 -- name: GetPostgresRolePermissions :many
 SELECT
-    tp.grantee,
-    tp.table_schema,
-    tp.table_name,
-    tp.privilege_type
+    tp.table_schema::text as table_schema,
+    tp.table_name::text as table_name,
+    tp.privilege_type::text as privilege_type
 FROM
     information_schema.table_privileges AS tp
 WHERE

--- a/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
@@ -321,17 +321,19 @@ GROUP BY
 
 -- name: GetPostgresRolePermissions :many
 SELECT
-    rtg.table_schema as table_schema,
-    rtg.table_name as table_name,
-    rtg.privilege_type as privilege_type
+    tp.grantee,
+    tp.table_schema,
+    tp.table_name,
+    tp.privilege_type
 FROM
-    information_schema.role_table_grants as rtg
+    information_schema.table_privileges AS tp
 WHERE
-    table_schema NOT IN ('pg_catalog', 'information_schema')
-AND grantee =  sqlc.arg('role')
+    tp.table_schema NOT IN ('pg_catalog', 'information_schema')
+AND (tp.grantee = current_user OR tp.grantee = 'PUBLIC')
 ORDER BY
-    table_schema,
-    table_name;
+    tp.table_schema,
+    tp.table_name;
+
 
 -- name: GetIndicesBySchemasAndTables :many
 SELECT

--- a/backend/pkg/sqlmanager/mock_SqlDatabase.go
+++ b/backend/pkg/sqlmanager/mock_SqlDatabase.go
@@ -266,9 +266,9 @@ func (_c *MockSqlDatabase_GetDatabaseSchema_Call) RunAndReturn(run func(context.
 	return _c
 }
 
-// GetRolePermissionsMap provides a mock function with given fields: ctx, role
-func (_m *MockSqlDatabase) GetRolePermissionsMap(ctx context.Context, role string) (map[string][]string, error) {
-	ret := _m.Called(ctx, role)
+// GetRolePermissionsMap provides a mock function with given fields: ctx
+func (_m *MockSqlDatabase) GetRolePermissionsMap(ctx context.Context) (map[string][]string, error) {
+	ret := _m.Called(ctx)
 
 	if len(ret) == 0 {
 		panic("no return value specified for GetRolePermissionsMap")
@@ -276,19 +276,19 @@ func (_m *MockSqlDatabase) GetRolePermissionsMap(ctx context.Context, role strin
 
 	var r0 map[string][]string
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, string) (map[string][]string, error)); ok {
-		return rf(ctx, role)
+	if rf, ok := ret.Get(0).(func(context.Context) (map[string][]string, error)); ok {
+		return rf(ctx)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, string) map[string][]string); ok {
-		r0 = rf(ctx, role)
+	if rf, ok := ret.Get(0).(func(context.Context) map[string][]string); ok {
+		r0 = rf(ctx)
 	} else {
 		if ret.Get(0) != nil {
 			r0 = ret.Get(0).(map[string][]string)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, string) error); ok {
-		r1 = rf(ctx, role)
+	if rf, ok := ret.Get(1).(func(context.Context) error); ok {
+		r1 = rf(ctx)
 	} else {
 		r1 = ret.Error(1)
 	}
@@ -303,14 +303,13 @@ type MockSqlDatabase_GetRolePermissionsMap_Call struct {
 
 // GetRolePermissionsMap is a helper method to define mock.On call
 //   - ctx context.Context
-//   - role string
-func (_e *MockSqlDatabase_Expecter) GetRolePermissionsMap(ctx interface{}, role interface{}) *MockSqlDatabase_GetRolePermissionsMap_Call {
-	return &MockSqlDatabase_GetRolePermissionsMap_Call{Call: _e.mock.On("GetRolePermissionsMap", ctx, role)}
+func (_e *MockSqlDatabase_Expecter) GetRolePermissionsMap(ctx interface{}) *MockSqlDatabase_GetRolePermissionsMap_Call {
+	return &MockSqlDatabase_GetRolePermissionsMap_Call{Call: _e.mock.On("GetRolePermissionsMap", ctx)}
 }
 
-func (_c *MockSqlDatabase_GetRolePermissionsMap_Call) Run(run func(ctx context.Context, role string)) *MockSqlDatabase_GetRolePermissionsMap_Call {
+func (_c *MockSqlDatabase_GetRolePermissionsMap_Call) Run(run func(ctx context.Context)) *MockSqlDatabase_GetRolePermissionsMap_Call {
 	_c.Call.Run(func(args mock.Arguments) {
-		run(args[0].(context.Context), args[1].(string))
+		run(args[0].(context.Context))
 	})
 	return _c
 }
@@ -320,7 +319,7 @@ func (_c *MockSqlDatabase_GetRolePermissionsMap_Call) Return(_a0 map[string][]st
 	return _c
 }
 
-func (_c *MockSqlDatabase_GetRolePermissionsMap_Call) RunAndReturn(run func(context.Context, string) (map[string][]string, error)) *MockSqlDatabase_GetRolePermissionsMap_Call {
+func (_c *MockSqlDatabase_GetRolePermissionsMap_Call) RunAndReturn(run func(context.Context) (map[string][]string, error)) *MockSqlDatabase_GetRolePermissionsMap_Call {
 	_c.Call.Return(run)
 	return _c
 }

--- a/backend/pkg/sqlmanager/mysql/mysql-manager.go
+++ b/backend/pkg/sqlmanager/mysql/mysql-manager.go
@@ -265,8 +265,8 @@ func (m *MysqlManager) getUniqueConstraintsMap(ctx context.Context, schemas []st
 	return output, nil
 }
 
-func (m *MysqlManager) GetRolePermissionsMap(ctx context.Context, role string) (map[string][]string, error) {
-	rows, err := m.querier.GetMysqlRolePermissions(ctx, m.pool, role)
+func (m *MysqlManager) GetRolePermissionsMap(ctx context.Context) (map[string][]string, error) {
+	rows, err := m.querier.GetMysqlRolePermissions(ctx, m.pool)
 	if err != nil && !nucleusdb.IsNoRows(err) {
 		return nil, err
 	} else if err != nil && nucleusdb.IsNoRows(err) {

--- a/backend/pkg/sqlmanager/mysql/mysql-manager_test.go
+++ b/backend/pkg/sqlmanager/mysql/mysql-manager_test.go
@@ -299,7 +299,7 @@ func Test_GetRolePermissionsMap_Mysql(t *testing.T) {
 		pool:    mockPool,
 	}
 
-	mysqlquerier.On("GetMysqlRolePermissions", mock.Anything, mockPool, "postgres").Return(
+	mysqlquerier.On("GetMysqlRolePermissions", mock.Anything, mockPool).Return(
 		[]*mysql_queries.GetMysqlRolePermissionsRow{
 			{TableSchema: "public", TableName: "users", PrivilegeType: "INSERT"},
 			{TableSchema: "public", TableName: "users", PrivilegeType: "UPDATE"},

--- a/backend/pkg/sqlmanager/mysql/mysql-manager_test.go
+++ b/backend/pkg/sqlmanager/mysql/mysql-manager_test.go
@@ -314,7 +314,7 @@ func Test_GetRolePermissionsMap_Mysql(t *testing.T) {
 		"other.accounts": {"INSERT"},
 	}
 
-	actual, err := manager.GetRolePermissionsMap(context.Background(), "postgres")
+	actual, err := manager.GetRolePermissionsMap(context.Background())
 	require.NoError(t, err)
 	for table, expect := range expected {
 		require.ElementsMatch(t, expect, actual[table])

--- a/backend/pkg/sqlmanager/postgres/postgres-manager.go
+++ b/backend/pkg/sqlmanager/postgres/postgres-manager.go
@@ -116,8 +116,8 @@ func (p *PostgresManager) GetTableConstraintsBySchema(ctx context.Context, schem
 	}, nil
 }
 
-func (p *PostgresManager) GetRolePermissionsMap(ctx context.Context, role string) (map[string][]string, error) {
-	rows, err := p.querier.GetPostgresRolePermissions(ctx, p.pool, role)
+func (p *PostgresManager) GetRolePermissionsMap(ctx context.Context) (map[string][]string, error) {
+	rows, err := p.querier.GetPostgresRolePermissions(ctx, p.pool)
 	if err != nil && !nucleusdb.IsNoRows(err) {
 		return nil, err
 	} else if err != nil && nucleusdb.IsNoRows(err) {

--- a/backend/pkg/sqlmanager/postgres/postgres-manager_test.go
+++ b/backend/pkg/sqlmanager/postgres/postgres-manager_test.go
@@ -244,7 +244,7 @@ func Test_GetRolePermissionsMap(t *testing.T) {
 		pool:    mockPool,
 	}
 
-	pgquerier.On("GetPostgresRolePermissions", mock.Anything, mockPool, "postgres").Return(
+	pgquerier.On("GetPostgresRolePermissions", mock.Anything, mockPool).Return(
 		[]*pg_queries.GetPostgresRolePermissionsRow{
 			{TableSchema: "public", TableName: "users", PrivilegeType: "INSERT"},
 			{TableSchema: "public", TableName: "users", PrivilegeType: "UPDATE"},

--- a/backend/pkg/sqlmanager/postgres/postgres-manager_test.go
+++ b/backend/pkg/sqlmanager/postgres/postgres-manager_test.go
@@ -259,7 +259,7 @@ func Test_GetRolePermissionsMap(t *testing.T) {
 		"other.accounts": {"INSERT"},
 	}
 
-	actual, err := manager.GetRolePermissionsMap(context.Background(), "postgres")
+	actual, err := manager.GetRolePermissionsMap(context.Background())
 	require.NoError(t, err)
 	for table, expect := range expected {
 		require.ElementsMatch(t, expect, actual[table])

--- a/backend/pkg/sqlmanager/sql-manager.go
+++ b/backend/pkg/sqlmanager/sql-manager.go
@@ -30,7 +30,7 @@ type SqlDatabase interface {
 	GetTableConstraintsBySchema(ctx context.Context, schemas []string) (*sqlmanager_shared.TableConstraints, error)
 	GetCreateTableStatement(ctx context.Context, schema, table string) (string, error)
 	GetTableInitStatements(ctx context.Context, tables []*sqlmanager_shared.SchemaTable) ([]*sqlmanager_shared.TableInitStatement, error)
-	GetRolePermissionsMap(ctx context.Context, role string) (map[string][]string, error)
+	GetRolePermissionsMap(ctx context.Context) (map[string][]string, error)
 	GetTableRowCount(ctx context.Context, schema, table string, whereClause *string) (int64, error)
 	GetSchemaTableDataTypes(ctx context.Context, tables []*sqlmanager_shared.SchemaTable) (*sqlmanager_shared.SchemaTableDataTypeResponse, error)
 	GetSchemaTableTriggers(ctx context.Context, tables []*sqlmanager_shared.SchemaTable) ([]*sqlmanager_shared.TableTrigger, error)

--- a/backend/services/mgmt/v1alpha1/connection-service/connection.go
+++ b/backend/services/mgmt/v1alpha1/connection-service/connection.go
@@ -40,7 +40,7 @@ func (s *Service) CheckConnectionConfig(
 			return nil, err
 		}
 		defer db.Db.Close()
-		schematablePrivsMap, err := db.Db.GetRolePermissionsMap(ctx, role)
+		schematablePrivsMap, err := db.Db.GetRolePermissionsMap(ctx)
 		if err != nil {
 			errmsg := err.Error()
 			return connect.NewResponse(&mgmtv1alpha1.CheckConnectionConfigResponse{

--- a/frontend/apps/web/components/permissions/PermissionsDataTable.tsx
+++ b/frontend/apps/web/components/permissions/PermissionsDataTable.tsx
@@ -92,17 +92,14 @@ export default function PermissionsDataTable<TData, TValue>({
         <StickyHeaderTable>
           <TableHeader className="bg-gray-100 dark:bg-gray-800 sticky top-0 z-10 grid">
             {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow
-                key={headerGroup.id}
-                className="flex flex-row items-center justify-between w-full px-2"
-              >
+              <TableRow key={headerGroup.id} className="flex w-full px-2">
                 {headerGroup.headers.map((header) => {
                   return (
                     <TableHead
                       key={header.id}
-                      style={{ minWidth: `${header.column.getSize()}px` }}
+                      style={{ width: header.getSize() }}
                       colSpan={header.colSpan}
-                      className="flex items-center"
+                      className="flex w-full"
                     >
                       {header.isPlaceholder
                         ? null
@@ -117,7 +114,7 @@ export default function PermissionsDataTable<TData, TValue>({
             ))}
           </TableHeader>
           <TableBody
-            className="grid"
+            className="grid relative"
             style={{
               height: `${rowVirtualizer.getTotalSize()}px`, //tells scrollbar how big the table is
             }}
@@ -138,15 +135,15 @@ export default function PermissionsDataTable<TData, TValue>({
                   style={{
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
-                  className="items-center flex absolute w-full justify-between px-2"
+                  className="flex absolute w-full px-2"
                 >
                   {row.getVisibleCells().map((cell) => {
                     return (
                       <td
                         key={cell.id}
-                        className="py-2 text-sm"
+                        className="py-2 text-sm flex"
                         style={{
-                          minWidth: cell.column.getSize(),
+                          width: cell.column.getSize(),
                         }}
                       >
                         {flexRender(

--- a/frontend/apps/web/components/permissions/PermissionsDataTable.tsx
+++ b/frontend/apps/web/components/permissions/PermissionsDataTable.tsx
@@ -92,7 +92,10 @@ export default function PermissionsDataTable<TData, TValue>({
         <StickyHeaderTable>
           <TableHeader className="bg-gray-100 dark:bg-gray-800 sticky top-0 z-10 grid">
             {table.getHeaderGroups().map((headerGroup) => (
-              <TableRow key={headerGroup.id} className="flex w-full px-2">
+              <TableRow
+                key={headerGroup.id}
+                className="flex justify-between w-full px-2"
+              >
                 {headerGroup.headers.map((header) => {
                   return (
                     <TableHead
@@ -135,7 +138,7 @@ export default function PermissionsDataTable<TData, TValue>({
                   style={{
                     transform: `translateY(${virtualRow.start}px)`,
                   }}
-                  className="flex absolute w-full px-2"
+                  className="flex absolute justify-between w-full px-2"
                 >
                   {row.getVisibleCells().map((cell) => {
                     return (

--- a/frontend/apps/web/components/permissions/columns.tsx
+++ b/frontend/apps/web/components/permissions/columns.tsx
@@ -43,6 +43,9 @@ export function getPermissionColumns(
           header: ({ column }) => (
             <DataTableColumnHeader column={column} title="Role" />
           ),
+          cell: ({ getValue }) => {
+            return <p className="truncate">{getValue<string>()}</p>;
+          },
         },
 
         {


### PR DESCRIPTION
This solves the issue where the role name used isn't the underlying role that makes it to the database.

Prime example here is subabase gives a user like `postgres.<tenant>` whereas the underlying postgres user is still just `postgres`.
By using the `current_user` sql, we don't have to concern ourselves with the user from the connection and can just use the authenticated user.