### PR TITLE
NEOS-1403:update forms to not shift on errors

### DIFF
--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/connect/page.tsx
@@ -639,7 +639,6 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                           )}
                         />
                       </div>
-
                       <Button
                         type="button"
                         variant="outline"

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/connect/page.tsx
@@ -156,19 +156,13 @@ export default function Page({ searchParams }: PageProps): ReactElement {
           <div
             className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4`}
           >
-            <div>
-              <div>
-                <div className="space-y-0.5">
-                  <h2 className="text-xl font-semibold tracking-tight">
-                    Source
-                  </h2>
-                  <p className="text-muted-foreground text-sm">
-                    The location of the source data.
-                  </p>
-                </div>
-              </div>
+            <div className="space-y-0.5">
+              <h2 className="text-xl font-semibold tracking-tight">Source</h2>
+              <p className="text-muted-foreground text-sm">
+                The location of the source data.
+              </p>
             </div>
-            <div className="space-y-4 col-span-2">
+            <div className=" col-span-2">
               <FormField
                 control={form.control}
                 name="sourceId"
@@ -763,7 +757,7 @@ function ValidationResponseBadge(props: ValidationResponseBadgeProps) {
     return (
       <div className="flex flex-row items-center gap-2 rounded-xl px-2 py-1 h-auto text-green-900 dark:text-green-100 border border-green-700 bg-green-100 dark:bg-green-900 transition-colors">
         <CheckCircledIcon />
-        <div className="text-nowrap text-xs font-semibold">
+        <div className="text-nowrap text-xs font-medium">
           Successfully connected
         </div>
       </div>
@@ -776,7 +770,7 @@ function ValidationResponseBadge(props: ValidationResponseBadgeProps) {
       <Link href={url} passHref target="_blank">
         <div className="flex flex-row items-center gap-2 rounded-xl px-2 py-1 h-auto text-orange-900 dark:text-orange-100 border border-orange-700 bg-orange-100 dark:bg-orange-900 hover:bg-orange-200 hover:dark:bg-orange-950/90 transition-colors">
           <TiWarningOutline />
-          <div className="text-nowrap text-xs font-semibold">
+          <div className="text-nowrap text-xs font-medium">
             Connection Warning - No tables found.{' '}
             <a
               href={url}
@@ -796,7 +790,7 @@ function ValidationResponseBadge(props: ValidationResponseBadgeProps) {
       <Link href={url} passHref target="_blank">
         <div className="flex flex-row items-center gap-2 rounded-xl px-2 py-1 h-auto text-red-900 dark:text-red-100 border border-red-700 bg-red-100 dark:bg-red-950 hover:dark:bg-red-950/90 hover:bg-red-200 transition-colors">
           <MdErrorOutline />
-          <div className="text-nowrap text-xs pl-2">
+          <div className="text-nowrap text-xs pl-2 font-medium">
             Connection Error - Unable to connect.{' '}
             <a
               href={url}

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/define/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/define/page.tsx
@@ -135,7 +135,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
         <div />
       </OverviewContainer>
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <form onSubmit={form.handleSubmit(onSubmit)}>
           <FormField
             control={form.control}
             name="jobName"
@@ -221,7 +221,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
               </AccordionTrigger>
               <AccordionContent>
                 <Separator />
-                <div className="flex flex-col gap-6 pt-6">
+                <div className="flex flex-col pt-6 p-2">
                   <FormField
                     control={form.control}
                     name="workflowSettings.runTimeout"
@@ -247,7 +247,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                       </FormItem>
                     )}
                   />
-                  <div className="flex flex-col gap-6">
+                  <div className="flex flex-col">
                     <FormField
                       control={form.control}
                       name="syncActivityOptions.startToCloseTimeout"
@@ -339,7 +339,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
               </AccordionContent>
             </AccordionItem>
           </Accordion>
-          <div className="flex flex-row justify-between">
+          <div className="flex flex-row justify-between pt-10 ">
             <Button
               variant="outline"
               type="reset"

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/schema/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/schema/page.tsx
@@ -324,7 +324,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
         <div />
       </OverviewContainer>
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <form onSubmit={form.handleSubmit(onSubmit)}>
           <FormField
             control={form.control}
             name="numRows"
@@ -377,7 +377,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
               </AlertTitle>
             </Alert>
           )}
-          <div className="flex flex-row gap-1 justify-between">
+          <div className="flex flex-row gap-1 justify-between pt-10">
             <Button key="back" type="button" onClick={() => router.back()}>
               Back
             </Button>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateCardNumber.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateCardNumber.tsx
@@ -18,21 +18,29 @@ export default function GenerateCardNumberForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
       <div className="space-y-0.5">
         <FormLabel>Valid Luhn</FormLabel>
-        <FormDescription className="w-[90%]">
+        <FormDescription>
           Generate a 16 digit card number that passes a luhn check.
         </FormDescription>
       </div>
-      <Switch
-        checked={value.validLuhn}
-        onCheckedChange={(checked) => {
-          setValue(new GenerateCardNumber({ ...value, validLuhn: checked }));
-        }}
-        disabled={isDisabled}
-      />
-      <FormErrorMessage message={errors?.validLuhn?.message} />
+      <div className="flex flex-col h-14">
+        <div className="justify-end flex">
+          <div className="w-[300px]">
+            <Switch
+              checked={value.validLuhn}
+              onCheckedChange={(checked) => {
+                setValue(
+                  new GenerateCardNumber({ ...value, validLuhn: checked })
+                );
+              }}
+              disabled={isDisabled}
+            />
+            <FormErrorMessage message={errors?.validLuhn?.message} />
+          </div>
+        </div>
+      </div>
     </div>
   );
 }

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateCategoricalForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateCategoricalForm.tsx
@@ -17,7 +17,7 @@ export default function GenerateCategoricalForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="space-y-0.5">
         <FormLabel>Categories</FormLabel>
         <FormDescription>
@@ -25,7 +25,7 @@ export default function GenerateCategoricalForm(props: Props): ReactElement {
           randomly select from.
         </FormDescription>
       </div>
-      <div className="flex flex-col items-start w-[300px]">
+      <div className="flex flex-col items-start">
         <Input
           value={value.categories}
           type="string"

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateCountryForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateCountryForm.tsx
@@ -18,7 +18,7 @@ export default function GenerateCountryForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Generate Full Name</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateEmailForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateEmailForm.tsx
@@ -21,7 +21,7 @@ export default function GenerateEmailForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="space-y-0.5">
         <FormLabel>Email Type</FormLabel>
         <FormDescription>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateGenderForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateGenderForm.tsx
@@ -18,7 +18,7 @@ export default function GenerateGenderForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Abbreviate</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateInt64Form.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateInt64Form.tsx
@@ -16,7 +16,7 @@ export default function GenerateInt64Form(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Randomize Sign</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateInternationalPhoneNumberForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateInternationalPhoneNumberForm.tsx
@@ -19,7 +19,7 @@ export default function GenerateInternationalPhoneNumberForm(
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Minimum Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateStateForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateStateForm.tsx
@@ -15,7 +15,7 @@ export default function GenerateStateForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Generate Full Name</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateStringForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateStringForm.tsx
@@ -18,7 +18,7 @@ export default function GenerateStringForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Minimum Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateStringPhoneNumberForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateStringPhoneNumberForm.tsx
@@ -19,7 +19,7 @@ export default function GenerateStringPhoneNumberNumberForm(
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Minimum Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateUuidForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateUuidForm.tsx
@@ -14,7 +14,7 @@ export default function GenerateUuidForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Include hyphens</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformCharacterScrambleForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformCharacterScrambleForm.tsx
@@ -62,7 +62,7 @@ export default function TransformCharacterScrambleForm(
   }
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row gap-2 justify-end">
         {isRegexValid !== 'null' && (
           <Badge
@@ -81,7 +81,7 @@ export default function TransformCharacterScrambleForm(
             />
           </Badge>
         )}
-        <Button type="button" onClick={handleValidateCode}>
+        <Button variant="outline" type="button" onClick={handleValidateCode}>
           <ButtonText
             leftIcon={isValidatingRegex ? <Spinner /> : null}
             text={'Validate'}

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformE164PhoneNumberForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformE164PhoneNumberForm.tsx
@@ -17,7 +17,7 @@ export default function TransformE164NumberForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Preserve Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformEmailForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformEmailForm.tsx
@@ -33,7 +33,7 @@ export default function TransformEmailForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4 ">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Preserve Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformFirstNameForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformFirstNameForm.tsx
@@ -16,7 +16,7 @@ interface Props
 export default function TransformFirstNameForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Preserve Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformFloat64Form.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformFloat64Form.tsx
@@ -17,7 +17,7 @@ export default function TransformFloat64Form(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Relative Minimum Range Value</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformFullNameForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformFullNameForm.tsx
@@ -16,7 +16,7 @@ interface Props
 export default function TransformFullNameForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Preserve Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformInt64Form.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformInt64Form.tsx
@@ -17,7 +17,7 @@ export default function TransformInt64Form(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Relative Minimum Range Value</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformInt64PhoneForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformInt64PhoneForm.tsx
@@ -19,7 +19,7 @@ export default function TransformIntPhoneNumberForm(
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700  p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Preserve Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformLastNameForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformLastNameForm.tsx
@@ -16,7 +16,7 @@ interface Props
 export default function TransformLastNameForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4 ">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Preserve Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformPhoneNumberForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformPhoneNumberForm.tsx
@@ -16,7 +16,7 @@ export default function TransformPhoneNumberForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Preserve Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformStringForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformStringForm.tsx
@@ -18,7 +18,7 @@ export default function TransformStringForm(props: Props): ReactElement {
   const { value, setValue, isDisabled, errors } = props;
 
   return (
-    <div className="flex flex-col w-full space-y-4 pt-4">
+    <div className="flex flex-col w-full space-y-4">
       <div className="flex flex-row items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
         <div className="space-y-0.5">
           <FormLabel>Preserve Length</FormLabel>

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
@@ -226,12 +226,12 @@ export default function NewTransformer(): ReactElement {
                     </SelectContent>
                   </Select>
                 </FormControl>
-                {/* <FormMessage />  we don't have any validation on this field so there's nothing to render*/}
+                <FormMessage />
               </FormItem>
             )}
           />
           {formSource != null && formSource !== 0 && (
-            <div className="pt-8">
+            <div>
               <FormField
                 control={form.control}
                 name="name"

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
@@ -172,7 +172,7 @@ export default function NewTransformer(): ReactElement {
       containerClassName="px-12 md:px-24 lg:px-32"
     >
       <Form {...form}>
-        <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+        <form onSubmit={form.handleSubmit(onSubmit)}>
           <FormField
             control={form.control}
             name="source"
@@ -226,12 +226,12 @@ export default function NewTransformer(): ReactElement {
                     </SelectContent>
                   </Select>
                 </FormControl>
-                <FormMessage />
+                {/* <FormMessage />  we don't have any validation on this field so there's nothing to render*/}
               </FormItem>
             )}
           />
           {formSource != null && formSource !== 0 && (
-            <div>
+            <div className="pt-8">
               <FormField
                 control={form.control}
                 name="name"
@@ -255,7 +255,7 @@ export default function NewTransformer(): ReactElement {
                   </FormItem>
                 )}
               />
-              <div className="pt-10">
+              <div>
                 <FormField
                   control={form.control}
                   name="description"
@@ -302,7 +302,7 @@ export default function NewTransformer(): ReactElement {
               )}
             />
           </div>
-          <div className="flex flex-row justify-end">
+          <div className="flex flex-row justify-end pt-10">
             <Button type="submit" disabled={!form.formState.isValid}>
               Submit
             </Button>

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/[id]/components/UpdateTransformerForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/[id]/components/UpdateTransformerForm.tsx
@@ -100,7 +100,7 @@ export default function UpdateTransformerForm(props: Props): ReactElement {
 
   return (
     <Form {...form}>
-      <form onSubmit={form.handleSubmit(onSubmit)} className="space-y-8">
+      <form onSubmit={form.handleSubmit(onSubmit)}>
         <FormField
           name="source"
           render={() => (
@@ -118,11 +118,10 @@ export default function UpdateTransformerForm(props: Props): ReactElement {
                   </SelectTrigger>
                 </Select>
               </FormControl>
-              <FormMessage />
             </FormItem>
           )}
         />
-        <div>
+        <div className="pt-8">
           <FormField
             control={form.control}
             name="name"
@@ -146,7 +145,7 @@ export default function UpdateTransformerForm(props: Props): ReactElement {
               </FormItem>
             )}
           />
-          <div className="pt-10">
+          <div>
             <FormField
               control={form.control}
               name="description"

--- a/frontend/apps/web/components/ListBox/ListBox.tsx
+++ b/frontend/apps/web/components/ListBox/ListBox.tsx
@@ -39,14 +39,14 @@ export default function ListBox<TData>(props: Props<TData>): ReactElement {
   return (
     <div
       className={cn(
-        'max-h-[164px] relative w-full rounded-md border border-gray-300 dark:border-gray-700 ',
+        'max-h-[164px] relative w-full rounded-md border border-gray-300 dark:border-gray-700',
         tableContainerClassName,
         rows.length > 0 && 'overflow-auto'
       )}
       ref={tableContainerRef}
     >
       <StickyHeaderTable>
-        <TableHeader className="bg-gray-100 dark:bg-gray-800 sticky top-0 z-10 grid">
+        <TableHeader className="bg-gray-100 dark:bg-gray-800 sticky top-0 z-10 grid rounded-md">
           {table.getHeaderGroups().map((headerGroup) => (
             <TableRow key={headerGroup.id} className="flex flex-row px-2">
               {headerGroup.headers.map((header) => {

--- a/frontend/apps/web/components/jobs/NosqlTable/NosqlTable.tsx
+++ b/frontend/apps/web/components/jobs/NosqlTable/NosqlTable.tsx
@@ -332,7 +332,7 @@ function AddNewRecord(props: AddNewRecordProps): ReactElement {
   });
 
   return (
-    <div className="flex flex-col w-full space-y-4">
+    <div className="flex flex-col w-full">
       <Form {...form}>
         <FormField
           control={form.control}

--- a/frontend/apps/web/components/ui/form.tsx
+++ b/frontend/apps/web/components/ui/form.tsx
@@ -143,32 +143,34 @@ const FormDescription = React.forwardRef<
 FormDescription.displayName = 'FormDescription';
 
 const FormMessage = React.forwardRef<
-  HTMLParagraphElement,
-  React.HTMLAttributes<HTMLParagraphElement>
+  HTMLDivElement,
+  React.HTMLAttributes<HTMLDivElement>
 >(({ className, children, ...props }, ref) => {
   const { error, formMessageId } = useFormField();
   const body = error ? String(error?.message) : children;
 
-  if (!body) {
-    return null;
-  }
-
   return (
-    <div className="inline-flex flex-row items-center gap-2 text-red-900 dark:text-red-100 border border-red-700 bg-red-100 dark:bg-red-950 rounded-xl p-1 px-2">
-      <MdErrorOutline />
-      <p
-        ref={ref}
-        id={formMessageId}
-        className={cn('text-xs font-medium ', className)}
-        {...props}
-      >
-        {body}
-      </p>
+    <div
+      ref={ref}
+      id={formMessageId}
+      className={cn(
+        'h-8 mt-2 transition-all duration-200 ease-in-out',
+        error ? 'opacity-100 visible' : 'opacity-0 invisible',
+        className
+      )}
+      {...props}
+    >
+      {body && (
+        <div className="inline-flex flex-row items-center gap-2 text-red-900 dark:text-red-100 border border-red-700 bg-red-100 dark:bg-red-950 rounded-xl p-1 px-2">
+          <MdErrorOutline />
+          <p className="text-xs font-medium">{body}</p>
+        </div>
+      )}
     </div>
   );
 });
-FormMessage.displayName = 'FormMessage';
 
+FormMessage.displayName = 'FormMessage';
 export {
   Form,
   FormControl,


### PR DESCRIPTION
This updates styling across most of the forms in the app to reduce the "jumping" of the UI when there is an error. It gives the <FormMessage /> component a static height, even if there is no error, so when there is an error it just fills the space without causing the rest of the UI to shift down. 