### PR TITLE
NEOS-1393: adds support for postgres special characters except for double quotes

### DIFF
--- a/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
@@ -256,12 +256,12 @@ ORDER BY
 SELECT
     con.conname AS constraint_name,
     con.contype::TEXT AS constraint_type,
-    con.connamespace::regnamespace::TEXT AS schema_name,
+    nsp.nspname AS schema_name,
     cls.relname AS table_name,
     array_agg(att.attname)::TEXT[] AS constraint_columns,
     array_agg(att.attnotnull)::BOOL[] AS notnullable,
     CASE
-        WHEN con.contype = 'f' THEN fn_cl.relnamespace::regnamespace::TEXT
+        WHEN con.contype = 'f' THEN fk_nsp.nspname
         ELSE ''
     END AS foreign_schema_name,
     CASE
@@ -288,6 +288,9 @@ JOIN
 LEFT JOIN
     pg_catalog.pg_class fn_cl ON
     fn_cl.oid = con.confrelid
+LEFT JOIN
+    pg_catalog.pg_namespace fk_nsp ON
+    fn_cl.relnamespace = fk_nsp.oid
 LEFT JOIN LATERAL (
         SELECT
             array_agg(fk_att.attname) AS foreign_column_names
@@ -299,15 +302,15 @@ LEFT JOIN LATERAL (
     ) AS fk_columns ON
     TRUE
 WHERE
-    con.connamespace::regnamespace::TEXT = sqlc.arg('schema')
-    AND con.conrelid::regclass::TEXT = sqlc.arg('table')
+    nsp.nspname = sqlc.arg('schema')
+    AND cls.relname = sqlc.arg('table')
 GROUP BY
     con.oid,
-    con.connamespace,
+    nsp.nspname,
     con.conname,
     cls.relname,
     con.contype,
-    fn_cl.relnamespace,
+    fk_nsp.nspname,
     fn_cl.relname,
     fk_columns.foreign_column_names;
 
@@ -315,12 +318,12 @@ GROUP BY
 SELECT
     con.conname AS constraint_name,
     con.contype::TEXT AS constraint_type,
-    con.connamespace::regnamespace::TEXT AS schema_name,
+    nsp.nspname AS schema_name,
     cls.relname AS table_name,
     array_agg(att.attname)::TEXT[] AS constraint_columns,
     array_agg(att.attnotnull)::BOOL[] AS notnullable,
     CASE
-        WHEN con.contype = 'f' THEN fn_cl.relnamespace::regnamespace::TEXT
+        WHEN con.contype = 'f' THEN fk_nsp.nspname
         ELSE ''
     END AS foreign_schema_name,
     CASE
@@ -347,6 +350,9 @@ JOIN
 LEFT JOIN
     pg_catalog.pg_class fn_cl ON
     fn_cl.oid = con.confrelid
+LEFT JOIN
+    pg_catalog.pg_namespace fk_nsp ON
+    fn_cl.relnamespace = fk_nsp.oid
 LEFT JOIN LATERAL (
         SELECT
             array_agg(fk_att.attname) AS foreign_column_names
@@ -358,16 +364,16 @@ LEFT JOIN LATERAL (
     ) AS fk_columns ON
     TRUE
 WHERE
-    con.connamespace::regnamespace::TEXT = ANY(
+    nsp.nspname = ANY(
         sqlc.arg('schema')::TEXT[]
     )
 GROUP BY
     con.oid,
-    con.connamespace,
+    nsp.nspname,
     con.conname,
     cls.relname,
     con.contype,
-    fn_cl.relnamespace,
+    fk_nsp.nspname,
     fn_cl.relname,
     fk_columns.foreign_column_names;
 

--- a/backend/pkg/sqlmanager/postgres/integration_test.go
+++ b/backend/pkg/sqlmanager/postgres/integration_test.go
@@ -38,7 +38,7 @@ func (s *IntegrationTestSuite) buildTable(tableName string) string {
 
 func (s *IntegrationTestSuite) SetupSuite() {
 	s.ctx = context.Background()
-	s.schema = "sqlmanagerpostgres"
+	s.schema = "sqlmanagerpostgres@special"
 
 	pgcontainer, err := testpg.Run(
 		s.ctx,

--- a/backend/pkg/sqlmanager/postgres/testdata/setup.sql
+++ b/backend/pkg/sqlmanager/postgres/testdata/setup.sql
@@ -1,6 +1,6 @@
-CREATE SCHEMA IF NOT EXISTS sqlmanagerpostgres;
+CREATE SCHEMA IF NOT EXISTS "sqlmanagerpostgres@special";
 
-SET search_path TO sqlmanagerpostgres;
+SET search_path TO "sqlmanagerpostgres@special";
 
 CREATE TABLE users (
     id TEXT NOT NULL,

--- a/backend/pkg/sqlmanager/postgres/testdata/teardown.sql
+++ b/backend/pkg/sqlmanager/postgres/testdata/teardown.sql
@@ -1,1 +1,1 @@
-DROP SCHEMA IF EXISTS sqlmanagerpostgres CASCADE;
+DROP SCHEMA IF EXISTS "sqlmanagerpostgres@special" CASCADE;


### PR DESCRIPTION
Adds support for special characters in postgres schemas and tables.

This does not currently support schemas/tables with double quotes.

Fast follow in Github: https://github.com/nucleuscloud/neosync/issues/2591