### PR TITLE
updates duplicate mapping functinality to be more performant

### DIFF
--- a/frontend/apps/web/components/jobs/NosqlTable/data-table-row-actions.tsx
+++ b/frontend/apps/web/components/jobs/NosqlTable/data-table-row-actions.tsx
@@ -37,7 +37,6 @@ export function DataTableRowActions<TData>({
         <DropdownMenuItem
           className="cursor-pointer"
           onClick={() => {
-            console.log('row', row.original);
             onDuplicate(row);
           }}
         >


### PR DESCRIPTION
A few updates to make making mongo mappings more performant. 

Abstracts the onDuplicate() function into a callback that gets called in the parent component.

Reworks the unique mapping creation to create a unique identifier instead of using an int. 