### PR TITLE
NEOS-1295: moves seed to be deferred for transformations

### DIFF
--- a/docs/docs/transformers/gen-javascript-transformer.md
+++ b/docs/docs/transformers/gen-javascript-transformer.md
@@ -442,7 +442,7 @@ Generates a boolean value at random.
 
 | Field    | Type | Default | Required | Description |
 | -------- | ---- | ------- | -------- | ----------- |
-| seed | int64 | Unix timestamp in nanoseconds | false | An optional seed value used to generate deterministic outputs.
+| seed | int64 |  | false | An optional seed value used to generate deterministic outputs.
 <br/>
 
 **Example**
@@ -450,7 +450,7 @@ Generates a boolean value at random.
 ```javascript
 
 const newValue = neosync.generateBool({ 
-	seed: 1,
+	seed: 1, 
 });
 
 ```
@@ -592,7 +592,7 @@ Generates a random first name.
 | Field    | Type | Default | Required | Description |
 | -------- | ---- | ------- | -------- | ----------- |
 | maxLength | int64 | 10000 | false | Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.
-| seed | int64 | Unix timestamp in nanoseconds | false | An optional seed value used to generate deterministic outputs.
+| seed | int64 |  | false | An optional seed value used to generate deterministic outputs.
 <br/>
 
 **Example**
@@ -601,7 +601,7 @@ Generates a random first name.
 
 const newValue = neosync.generateFirstName({ 
 	maxLength: 10000, 
-	seed: 1,
+	seed: 1, 
 });
 
 ```
@@ -627,7 +627,7 @@ Generates a random float64 value.
 | max | float64 |  | true | Specifies the maximum value for the generated float
 | precision | int64 |  | false | An optional parameter that defines the number of significant digits for the generated float.
 | scale | int64 |  | false | An optional parameter that defines the number of decimal places for the generated float.
-| seed | int64 | Unix timestamp in nanoseconds | false | An optional seed value used to generate deterministic outputs.
+| seed | int64 |  | false | An optional seed value used to generate deterministic outputs.
 <br/>
 
 **Example**
@@ -640,7 +640,7 @@ const newValue = neosync.generateFloat64({
 	max: 1.12,  
 	precision: 1,  
 	scale: 1,  
-	seed: 1,
+	seed: 1, 
 });
 
 ```
@@ -691,7 +691,7 @@ Generates a new full name consisting of a first and last name.
 | Field    | Type | Default | Required | Description |
 | -------- | ---- | ------- | -------- | ----------- |
 | maxLength | int64 | 10000 | false | Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.
-| seed | int64 | Unix timestamp in nanoseconds | false | An optional seed value used to generate deterministic outputs.
+| seed | int64 |  | false | An optional seed value used to generate deterministic outputs.
 <br/>
 
 **Example**
@@ -700,7 +700,7 @@ Generates a new full name consisting of a first and last name.
 
 const newValue = neosync.generateFullName({ 
 	maxLength: 10000, 
-	seed: 1,
+	seed: 1, 
 });
 
 ```
@@ -723,7 +723,7 @@ Randomly generates one of the following genders: female, male, undefined, nonbin
 | -------- | ---- | ------- | -------- | ----------- |
 | abbreviate | bool | false | false | Shortens length of generated value to 1.
 | maxLength | int64 | 10000 | false | Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.
-| seed | int64 | Unix timestamp in nanoseconds | false | An optional seed value used to generate deterministic outputs.
+| seed | int64 |  | false | An optional seed value used to generate deterministic outputs.
 <br/>
 
 **Example**
@@ -733,7 +733,7 @@ Randomly generates one of the following genders: female, male, undefined, nonbin
 const newValue = neosync.generateGender({ 
 	abbreviate: false, 
 	maxLength: 10000, 
-	seed: 1,
+	seed: 1, 
 });
 
 ```
@@ -757,7 +757,6 @@ Generates a random integer value with a default length of 4 unless the Integer L
 | randomizeSign | bool | false | false | A boolean indicating whether the sign of the float should be randomized.
 | min | int64 |  | true | Specifies the minimum value for the generated int.
 | max | int64 |  | true | Specifies the maximum value for the generated int.
-| seed | int64 | Unix timestamp in nanoseconds | false | An optional seed value used to generate deterministic outputs.
 <br/>
 
 **Example**
@@ -767,8 +766,7 @@ Generates a random integer value with a default length of 4 unless the Integer L
 const newValue = neosync.generateInt64({ 
 	randomizeSign: false, 
 	min: 1,  
-	max: 1,  
-	seed: 1,
+	max: 1, 
 });
 
 ```
@@ -847,7 +845,7 @@ Generates a random last name.
 | Field    | Type | Default | Required | Description |
 | -------- | ---- | ------- | -------- | ----------- |
 | maxLength | int64 | 10000 | false | Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.
-| seed | int64 | Unix timestamp in nanoseconds | false | An optional seed value used to generate deterministic outputs.
+| seed | int64 |  | false | An optional seed value used to generate deterministic outputs.
 <br/>
 
 **Example**
@@ -856,7 +854,7 @@ Generates a random last name.
 
 const newValue = neosync.generateLastName({ 
 	maxLength: 10000, 
-	seed: 1,
+	seed: 1, 
 });
 
 ```
@@ -934,7 +932,7 @@ Generates a completely random social security numbers including the hyphens in t
 
 | Field    | Type | Default | Required | Description |
 | -------- | ---- | ------- | -------- | ----------- |
-| seed | int64 | Unix timestamp in nanoseconds | false | An optional seed value used to generate deterministic outputs.
+| seed | int64 |  | false | An optional seed value used to generate deterministic outputs.
 <br/>
 
 **Example**
@@ -942,7 +940,7 @@ Generates a completely random social security numbers including the hyphens in t
 ```javascript
 
 const newValue = neosync.generateSSN({ 
-	seed: 1,
+	seed: 1, 
 });
 
 ```
@@ -1079,7 +1077,7 @@ Randomly generates a username
 | Field    | Type | Default | Required | Description |
 | -------- | ---- | ------- | -------- | ----------- |
 | maxLength | int64 | 10000 | false | Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.
-| seed | int64 | Unix timestamp in nanoseconds | false | An optional seed value used to generate deterministic outputs.
+| seed | int64 |  | false | An optional seed value used to generate deterministic outputs.
 <br/>
 
 **Example**
@@ -1088,7 +1086,7 @@ Randomly generates a username
 
 const newValue = neosync.generateUsername({ 
 	maxLength: 10000, 
-	seed: 1,
+	seed: 1, 
 });
 
 ```

--- a/worker/pkg/benthos/transformers/gen_generate_int64.go
+++ b/worker/pkg/benthos/transformers/gen_generate_int64.go
@@ -7,16 +7,11 @@ package transformers
 import (
 	"fmt"
 	
-	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
-	"github.com/nucleuscloud/neosync/worker/pkg/rng"
-	
 )
 
 type GenerateInt64 struct{}
 
 type GenerateInt64Opts struct {
-	randomizer     rng.Rand
-	
 	randomizeSign bool
 	min int64
 	max int64
@@ -54,19 +49,6 @@ func (t *GenerateInt64) ParseOptions(opts map[string]any) (any, error) {
 	}
 	max := opts["max"].(int64)
 	transformerOpts.max = max
-
-	var seed int64
-	seedArg, ok := opts["seed"].(int64)
-	if ok {
-		seed = seedArg
-	} else {
-		var err error
-		seed, err = transformer_utils.GenerateCryptoSeed()
-		if err != nil {
-			return nil, fmt.Errorf("unable to generate seed: %w", err)
-		}
-	}
-	transformerOpts.randomizer = rng.New(seed)
 
 	return transformerOpts, nil
 }

--- a/worker/pkg/benthos/transformers/generate_bool.go
+++ b/worker/pkg/benthos/transformers/generate_bool.go
@@ -3,8 +3,8 @@ package transformers
 import (
 	"errors"
 	"math/rand"
-	"time"
 
+	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
 	"github.com/nucleuscloud/neosync/worker/pkg/rng"
 	"github.com/warpstreamlabs/bento/public/bloblang"
 )
@@ -14,10 +14,15 @@ import (
 func init() {
 	spec := bloblang.NewPluginSpec().
 		Description("Generates a boolean value at random.").
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()).Description("An optional seed value used to generate deterministic outputs."))
+		Param(bloblang.NewInt64Param("seed").Optional().Description("An optional seed value used to generate deterministic outputs."))
 
 	err := bloblang.RegisterFunctionV2("generate_bool", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
+		if err != nil {
+			return nil, err
+		}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/pkg/benthos/transformers/generate_email.go
+++ b/worker/pkg/benthos/transformers/generate_email.go
@@ -52,16 +52,10 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		var seed int64
-		if seedArg != nil {
-			seed = *seedArg
-		} else {
-			// we want a bit more randomness here with generate_email so using something that isn't time based
-			var err error
-			seed, err = transformer_utils.GenerateCryptoSeed()
-			if err != nil {
-				return nil, err
-			}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
+		if err != nil {
+			return nil, err
 		}
 		randomizer := rng.New(seed)
 

--- a/worker/pkg/benthos/transformers/generate_first_name.go
+++ b/worker/pkg/benthos/transformers/generate_first_name.go
@@ -3,7 +3,6 @@ package transformers
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	transformers_dataset "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/data-sets"
 	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
@@ -17,14 +16,19 @@ func init() {
 	spec := bloblang.NewPluginSpec().
 		Description("Generates a random first name.").
 		Param(bloblang.NewInt64Param("max_length").Default(10000).Description("Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.")).
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()).Description("An optional seed value used to generate deterministic outputs."))
+		Param(bloblang.NewInt64Param("seed").Optional().Description("An optional seed value used to generate deterministic outputs."))
 
 	err := bloblang.RegisterFunctionV2("generate_first_name", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		maxLength, err := args.GetInt64("max_length")
 		if err != nil {
 			return nil, err
 		}
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
+		if err != nil {
+			return nil, err
+		}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/pkg/benthos/transformers/generate_float.go
+++ b/worker/pkg/benthos/transformers/generate_float.go
@@ -6,7 +6,6 @@ import (
 	"math"
 	"strconv"
 	"strings"
-	"time"
 
 	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
 	"github.com/nucleuscloud/neosync/worker/pkg/rng"
@@ -23,7 +22,7 @@ func init() {
 		Param(bloblang.NewFloat64Param("max").Description("Specifies the maximum value for the generated float")).
 		Param(bloblang.NewInt64Param("precision").Optional().Description("An optional parameter that defines the number of significant digits for the generated float.")).
 		Param(bloblang.NewInt64Param("scale").Optional().Description("An optional parameter that defines the number of decimal places for the generated float.")).
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()).Description("An optional seed value used to generate deterministic outputs."))
+		Param(bloblang.NewInt64Param("seed").Optional().Description("An optional seed value used to generate deterministic outputs."))
 
 	err := bloblang.RegisterFunctionV2("generate_float64", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		randomizeSign, err := args.GetBool("randomize_sign")
@@ -49,7 +48,12 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
+		if err != nil {
+			return nil, err
+		}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/pkg/benthos/transformers/generate_full_name.go
+++ b/worker/pkg/benthos/transformers/generate_full_name.go
@@ -3,7 +3,6 @@ package transformers
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	transformers_dataset "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/data-sets"
 	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
@@ -17,14 +16,19 @@ func init() {
 	spec := bloblang.NewPluginSpec().
 		Description("Generates a new full name consisting of a first and last name.").
 		Param(bloblang.NewInt64Param("max_length").Default(10000).Description("Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.")).
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()).Description("An optional seed value used to generate deterministic outputs."))
+		Param(bloblang.NewInt64Param("seed").Optional().Description("An optional seed value used to generate deterministic outputs."))
 
 	err := bloblang.RegisterFunctionV2("generate_full_name", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		maxLength, err := args.GetInt64("max_length")
 		if err != nil {
 			return nil, err
 		}
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
+		if err != nil {
+			return nil, err
+		}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/pkg/benthos/transformers/generate_gender.go
+++ b/worker/pkg/benthos/transformers/generate_gender.go
@@ -2,7 +2,6 @@ package transformers
 
 import (
 	"errors"
-	"time"
 
 	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
 	"github.com/nucleuscloud/neosync/worker/pkg/rng"
@@ -16,7 +15,7 @@ func init() {
 		Description("Randomly generates one of the following genders: female, male, undefined, nonbinary.").
 		Param(bloblang.NewBoolParam("abbreviate").Default(false).Description("Shortens length of generated value to 1.")).
 		Param(bloblang.NewInt64Param("max_length").Default(10000).Description("Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.")).
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()).Description("An optional seed value used to generate deterministic outputs."))
+		Param(bloblang.NewInt64Param("seed").Optional().Description("An optional seed value used to generate deterministic outputs."))
 
 	err := bloblang.RegisterFunctionV2("generate_gender", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		shouldAbbreviate, err := args.GetBool("abbreviate")
@@ -29,7 +28,12 @@ func init() {
 			return nil, err
 		}
 
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
+		if err != nil {
+			return nil, err
+		}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/pkg/benthos/transformers/generate_int64.go
+++ b/worker/pkg/benthos/transformers/generate_int64.go
@@ -3,7 +3,6 @@ package transformers
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
 	"github.com/warpstreamlabs/bento/public/bloblang"
@@ -32,8 +31,7 @@ func init() {
 		Description("Generates a random integer value with a default length of 4 unless the Integer Length or Preserve Length parameters are defined.").
 		Param(bloblang.NewBoolParam("randomize_sign").Default(false).Description("A boolean indicating whether the sign of the float should be randomized.")).
 		Param(bloblang.NewInt64Param("min").Description("Specifies the minimum value for the generated int.")).
-		Param(bloblang.NewInt64Param("max").Description("Specifies the maximum value for the generated int.")).
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()).Description("An optional seed value used to generate deterministic outputs."))
+		Param(bloblang.NewInt64Param("max").Description("Specifies the maximum value for the generated int."))
 
 	err := bloblang.RegisterFunctionV2("generate_int64", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		randomizeSign, err := args.GetBool("randomize_sign")

--- a/worker/pkg/benthos/transformers/generate_last_name.go
+++ b/worker/pkg/benthos/transformers/generate_last_name.go
@@ -3,7 +3,6 @@ package transformers
 import (
 	"errors"
 	"fmt"
-	"time"
 
 	transformers_dataset "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/data-sets"
 	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
@@ -17,14 +16,19 @@ func init() {
 	spec := bloblang.NewPluginSpec().
 		Description("Generates a random last name.").
 		Param(bloblang.NewInt64Param("max_length").Default(10000).Description("Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.")).
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()).Description("An optional seed value used to generate deterministic outputs."))
+		Param(bloblang.NewInt64Param("seed").Optional().Description("An optional seed value used to generate deterministic outputs."))
 
 	err := bloblang.RegisterFunctionV2("generate_last_name", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		maxLength, err := args.GetInt64("max_length")
 		if err != nil {
 			return nil, err
 		}
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
+		if err != nil {
+			return nil, err
+		}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/pkg/benthos/transformers/generate_ssn.go
+++ b/worker/pkg/benthos/transformers/generate_ssn.go
@@ -3,8 +3,8 @@ package transformers
 import (
 	"errors"
 	"fmt"
-	"time"
 
+	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
 	"github.com/nucleuscloud/neosync/worker/pkg/rng"
 	"github.com/warpstreamlabs/bento/public/bloblang"
 )
@@ -14,10 +14,15 @@ import (
 func init() {
 	spec := bloblang.NewPluginSpec().
 		Description("Generates a completely random social security numbers including the hyphens in the format xxx-xx-xxxx.").
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()).Description("An optional seed value used to generate deterministic outputs."))
+		Param(bloblang.NewInt64Param("seed").Optional().Description("An optional seed value used to generate deterministic outputs."))
 
 	err := bloblang.RegisterFunctionV2("generate_ssn", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
+		if err != nil {
+			return nil, err
+		}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/pkg/benthos/transformers/generate_username.go
+++ b/worker/pkg/benthos/transformers/generate_username.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"strings"
-	"time"
 
 	transformer_utils "github.com/nucleuscloud/neosync/worker/pkg/benthos/transformers/utils"
 	"github.com/nucleuscloud/neosync/worker/pkg/rng"
@@ -17,14 +16,19 @@ func init() {
 	spec := bloblang.NewPluginSpec().
 		Description("Randomly generates a username").
 		Param(bloblang.NewInt64Param("max_length").Default(10000).Description("Specifies the maximum length for the generated data. This field ensures that the output does not exceed a certain number of characters.")).
-		Param(bloblang.NewInt64Param("seed").Default(time.Now().UnixNano()).Description("An optional seed value used to generate deterministic outputs."))
+		Param(bloblang.NewInt64Param("seed").Optional().Description("An optional seed value used to generate deterministic outputs."))
 
 	err := bloblang.RegisterFunctionV2("generate_username", spec, func(args *bloblang.ParsedParams) (bloblang.Function, error) {
 		maxLength, err := args.GetInt64("max_length")
 		if err != nil {
 			return nil, err
 		}
-		seed, err := args.GetInt64("seed")
+		seedArg, err := args.GetOptionalInt64("seed")
+		if err != nil {
+			return nil, err
+		}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
 		if err != nil {
 			return nil, err
 		}

--- a/worker/pkg/benthos/transformers/transform_email.go
+++ b/worker/pkg/benthos/transformers/transform_email.go
@@ -103,16 +103,10 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		var seed int64
-		if seedArg != nil {
-			seed = *seedArg
-		} else {
-			// we want a bit more randomness here with generate_email so using something that isn't time based
-			var err error
-			seed, err = transformer_utils.GenerateCryptoSeed()
-			if err != nil {
-				return nil, err
-			}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
+		if err != nil {
+			return nil, err
 		}
 		randomizer := rng.New(seed)
 		return func() (any, error) {

--- a/worker/pkg/benthos/transformers/transform_first_name.go
+++ b/worker/pkg/benthos/transformers/transform_first_name.go
@@ -44,16 +44,10 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		var seed int64
-		if seedArg != nil {
-			seed = *seedArg
-		} else {
-			// we want a bit more randomness here with generate_email so using something that isn't time based
-			var err error
-			seed, err = transformer_utils.GenerateCryptoSeed()
-			if err != nil {
-				return nil, err
-			}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
+		if err != nil {
+			return nil, err
 		}
 
 		randomizer := rng.New(seed)

--- a/worker/pkg/benthos/transformers/transform_float.go
+++ b/worker/pkg/benthos/transformers/transform_float.go
@@ -52,16 +52,10 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		var seed int64
-		if seedArg != nil {
-			seed = *seedArg
-		} else {
-			// we want a bit more randomness here with generate_email so using something that isn't time based
-			var err error
-			seed, err = transformer_utils.GenerateCryptoSeed()
-			if err != nil {
-				return nil, err
-			}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
+		if err != nil {
+			return nil, err
 		}
 		randomizer := rng.New(seed)
 

--- a/worker/pkg/benthos/transformers/transform_full_name.go
+++ b/worker/pkg/benthos/transformers/transform_full_name.go
@@ -45,16 +45,10 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		var seed int64
-		if seedArg != nil {
-			seed = *seedArg
-		} else {
-			// we want a bit more randomness here with generate_email so using something that isn't time based
-			var err error
-			seed, err = transformer_utils.GenerateCryptoSeed()
-			if err != nil {
-				return nil, err
-			}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
+		if err != nil {
+			return nil, err
 		}
 
 		randomizer := rng.New(seed)

--- a/worker/pkg/benthos/transformers/transform_lastname.go
+++ b/worker/pkg/benthos/transformers/transform_lastname.go
@@ -43,16 +43,10 @@ func init() {
 		if err != nil {
 			return nil, err
 		}
-		var seed int64
-		if seedArg != nil {
-			seed = *seedArg
-		} else {
-			// we want a bit more randomness here with generate_email so using something that isn't time based
-			var err error
-			seed, err = transformer_utils.GenerateCryptoSeed()
-			if err != nil {
-				return nil, err
-			}
+
+		seed, err := transformer_utils.GetSeedOrDefault(seedArg)
+		if err != nil {
+			return nil, err
 		}
 
 		randomizer := rng.New(seed)

--- a/worker/pkg/benthos/transformers/utils/integer_utils.go
+++ b/worker/pkg/benthos/transformers/utils/integer_utils.go
@@ -147,3 +147,10 @@ func GenerateCryptoSeed() (int64, error) {
 	}
 	return n.Int64(), nil
 }
+
+func GetSeedOrDefault(seed *int64) (int64, error) {
+	if seed != nil {
+		return *seed, nil
+	}
+	return GenerateCryptoSeed()
+}


### PR DESCRIPTION
This was causing the generated values to be the same every time inbetween runs in the default case.