### PR TITLE
updates default openai common models to document latest gpt models

### DIFF
--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/aigenerate/single/schema/SelectModelNames.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/aigenerate/single/schema/SelectModelNames.tsx
@@ -15,7 +15,7 @@ interface Props {
 
 // Add more common models here to make it easier for folks to plug in to well known OpenAI compatible platforms
 const COMMON_MODELS = {
-  OpenAI: ['gpt-3.5-turbo', 'gpt-4', 'gpt-4-32k', 'gpt-4-turbo', 'gpt-4o'],
+  OpenAI: ['gpt-4o-mini', 'gpt-4o', 'gpt-4-turbo'],
 };
 
 export default function SelectModelNames(props: Props): ReactElement {


### PR DESCRIPTION
Also removes gpt-4 as it hasnt worked in months. Removes 3.5 as it's recommended by openai to be replaced by 4-o-mini