### PR TITLE
NEOS-1361, NEOS-1370: Support updating mongo mappings inline

### DIFF
--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataSyncConnectionCard.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataSyncConnectionCard.tsx
@@ -609,21 +609,10 @@ export default function DataSyncConnectionCard({ jobId }: Props): ReactElement {
                 form.setValue('destinationOptions', updatedDestOpts);
               }}
               onEditMappings={(values) => {
-                const valuesMap = new Map(
-                  values.map((v) => [
-                    `${v.schema}.${v.table}.${v.column}`,
-                    v.transformer,
-                  ])
-                );
+                const valuesMap = new Map(values.map((v) => [`${v.id}`, v]));
                 formMappings.forEach((fm, idx) => {
-                  const fmKey = `${fm.schema}.${fm.table}.${fm.column}`;
-                  const fmTrans = valuesMap.get(fmKey);
-                  if (fmTrans) {
-                    update(idx, {
-                      ...fm,
-                      transformer: fmTrans,
-                    });
-                  }
+                  const value = valuesMap.get(fm.id);
+                  update(idx, value ?? fm);
                 });
               }}
               onAddMappings={(values) => {

--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataSyncConnectionCard.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataSyncConnectionCard.tsx
@@ -608,12 +608,10 @@ export default function DataSyncConnectionCard({ jobId }: Props): ReactElement {
                   );
                 form.setValue('destinationOptions', updatedDestOpts);
               }}
-              onEditMappings={(values) => {
-                const valuesMap = new Map(values.map((v) => [`${v.id}`, v]));
-                formMappings.forEach((fm, idx) => {
-                  const value = valuesMap.get(fm.id);
-                  update(idx, value ?? fm);
-                });
+              onEditMappings={(values, index) => {
+                if (index >= 0 && index < formMappings.length) {
+                  update(index, values);
+                }
               }}
               onAddMappings={(values) => {
                 append(

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
@@ -542,7 +542,6 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 form.setValue('destinationOptions', updatedDestOpts);
               }}
               onEditMappings={(values) => {
-                console.log('values', values);
                 const valuesMap = new Map(
                   values.map((v) => [
                     `${v.schema}.${v.table}.${v.column}`,

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
@@ -541,10 +541,10 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                   );
                 form.setValue('destinationOptions', updatedDestOpts);
               }}
-              onEditMappings={(values) => {
-                values.forEach((fm, idx) => {
-                  update(idx, fm);
-                });
+              onEditMappings={(values, index) => {
+                if (index >= 0 && index < formMappings.length) {
+                  update(index, values);
+                }
               }}
               onAddMappings={(values) => {
                 append(

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
@@ -542,6 +542,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 form.setValue('destinationOptions', updatedDestOpts);
               }}
               onEditMappings={(values) => {
+                console.log('values', values);
                 const valuesMap = new Map(
                   values.map((v) => [
                     `${v.schema}.${v.table}.${v.column}`,

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
@@ -542,21 +542,8 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                 form.setValue('destinationOptions', updatedDestOpts);
               }}
               onEditMappings={(values) => {
-                const valuesMap = new Map(
-                  values.map((v) => [
-                    `${v.schema}.${v.table}.${v.column}`,
-                    v.transformer,
-                  ])
-                );
-                formMappings.forEach((fm, idx) => {
-                  const fmKey = `${fm.schema}.${fm.table}.${fm.column}`;
-                  const fmTrans = valuesMap.get(fmKey);
-                  if (fmTrans) {
-                    update(idx, {
-                      ...fm,
-                      transformer: fmTrans,
-                    });
-                  }
+                values.forEach((fm, idx) => {
+                  update(idx, fm);
                 });
               }}
               onAddMappings={(values) => {

--- a/frontend/apps/web/components/jobs/NosqlTable/NosqlTable.tsx
+++ b/frontend/apps/web/components/jobs/NosqlTable/NosqlTable.tsx
@@ -427,6 +427,7 @@ function getColumns(props: GetColumnsProps): ColumnDef<Row>[] {
                 table: updatedObject.collection.split('.')[1],
                 column: row.getValue('column'),
                 transformer: row.getValue('transformer'),
+                id: row.original.id,
               });
             }}
           />
@@ -451,6 +452,7 @@ function getColumns(props: GetColumnsProps): ColumnDef<Row>[] {
                 table: row.getValue('table'),
                 column: updatedObject.column,
                 transformer: row.getValue('transformer'),
+                id: row.original.id,
               });
             }}
           />
@@ -500,6 +502,7 @@ function getColumns(props: GetColumnsProps): ColumnDef<Row>[] {
                       table: row.getValue('table'),
                       column: row.getValue('column'),
                       transformer: updatedTransformer,
+                      id: row.original.id,
                     })
                   }
                   side={'left'}
@@ -516,6 +519,7 @@ function getColumns(props: GetColumnsProps): ColumnDef<Row>[] {
                     table: row.getValue('table'),
                     column: row.getValue('column'),
                     transformer: updatedTransformer,
+                    id: row.original.id,
                   });
                 }}
                 disabled={!transformer}
@@ -622,21 +626,24 @@ function EditCollection(props: EditCollectionProps): ReactElement {
   const { collections, text, onEdit } = props;
 
   const [isEditingMapping, setIsEditingMapping] = useState<boolean>(false);
-  const [collection, setCollection] = useState<string>(text);
+  const [isSelectedCollection, setSelectedCollection] = useState<string>(text);
 
   const handleSave = () => {
-    onEdit({ collection: collection });
+    onEdit({ collection: isSelectedCollection });
     setIsEditingMapping(false);
   };
 
   return (
     <div className="w-full flex flex-row items-center gap-4">
       {isEditingMapping ? (
-        <Select onValueChange={(val) => setCollection(val)} value={collection}>
+        <Select
+          onValueChange={(val) => setSelectedCollection(val)}
+          value={isSelectedCollection}
+        >
           <SelectTrigger>
             <SelectValue
               placeholder="Select a collection"
-              className="placeholder:text-muted-foreground/70 "
+              className="placeholder:text-muted-foreground/70"
             />
           </SelectTrigger>
           <SelectContent>
@@ -648,7 +655,7 @@ function EditCollection(props: EditCollectionProps): ReactElement {
           </SelectContent>
         </Select>
       ) : (
-        <TruncatedText text={collection} />
+        <TruncatedText text={isSelectedCollection} />
       )}
       <Button
         variant="outline"

--- a/frontend/apps/web/components/jobs/NosqlTable/NosqlTable.tsx
+++ b/frontend/apps/web/components/jobs/NosqlTable/NosqlTable.tsx
@@ -84,7 +84,7 @@ interface Props {
   formErrors: FormError[];
   onAddMappings(values: AddNewNosqlRecordFormValues[]): void;
   onRemoveMappings(values: JobMappingFormValues[]): void;
-  onEditMappings(values: JobMappingFormValues[]): void;
+  onEditMappings(values: JobMappingFormValues, index: number): void;
 
   destinationOptions: EditDestinationOptionsFormValues[];
   destinationDetailsRecord: Record<string, DestinationDetails>;
@@ -121,8 +121,8 @@ export default function NosqlTable(props: Props): ReactElement {
         onDelete(row) {
           onRemoveMappings([row]);
         },
-        onEdit(row) {
-          onEditMappings([row]);
+        onEdit(row, index) {
+          onEditMappings(row, index);
         },
         transformerHandler: handler,
         collections: collections,
@@ -356,7 +356,7 @@ function AddNewRecord(props: AddNewRecordProps): ReactElement {
 interface GetColumnsProps {
   onDelete(row: Row): void;
   transformerHandler: TransformerHandler;
-  onEdit(row: Row): void;
+  onEdit(row: Row, index: number): void;
   collections: string[];
 }
 
@@ -422,13 +422,15 @@ function getColumns(props: GetColumnsProps): ColumnDef<Row>[] {
             collections={collections}
             text={getValue<string>()}
             onEdit={(updatedObject) => {
-              onEdit({
-                schema: updatedObject.collection.split('.')[0],
-                table: updatedObject.collection.split('.')[1],
-                column: row.getValue('column'),
-                transformer: row.getValue('transformer'),
-                id: row.original.id,
-              });
+              onEdit(
+                {
+                  schema: updatedObject.collection.split('.')[0],
+                  table: updatedObject.collection.split('.')[1],
+                  column: row.getValue('column'),
+                  transformer: row.getValue('transformer'),
+                },
+                row.index
+              );
             }}
           />
         );
@@ -447,13 +449,15 @@ function getColumns(props: GetColumnsProps): ColumnDef<Row>[] {
           <EditDocumentKey
             text={text}
             onEdit={(updatedObject) => {
-              onEdit({
-                schema: row.getValue('schema'),
-                table: row.getValue('table'),
-                column: updatedObject.column,
-                transformer: row.getValue('transformer'),
-                id: row.original.id,
-              });
+              onEdit(
+                {
+                  schema: row.getValue('schema'),
+                  table: row.getValue('table'),
+                  column: updatedObject.column,
+                  transformer: row.getValue('transformer'),
+                },
+                row.index
+              );
             }}
           />
         );
@@ -497,13 +501,15 @@ function getColumns(props: GetColumnsProps): ColumnDef<Row>[] {
                   buttonText={buttonText}
                   value={fv}
                   onSelect={(updatedTransformer) =>
-                    onEdit({
-                      schema: row.getValue('schema'),
-                      table: row.getValue('table'),
-                      column: row.getValue('column'),
-                      transformer: updatedTransformer,
-                      id: row.original.id,
-                    })
+                    onEdit(
+                      {
+                        schema: row.getValue('schema'),
+                        table: row.getValue('table'),
+                        column: row.getValue('column'),
+                        transformer: updatedTransformer,
+                      },
+                      row.index
+                    )
                   }
                   side={'left'}
                   disabled={false}
@@ -514,13 +520,15 @@ function getColumns(props: GetColumnsProps): ColumnDef<Row>[] {
                 transformer={transformer ?? new SystemTransformer()}
                 value={fv}
                 onSubmit={(updatedTransformer) => {
-                  onEdit({
-                    schema: row.getValue('schema'),
-                    table: row.getValue('table'),
-                    column: row.getValue('column'),
-                    transformer: updatedTransformer,
-                    id: row.original.id,
-                  });
+                  onEdit(
+                    {
+                      schema: row.getValue('schema'),
+                      table: row.getValue('table'),
+                      column: row.getValue('column'),
+                      transformer: updatedTransformer,
+                    },
+                    row.index
+                  );
                 }}
                 disabled={!transformer}
               />

--- a/frontend/apps/web/components/jobs/SchemaTable/SchemaPageTable.tsx
+++ b/frontend/apps/web/components/jobs/SchemaTable/SchemaPageTable.tsx
@@ -50,7 +50,6 @@ export default function SchemaPageTable<TData, TValue>({
     data,
     columns,
     initialState: {
-      sorting: [{ id: 'schemaTable', desc: false }],
       columnVisibility: {
         schema: false,
         table: false,

--- a/frontend/apps/web/yup-validations/jobs.ts
+++ b/frontend/apps/web/yup-validations/jobs.ts
@@ -68,6 +68,7 @@ export const JobMappingFormValues = Yup.object({
   schema: Yup.string().required(),
   table: Yup.string().required(),
   column: Yup.string().required(),
+  id: Yup.string().optional(),
   transformer: JobMappingTransformerForm,
 }).required();
 export type JobMappingFormValues = Yup.InferType<typeof JobMappingFormValues>;

--- a/frontend/apps/web/yup-validations/jobs.ts
+++ b/frontend/apps/web/yup-validations/jobs.ts
@@ -68,7 +68,6 @@ export const JobMappingFormValues = Yup.object({
   schema: Yup.string().required(),
   table: Yup.string().required(),
   column: Yup.string().required(),
-  id: Yup.string().optional(),
   transformer: JobMappingTransformerForm,
 }).required();
 export type JobMappingFormValues = Yup.InferType<typeof JobMappingFormValues>;


### PR DESCRIPTION
Adding in support for editing mongo db mappings in line. 

The user can now press the edit button after a mapping has been added and then edit it right there and then click on the check icon to save it right after. 

Clicking on the save icon updates the form but will not persist across reloads unless the user hits the 'update' button, as we have it with other updates as well. 