### PR TITLE
workflow: add github action for checking pr label

### DIFF
--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -12,7 +12,7 @@ jobs:
   check_labels:
     runs-on: ubuntu-latest
     permissions:
-      pull-requests: write
+      issues: write
     env:
       HAS_LABELS: ${{ github.event.pull_request.labels[0] != null }}
     steps:

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,7 +8,8 @@ on:
       - opened
       - labeled
       - unlabeled
-
+permissions:
+  pull-requests: write
 jobs:
   check_labels:
     runs-on: ubuntu-latest

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,0 +1,35 @@
+name: Check PR Labels
+
+on:
+  pull_request:
+    branches:
+      - main
+    types:
+      - opened
+      - labeled
+      - unlabeled
+
+jobs:
+  check_labels:
+    runs-on: ubuntu-latest
+
+    env:
+      HAS_LABELS: ${{ github.event.pull_request.labels[0] != null }}
+
+    steps:
+      - name: Add a comment to the PR if no labels
+        if: env.HAS_LABELS == 'false'
+        uses: actions/github-script@v6
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: 'Your pull request does not have any labels. Please add at least one label to pass the checks.'
+            })
+
+      - name: Fail the job if no labels are found
+        if: env.HAS_LABELS == 'false'
+        run: exit 1
+        shell: bash

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -8,15 +8,13 @@ on:
       - opened
       - labeled
       - unlabeled
-permissions:
-  pull-requests: write
 jobs:
   check_labels:
     runs-on: ubuntu-latest
-
+    permissions:
+      pull-requests: write
     env:
       HAS_LABELS: ${{ github.event.pull_request.labels[0] != null }}
-
     steps:
       - name: Add a comment to the PR if no labels
         if: env.HAS_LABELS == 'false'

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Ensure PR Has Labels
+name: Ensure PR Has Label(s)
 
 on:
   pull_request:
@@ -12,8 +12,8 @@ jobs:
   check_labels:
     runs-on: ubuntu-latest
     steps:
-      - name: Fail the job if no labels are found
-        if:  ${{ github.event.pull_request.labels[0] == null }} == 'true'
+      - name: Ensure PR has at least one label
+        if:  ${{ github.event.pull_request.labels[0] == null }}
         run: |
           echo "No labels found: please add at least one label to the PR"
           exit 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -13,7 +13,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Fail the job if no labels are found
-        if:  ${{ github.event.pull_request.labels[0] != null }}
+        if:  ${{ github.event.pull_request.labels[0] == null }} == 'true'
         run: |
           echo "No labels found: please add at least one label to the PR"
           exit 1

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -1,4 +1,4 @@
-name: Check PR Labels
+name: Ensure PR Has Labels
 
 on:
   pull_request:
@@ -11,24 +11,10 @@ on:
 jobs:
   check_labels:
     runs-on: ubuntu-latest
-    permissions:
-      issues: write
-    env:
-      HAS_LABELS: ${{ github.event.pull_request.labels[0] != null }}
     steps:
-      - name: Add a comment to the PR if no labels
-        if: env.HAS_LABELS == 'false'
-        uses: actions/github-script@v6
-        with:
-          script: |
-            github.rest.issues.createComment({
-              issue_number: context.issue.number,
-              owner: context.repo.owner,
-              repo: context.repo.repo,
-              body: 'Your pull request does not have any labels. Please add at least one label to pass the checks.'
-            })
-
       - name: Fail the job if no labels are found
-        if: env.HAS_LABELS == 'false'
-        run: exit 1
+        if:  ${{ github.event.pull_request.labels[0] != null }}
+        run: |
+          echo "No labels found: please add at least one label to the PR"
+          exit 1
         shell: bash


### PR DESCRIPTION
This PR adds a new Github Action, the action checks if there is atleast one PR label present, if not it makes a comment in the PR. This PR addresses issue #2294
### Example: 
- Opening a PR without a label
<img width="1128" alt="image" src="https://github.com/user-attachments/assets/4ccda23d-ebb5-4869-bdf5-213009725da9">

- Adding a label after said comment
<img width="1259" alt="image" src="https://github.com/user-attachments/assets/15e90c56-89cd-4f4c-a42b-8ac157a326bd">
