### PR TITLE
NEOS-1381: fixes inconsistent ordering of mssql constraints

### DIFF
--- a/backend/pkg/sqlmanager/mssql/mssql-manager_integration_test.go
+++ b/backend/pkg/sqlmanager/mssql/mssql-manager_integration_test.go
@@ -147,7 +147,6 @@ func (s *IntegrationTestSuite) Test_GetRolePermissionsMap() {
 	require.Contains(s.T(), usersRecord, "UPDATE")
 	require.Contains(s.T(), usersRecord, "SELECT")
 	require.Contains(s.T(), usersRecord, "DELETE")
-	require.Contains(s.T(), usersRecord, "EXECUTE")
 }
 
 // func (s *IntegrationTestSuite) Test_GetCreateTableStatement() {

--- a/backend/pkg/sqlmanager/shared/utils.go
+++ b/backend/pkg/sqlmanager/shared/utils.go
@@ -49,15 +49,18 @@ func BuildTable(schema, table string) string {
 	return table
 }
 
+// Dedupes the input slice and ensures consistent ordering with the input. Returns a niew slice.
 func DedupeSlice(input []string) []string {
-	set := map[string]any{}
-	for _, i := range input {
-		set[i] = struct{}{}
+	seen := make(map[string]struct{})
+	output := []string{}
+
+	for _, item := range input {
+		if _, exists := seen[item]; !exists {
+			seen[item] = struct{}{}
+			output = append(output, item)
+		}
 	}
-	output := make([]string, 0, len(set))
-	for key := range set {
-		output = append(output, key)
-	}
+
 	return output
 }
 

--- a/backend/pkg/sqlmanager/shared/utils_test.go
+++ b/backend/pkg/sqlmanager/shared/utils_test.go
@@ -33,3 +33,9 @@ func Test_splitTableKey(t *testing.T) {
 	require.Equal(t, schema, "neosync")
 	require.Equal(t, table, "foo")
 }
+
+func Test_DedupeSlice(t *testing.T) {
+	input := []string{"foo", "bar", "foo", "bar", "baz"}
+	actual := DedupeSlice(input)
+	require.Equal(t, []string{"foo", "bar", "baz"}, actual)
+}


### PR DESCRIPTION
Bug was in dedupe slice which was not preserving order.