### PR TITLE
NEOS-1389: adds support for duplicating nosql mapping rows

### DIFF
--- a/frontend/apps/web/components/jobs/NosqlTable/data-table-row-actions.tsx
+++ b/frontend/apps/web/components/jobs/NosqlTable/data-table-row-actions.tsx
@@ -14,11 +14,13 @@ import {
 interface DataTableRowActionsProps<TData> {
   row: Row<TData>;
   onDelete(data: Row<TData>): void;
+  onDuplicate(data: Row<TData>): void;
 }
 
 export function DataTableRowActions<TData>({
   row,
   onDelete,
+  onDuplicate,
 }: DataTableRowActionsProps<TData>) {
   return (
     <DropdownMenu>
@@ -32,6 +34,15 @@ export function DataTableRowActions<TData>({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent align="end" className="w-[160px]">
+        <DropdownMenuItem
+          className="cursor-pointer"
+          onClick={() => {
+            console.log('row', row.original);
+            onDuplicate(row);
+          }}
+        >
+          Duplicate
+        </DropdownMenuItem>
         <DropdownMenuItem
           className="cursor-pointer"
           onClick={() => onDelete(row)}


### PR DESCRIPTION
This adds support for one-click duplicating mapping rows in the nosql mapping table so that as a user you don't have to recreate the entire mapping from scratch. This is helpful if you have a deeply nested object and want to map it's elements. Instead of writing out the entire path every time, you can just duplicate they key and then update the leaf. 

Duplicating a row appends a `_{num}` to the end. Duplicating the same row over and ovre again, increments the `num`. 

This takes the collection into consideration as well and treats the entire row of collection.key as a unique key. 

https://www.loom.com/share/b2ca663c0ef4498a8b47a9fc8436edea?sid=03b2fe45-015c-4a0b-ac86-53c798e29663