### PR TITLE
added 'temporal-network' network and changed temporalio/admin-tools

### DIFF
--- a/compose.yml
+++ b/compose.yml
@@ -96,7 +96,7 @@ services:
 
   temporal-seed:
     container_name: neosync-temporal-seed
-    image: temporalio/admin-tools:1.23
+    image: temporalio/admin-tools:1.23.0
     environment:
       - TEMPORAL_ADDRESS=temporal:7233
     entrypoint: /bin/sh -c "/create_schedules.sh"
@@ -141,3 +141,5 @@ volumes:
 networks:
   neosync-network:
     name: neosync-network
+  temporal-network:
+    name: temporal-network

--- a/compose.yml
+++ b/compose.yml
@@ -141,5 +141,3 @@ volumes:
 networks:
   neosync-network:
     name: neosync-network
-  temporal-network:
-    name: temporal-network


### PR DESCRIPTION
changed Dockerfile added network `temporal-network`, and changed temporalio/admin-tools, from 1.23 to 1.23.0

Closes #2356 