### PR TITLE
NEOS-1290: updates benthos dynamodb input to use partiql instead of scan

### DIFF
--- a/worker/pkg/benthos/dynamodb/input.go
+++ b/worker/pkg/benthos/dynamodb/input.go
@@ -112,11 +112,6 @@ func (d *dynamodbInput) ReadBatch(ctx context.Context) (service.MessageBatch, se
 	}
 
 	// todo: allow specifying batch size
-	// result, err := d.client.Scan(ctx, &dynamodb.ScanInput{
-	// 	TableName:         &d.table,
-	// 	ExclusiveStartKey: d.lastEvaluatedKey,
-	// 	ConsistentRead:    aws.Bool(true),
-	// })
 	result, err := d.client.ExecuteStatement(ctx, &dynamodb.ExecuteStatementInput{
 		Statement:      aws.String(fmt.Sprintf(`SELECT * from %q`, d.table)),
 		NextToken:      d.nextToken,

--- a/worker/pkg/benthos/dynamodb/input.go
+++ b/worker/pkg/benthos/dynamodb/input.go
@@ -38,7 +38,7 @@ func RegisterDynamoDbInput(env *service.Environment) error {
 
 type dynamoDBAPIV2 interface {
 	DescribeTable(ctx context.Context, params *dynamodb.DescribeTableInput, optFns ...func(*dynamodb.Options)) (*dynamodb.DescribeTableOutput, error)
-	Scan(ctx context.Context, params *dynamodb.ScanInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)
+	ExecuteStatement(ctx context.Context, params *dynamodb.ExecuteStatementInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ExecuteStatementOutput, error)
 }
 
 func newDynamoDbBatchInput(conf *service.ParsedConfig, logger *service.Logger) (service.BatchInput, error) {
@@ -66,9 +66,9 @@ type dynamodbInput struct {
 	logger    *service.Logger
 	readMu    sync.Mutex
 
-	table            string
-	lastEvaluatedKey map[string]types.AttributeValue
-	done             bool
+	table     string
+	nextToken *string
+	done      bool
 }
 
 var _ service.BatchInput = &dynamodbInput{}
@@ -112,10 +112,15 @@ func (d *dynamodbInput) ReadBatch(ctx context.Context) (service.MessageBatch, se
 	}
 
 	// todo: allow specifying batch size
-	result, err := d.client.Scan(ctx, &dynamodb.ScanInput{
-		TableName:         &d.table,
-		ExclusiveStartKey: d.lastEvaluatedKey,
-		ConsistentRead:    aws.Bool(true),
+	// result, err := d.client.Scan(ctx, &dynamodb.ScanInput{
+	// 	TableName:         &d.table,
+	// 	ExclusiveStartKey: d.lastEvaluatedKey,
+	// 	ConsistentRead:    aws.Bool(true),
+	// })
+	result, err := d.client.ExecuteStatement(ctx, &dynamodb.ExecuteStatementInput{
+		Statement:      aws.String(fmt.Sprintf(`SELECT * from %q`, d.table)),
+		NextToken:      d.nextToken,
+		ConsistentRead: aws.Bool(true),
 	})
 	if err != nil {
 		return nil, nil, err
@@ -131,8 +136,8 @@ func (d *dynamodbInput) ReadBatch(ctx context.Context) (service.MessageBatch, se
 		msg.SetStructuredMut(resMap)
 		batch = append(batch, msg)
 	}
-	d.lastEvaluatedKey = result.LastEvaluatedKey
-	d.done = result.LastEvaluatedKey == nil
+	d.nextToken = result.NextToken
+	d.done = result.NextToken == nil
 
 	return batch, emptyAck, nil
 }

--- a/worker/pkg/benthos/dynamodb/mock_dynamoDBAPIV2.go
+++ b/worker/pkg/benthos/dynamodb/mock_dynamoDBAPIV2.go
@@ -96,8 +96,8 @@ func (_c *MockdynamoDBAPIV2_DescribeTable_Call) RunAndReturn(run func(context.Co
 	return _c
 }
 
-// Scan provides a mock function with given fields: ctx, params, optFns
-func (_m *MockdynamoDBAPIV2) Scan(ctx context.Context, params *dynamodb.ScanInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error) {
+// ExecuteStatement provides a mock function with given fields: ctx, params, optFns
+func (_m *MockdynamoDBAPIV2) ExecuteStatement(ctx context.Context, params *dynamodb.ExecuteStatementInput, optFns ...func(*dynamodb.Options)) (*dynamodb.ExecuteStatementOutput, error) {
 	_va := make([]interface{}, len(optFns))
 	for _i := range optFns {
 		_va[_i] = optFns[_i]
@@ -108,23 +108,23 @@ func (_m *MockdynamoDBAPIV2) Scan(ctx context.Context, params *dynamodb.ScanInpu
 	ret := _m.Called(_ca...)
 
 	if len(ret) == 0 {
-		panic("no return value specified for Scan")
+		panic("no return value specified for ExecuteStatement")
 	}
 
-	var r0 *dynamodb.ScanOutput
+	var r0 *dynamodb.ExecuteStatementOutput
 	var r1 error
-	if rf, ok := ret.Get(0).(func(context.Context, *dynamodb.ScanInput, ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *dynamodb.ExecuteStatementInput, ...func(*dynamodb.Options)) (*dynamodb.ExecuteStatementOutput, error)); ok {
 		return rf(ctx, params, optFns...)
 	}
-	if rf, ok := ret.Get(0).(func(context.Context, *dynamodb.ScanInput, ...func(*dynamodb.Options)) *dynamodb.ScanOutput); ok {
+	if rf, ok := ret.Get(0).(func(context.Context, *dynamodb.ExecuteStatementInput, ...func(*dynamodb.Options)) *dynamodb.ExecuteStatementOutput); ok {
 		r0 = rf(ctx, params, optFns...)
 	} else {
 		if ret.Get(0) != nil {
-			r0 = ret.Get(0).(*dynamodb.ScanOutput)
+			r0 = ret.Get(0).(*dynamodb.ExecuteStatementOutput)
 		}
 	}
 
-	if rf, ok := ret.Get(1).(func(context.Context, *dynamodb.ScanInput, ...func(*dynamodb.Options)) error); ok {
+	if rf, ok := ret.Get(1).(func(context.Context, *dynamodb.ExecuteStatementInput, ...func(*dynamodb.Options)) error); ok {
 		r1 = rf(ctx, params, optFns...)
 	} else {
 		r1 = ret.Error(1)
@@ -133,21 +133,21 @@ func (_m *MockdynamoDBAPIV2) Scan(ctx context.Context, params *dynamodb.ScanInpu
 	return r0, r1
 }
 
-// MockdynamoDBAPIV2_Scan_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'Scan'
-type MockdynamoDBAPIV2_Scan_Call struct {
+// MockdynamoDBAPIV2_ExecuteStatement_Call is a *mock.Call that shadows Run/Return methods with type explicit version for method 'ExecuteStatement'
+type MockdynamoDBAPIV2_ExecuteStatement_Call struct {
 	*mock.Call
 }
 
-// Scan is a helper method to define mock.On call
+// ExecuteStatement is a helper method to define mock.On call
 //   - ctx context.Context
-//   - params *dynamodb.ScanInput
+//   - params *dynamodb.ExecuteStatementInput
 //   - optFns ...func(*dynamodb.Options)
-func (_e *MockdynamoDBAPIV2_Expecter) Scan(ctx interface{}, params interface{}, optFns ...interface{}) *MockdynamoDBAPIV2_Scan_Call {
-	return &MockdynamoDBAPIV2_Scan_Call{Call: _e.mock.On("Scan",
+func (_e *MockdynamoDBAPIV2_Expecter) ExecuteStatement(ctx interface{}, params interface{}, optFns ...interface{}) *MockdynamoDBAPIV2_ExecuteStatement_Call {
+	return &MockdynamoDBAPIV2_ExecuteStatement_Call{Call: _e.mock.On("ExecuteStatement",
 		append([]interface{}{ctx, params}, optFns...)...)}
 }
 
-func (_c *MockdynamoDBAPIV2_Scan_Call) Run(run func(ctx context.Context, params *dynamodb.ScanInput, optFns ...func(*dynamodb.Options))) *MockdynamoDBAPIV2_Scan_Call {
+func (_c *MockdynamoDBAPIV2_ExecuteStatement_Call) Run(run func(ctx context.Context, params *dynamodb.ExecuteStatementInput, optFns ...func(*dynamodb.Options))) *MockdynamoDBAPIV2_ExecuteStatement_Call {
 	_c.Call.Run(func(args mock.Arguments) {
 		variadicArgs := make([]func(*dynamodb.Options), len(args)-2)
 		for i, a := range args[2:] {
@@ -155,17 +155,17 @@ func (_c *MockdynamoDBAPIV2_Scan_Call) Run(run func(ctx context.Context, params 
 				variadicArgs[i] = a.(func(*dynamodb.Options))
 			}
 		}
-		run(args[0].(context.Context), args[1].(*dynamodb.ScanInput), variadicArgs...)
+		run(args[0].(context.Context), args[1].(*dynamodb.ExecuteStatementInput), variadicArgs...)
 	})
 	return _c
 }
 
-func (_c *MockdynamoDBAPIV2_Scan_Call) Return(_a0 *dynamodb.ScanOutput, _a1 error) *MockdynamoDBAPIV2_Scan_Call {
+func (_c *MockdynamoDBAPIV2_ExecuteStatement_Call) Return(_a0 *dynamodb.ExecuteStatementOutput, _a1 error) *MockdynamoDBAPIV2_ExecuteStatement_Call {
 	_c.Call.Return(_a0, _a1)
 	return _c
 }
 
-func (_c *MockdynamoDBAPIV2_Scan_Call) RunAndReturn(run func(context.Context, *dynamodb.ScanInput, ...func(*dynamodb.Options)) (*dynamodb.ScanOutput, error)) *MockdynamoDBAPIV2_Scan_Call {
+func (_c *MockdynamoDBAPIV2_ExecuteStatement_Call) RunAndReturn(run func(context.Context, *dynamodb.ExecuteStatementInput, ...func(*dynamodb.Options)) (*dynamodb.ExecuteStatementOutput, error)) *MockdynamoDBAPIV2_ExecuteStatement_Call {
 	_c.Call.Return(run)
 	return _c
 }


### PR DESCRIPTION
Prepares us for enabling user-defined subsetting for dynamodb