### PR TITLE
Replaces Docker Compose Watch with Bind Mounts

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ frontend/out
 /package-lock.json
 
 env/
+
+tmp

--- a/Makefile
+++ b/Makefile
@@ -118,13 +118,13 @@ compose/auth/down: ## Composes down the production environment with auth
 	docker compose -f $(PROD_COMPOSE_FILE) -f $(PROD_AUTH_COMPOSE_FILE) down
 
 compose/dev/up: ## Composes up the development environment. Must run dbuild first.
-	BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose -f $(DEV_COMPOSE_FILE) watch
+	BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose -f $(DEV_COMPOSE_FILE) up -d
 
 compose/dev/down: ## Composes down the development environment
 	docker compose -f $(DEV_COMPOSE_FILE) down
 
 compose/dev/auth/up: ## Composes up the development environment with auth. Must run dbuild first.
-	BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose -f $(DEV_COMPOSE_FILE) -f $(DEV_AUTH_COMPOSE_FILE) watch
+	BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose -f $(DEV_COMPOSE_FILE) -f $(DEV_AUTH_COMPOSE_FILE) up -d
 
 compose/dev/auth/down: ## Composes down the development environment with auth
 	docker compose -f $(DEV_COMPOSE_FILE) -f $(DEV_AUTH_COMPOSE_FILE) down

--- a/Makefile
+++ b/Makefile
@@ -117,13 +117,13 @@ compose/auth/up: ## Composes up the production environment with auth
 compose/auth/down: ## Composes down the production environment with auth
 	docker compose -f $(PROD_COMPOSE_FILE) -f $(PROD_AUTH_COMPOSE_FILE) down
 
-compose/dev/up: ## Composes up the development environment. Must run dbuild first.
+compose/dev/up: ## Composes up the development environment.
 	BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose -f $(DEV_COMPOSE_FILE) up -d
 
 compose/dev/down: ## Composes down the development environment
 	docker compose -f $(DEV_COMPOSE_FILE) down
 
-compose/dev/auth/up: ## Composes up the development environment with auth. Must run dbuild first.
+compose/dev/auth/up: ## Composes up the development environment with auth.
 	BUILDX_NO_DEFAULT_ATTESTATIONS=1 docker compose -f $(DEV_COMPOSE_FILE) -f $(DEV_AUTH_COMPOSE_FILE) up -d
 
 compose/dev/auth/down: ## Composes down the development environment with auth

--- a/backend/dev/build/.air.toml
+++ b/backend/dev/build/.air.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = ["serve", "connect"]
   bin = "./tmp/mgmt"
-  cmd = "go build -ldflags=\"-s -w\" -o ./tmp/mgmt cmd/mgmt/*.go"
+  cmd = "go build -ldflags=\"-s -w\" -o ./tmp/mgmt backend/cmd/mgmt/*.go"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]
   exclude_file = []

--- a/backend/dev/build/.air.toml
+++ b/backend/dev/build/.air.toml
@@ -1,0 +1,51 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = ["serve", "connect"]
+  bin = "./tmp/mgmt"
+  cmd = "go build -ldflags=\"-s -w\" -o ./tmp/mgmt cmd/mgmt/*.go"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = true
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = true
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/backend/dev/build/Dockerfile.dev
+++ b/backend/dev/build/Dockerfile.dev
@@ -1,42 +1,23 @@
 # Build the manager binary
 FROM golang:1.22-bookworm AS builder
 
+WORKDIR /workspace
+
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive \
   apt-get install --no-install-recommends -y \
     build-essential
 
-WORKDIR /workspace
+RUN go install github.com/air-verse/air@latest
+
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY go.mod go.sum ./
 
-RUN --mount=type=cache,target=/go/pkg/mod \
-  go mod download
+RUN go mod download
 
-WORKDIR /workspace
-COPY worker/internal/ worker/internal/
-COPY worker/pkg/ worker/pkg/
-COPY internal/ internal/
+COPY backend/dev/build/.air.toml .air.toml
+COPY /backend/sql/postgresql/schema/ /migrations/
 
 WORKDIR /workspace/backend
 
-# Copy in generated code
-COPY backend/gen/ gen/
-
-# Copy the go source
-COPY backend/cmd/ cmd/
-COPY backend/internal/ internal/
-COPY backend/services/ services/
-COPY backend/pkg/ pkg/
-COPY backend/sql sql/
-COPY /backend/sql/postgresql/schema/ /migrations/
-
-# Build
-RUN --mount=type=cache,target=/go/pkg/mod \
-  --mount=type=cache,target=/root/.cache/go-build \
-  go build -ldflags="-s -w" -o bin/mgmt cmd/mgmt/*.go
-
-ENTRYPOINT ["/workspace/backend/bin/mgmt"]
-
-CMD ["serve", "connect"]
+CMD ["air", "-c", "/workspace/.air.toml"]

--- a/backend/dev/build/Dockerfile.dev
+++ b/backend/dev/build/Dockerfile.dev
@@ -18,6 +18,4 @@ RUN go mod download
 COPY backend/dev/build/.air.toml .air.toml
 COPY /backend/sql/postgresql/schema/ /migrations/
 
-WORKDIR /workspace/backend
-
 CMD ["air", "-c", "/workspace/.air.toml"]

--- a/backend/services/mgmt/v1alpha1/user-account-service/users.go
+++ b/backend/services/mgmt/v1alpha1/user-account-service/users.go
@@ -543,7 +543,7 @@ func (s *Service) GetSystemInformation(ctx context.Context, req *connect.Request
 		return nil, err
 	}
 	return connect.NewResponse(&mgmtv1alpha1.GetSystemInformationResponse{
-		Version:   versionInfo.GitVersion + "fo",
+		Version:   versionInfo.GitVersion,
 		Commit:    versionInfo.GitCommit,
 		Compiler:  versionInfo.Compiler,
 		Platform:  versionInfo.Platform,

--- a/backend/services/mgmt/v1alpha1/user-account-service/users.go
+++ b/backend/services/mgmt/v1alpha1/user-account-service/users.go
@@ -543,7 +543,7 @@ func (s *Service) GetSystemInformation(ctx context.Context, req *connect.Request
 		return nil, err
 	}
 	return connect.NewResponse(&mgmtv1alpha1.GetSystemInformationResponse{
-		Version:   versionInfo.GitVersion,
+		Version:   versionInfo.GitVersion + "fo",
 		Commit:    versionInfo.GitCommit,
 		Compiler:  versionInfo.Compiler,
 		Platform:  versionInfo.Platform,

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -13,7 +13,6 @@ include:
 services:
   app:
     container_name: neosync-app
-    # image: neosync-app
     build:
       context: ./
       dockerfile: ./frontend/apps/web/dev/build/Dockerfile.dev

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -98,7 +98,7 @@ services:
       - ./internal:/workspace/internal:rw
       - ./go.mod:/workspace/go.mod:rw
       - ./go.sum:/workspace/go.sum:rw
-      - neosync_api_tmp:/workspace/backend/tmp
+      - neosync_api_tmp:/workspace/tmp
       - neosync_go_mod_cache:/go/pkg/mod
       - neosync_backend_build_cache:/root/.cache/go-build
     restart: on-failure
@@ -130,7 +130,7 @@ services:
       - ./internal:/workspace/internal:rw
       - ./go.mod:/workspace/go.mod:rw
       - ./go.sum:/workspace/go.sum:rw
-      - neosync_worker_tmp:/workspace/worker/tmp
+      - neosync_worker_tmp:/workspace/tmp
       - neosync_go_mod_cache:/go/pkg/mod
       - neosync_worker_build_cache:/root/.cache/go-build
     restart: on-failure

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -13,10 +13,10 @@ include:
 services:
   app:
     container_name: neosync-app
-    image: neosync-app
+    # image: neosync-app
     build:
-      context: ./frontend
-      dockerfile: ./apps/web/dev/build/Dockerfile.dev
+      context: ./
+      dockerfile: ./frontend/apps/web/dev/build/Dockerfile.dev
     ports:
       - 3000:3000
     environment:
@@ -33,17 +33,9 @@ services:
 
     networks:
       - neosync-network
-    develop:
-      watch:
-        - path: frontend/package.json
-          action: rebuild
-        - path: frontend/package-lock.json
-          action: rebuild
-        - path: frontend/
-          action: sync
-          target: /app
-          ignore:
-            - frontend/node_modules/
+    volumes:
+      - ./frontend:/app/:rw
+      - neosync_app_nodemodules:/app/node_modules
 
   db:
     container_name: neosync-db
@@ -67,13 +59,11 @@ services:
 
   api:
     container_name: neosync-api
-    image: neosync-api
     build:
       context: ./
       dockerfile: ./backend/dev/build/Dockerfile.dev
     ports:
       - 8080:8080
-    command: serve connect
     environment:
       - HOST=0.0.0.0
       - PORT=8080
@@ -103,25 +93,18 @@ services:
         condition: service_healthy
         restart: true
     volumes:
-      - neosync_backend_build_cache:/root/.cache/go-build
+      - ./backend:/workspace/backend:rw
+      - ./worker:/workspace/worker:rw
+      - ./internal:/workspace/internal:rw
+      - ./go.mod:/workspace/go.mod:rw
+      - ./go.sum:/workspace/go.sum:rw
+      - neosync_api_tmp:/workspace/backend/tmp
       - neosync_go_mod_cache:/go/pkg/mod
-    develop:
-      watch:
-        - action: rebuild
-          path: internal
-        - action: rebuild
-          path: backend
-        - action: rebuild
-          path: worker
-        - action: rebuild
-          path: go.mod
-        - action: rebuild
-          path: go.sum
+      - neosync_backend_build_cache:/root/.cache/go-build
     restart: on-failure
 
   worker:
     container_name: neosync-worker
-    image: neosync-worker
     build:
       context: ./
       dockerfile: ./worker/dev/build/Dockerfile.dev
@@ -137,21 +120,19 @@ services:
     networks:
       - neosync-network
       - temporal-network
+    depends_on:
+      temporal:
+        condition: service_healthy
+        restart: true
     volumes:
-      - neosync_worker_build_cache:/root/.cache/go-build
+      - ./backend:/workspace/backend:rw
+      - ./worker:/workspace/worker:rw
+      - ./internal:/workspace/internal:rw
+      - ./go.mod:/workspace/go.mod:rw
+      - ./go.sum:/workspace/go.sum:rw
+      - neosync_worker_tmp:/workspace/worker/tmp
       - neosync_go_mod_cache:/go/pkg/mod
-    develop:
-      watch:
-        - action: rebuild
-          path: internal
-        - action: rebuild
-          path: worker
-        - action: rebuild
-          path: backend
-        - action: rebuild
-          path: go.mod
-        - action: rebuild
-          path: go.sum
+      - neosync_worker_build_cache:/root/.cache/go-build
     restart: on-failure
 
   redis:
@@ -168,9 +149,12 @@ services:
 volumes:
   neosync_redis_cache:
   neosync_pg_data:
-  neosync_worker_build_cache:
+  neosync_api_tmp:
   neosync_backend_build_cache:
+  neosync_worker_tmp:
+  neosync_worker_build_cache:
   neosync_go_mod_cache:
+  neosync_app_nodemodules:
 
 networks:
   neosync-network:

--- a/compose/temporal/compose.yml
+++ b/compose/temporal/compose.yml
@@ -52,6 +52,22 @@ services:
       kompose.volume.type: configMap
     volumes:
       - ./dynamicconfig:/etc/temporal/config/dynamicconfig
+    healthcheck:
+      test:
+        [
+          "CMD",
+          "tctl",
+          "--address",
+          "temporal:7233",
+          "workflow",
+          "list",
+          "||",
+          "exit 1",
+        ]
+      interval: 1s
+      timeout: 5s
+      retries: 30
+      start_period: 5s
   # temporal-admin-tools:
   #   container_name: temporal-admin-tools
   #   depends_on:

--- a/docs/docs/guides/neosync-local-dev.md
+++ b/docs/docs/guides/neosync-local-dev.md
@@ -34,21 +34,22 @@ Afterwards, drop your token in the `backend/.env.dev.secrets` file.
 echo "BUF_TOKEN=<token>" >> ./backend/.env.dev.secrets
 ```
 
-The docker compose environment runs almost entirely by itself. However, the Golang services (backend, worker), must be built on the host system.
+The docker compose environment runs entirely by itself.
 
-This can be done easily from the root by simply running `make dbuild`. This will build the project for Docker (Linux). It builds the entire project so it may take some time.
-Note: This command will not build the frontend and will only install node modules. This is because Nextjs runs in dev mode and only builds what it needs to. The frontend build command is meant for production deployments.
+To start:
 
-Afterwards, running `make compose/dev/up` will stand up Neosync and it's dependencies.
-**Currently there is a limitation with devcontainers where this command must be run via `sudo`.**
+```
+make compose/dev/up
+```
 
-The frontend, backend, and worker will be in watch mode, which will cause them to look for changes and reload. The frontend will reload on save, where as the backend/worker will reload on the next `make dbuild` run.
+> Note: The `backend` and `worker` containers will start but may take some time to to do their initial build.
 
-You can run the sub-commands to make this faster as you won't need to rebuild the entire project.
+Once they have a build cache, they will come online and re-build much faster!
 
-```sh
-make dbuild/backend
-make dbuild/worker
+To stop:
+
+```
+make compose/dev/down
 ```
 
 Once everything is up and running, The app can be accessed locally at [http://localhost:3000](http://localhost:3000).
@@ -69,7 +70,10 @@ make compose/dev/auth/down
 
 ## Setup with Tilt
 
-Developing with Kubernetes via Tilt is also an option, however it is a bit more setup and is heavier. The benefits of this are that it allows you to develop more closely to what a k8s production environment could look like.d
+Developing with Kubernetes via Tilt is also an option, however it is a bit more setup and is heavier. The benefits of this are that it allows you to develop more closely to what a k8s production environment could look like.
+
+> Note: This was our original way of developing Neosync but we have transitioned to a docker compose setup for development.
+> If you're trying this and run into issues. please reach out to us on Discord.
 
 ### Docker Desktop
 

--- a/frontend/apps/web/dev/build/Dockerfile.dev
+++ b/frontend/apps/web/dev/build/Dockerfile.dev
@@ -2,7 +2,9 @@ FROM node:20-alpine
 
 WORKDIR /app
 
-ADD . .
+COPY frontend/ ./
+
 RUN npm install
 
-ENTRYPOINT [ "npm", "run", "dev" ]
+CMD ["npm", "run", "dev"]
+

--- a/worker/cmd/worker/main.go
+++ b/worker/cmd/worker/main.go
@@ -1,6 +1,8 @@
 package main
 
-import worker_cmd "github.com/nucleuscloud/neosync/worker/internal/cmds/worker"
+import (
+	worker_cmd "github.com/nucleuscloud/neosync/worker/internal/cmds/worker"
+)
 
 func main() {
 	worker_cmd.Execute()

--- a/worker/dev/build/.air.toml
+++ b/worker/dev/build/.air.toml
@@ -1,0 +1,51 @@
+root = "."
+testdata_dir = "testdata"
+tmp_dir = "tmp"
+
+[build]
+  args_bin = ["serve"]
+  bin = "./tmp/worker"
+  cmd = "go build -ldflags=\"-s -w\" -o ./tmp/worker cmd/worker/*.go"
+  delay = 1000
+  exclude_dir = ["assets", "tmp", "vendor", "testdata"]
+  exclude_file = []
+  exclude_regex = ["_test.go"]
+  exclude_unchanged = true
+  follow_symlink = false
+  full_bin = ""
+  include_dir = []
+  include_ext = ["go", "tpl", "tmpl", "html"]
+  include_file = []
+  kill_delay = "0s"
+  log = "build-errors.log"
+  poll = false
+  poll_interval = 0
+  post_cmd = []
+  pre_cmd = []
+  rerun = true
+  rerun_delay = 500
+  send_interrupt = false
+  stop_on_error = false
+
+[color]
+  app = ""
+  build = "yellow"
+  main = "magenta"
+  runner = "green"
+  watcher = "cyan"
+
+[log]
+  main_only = false
+  time = false
+
+[misc]
+  clean_on_exit = false
+
+[proxy]
+  app_port = 0
+  enabled = false
+  proxy_port = 0
+
+[screen]
+  clear_on_rebuild = false
+  keep_scroll = true

--- a/worker/dev/build/.air.toml
+++ b/worker/dev/build/.air.toml
@@ -5,7 +5,7 @@ tmp_dir = "tmp"
 [build]
   args_bin = ["serve"]
   bin = "./tmp/worker"
-  cmd = "go build -ldflags=\"-s -w\" -o ./tmp/worker cmd/worker/*.go"
+  cmd = "go build -ldflags=\"-s -w\" -o ./tmp/worker worker/cmd/worker/*.go"
   delay = 1000
   exclude_dir = ["assets", "tmp", "vendor", "testdata"]
   exclude_file = []

--- a/worker/dev/build/Dockerfile.dev
+++ b/worker/dev/build/Dockerfile.dev
@@ -1,38 +1,22 @@
 # Build the manager binary
 FROM golang:1.22-bookworm AS builder
 
+WORKDIR /workspace
+
 RUN apt-get update \
   && DEBIAN_FRONTEND=noninteractive \
   apt-get install --no-install-recommends -y \
     build-essential
 
-WORKDIR /workspace
+RUN go install github.com/air-verse/air@latest
+
 # Copy the Go Modules manifests
-COPY go.mod go.mod
-COPY go.sum go.sum
+COPY go.mod go.sum ./
 
-RUN --mount=type=cache,target=/go/pkg/mod \
-  go mod download
+RUN go mod download
 
-WORKDIR /workspace
-COPY backend/internal/ backend/internal/
-COPY backend/pkg/ backend/pkg/
-COPY backend/sql backend/sql/
-COPY backend/gen/ backend/gen/
-COPY internal/ internal/
+COPY worker/dev/build/.air.toml .air.toml
 
 WORKDIR /workspace/worker
 
-# Copy the go source
-COPY worker/cmd/ cmd/
-COPY worker/internal/ internal/
-COPY worker/pkg/ pkg/
-
-# Build
-RUN --mount=type=cache,target=/go/pkg/mod \
-  --mount=type=cache,target=/root/.cache/go-build \
-  go build -ldflags="-s -w" -o bin/worker cmd/worker/*.go
-
-ENTRYPOINT ["/workspace/worker/bin/worker"]
-
-CMD ["serve"]
+CMD ["air", "-c", "/workspace/.air.toml"]

--- a/worker/dev/build/Dockerfile.dev
+++ b/worker/dev/build/Dockerfile.dev
@@ -17,6 +17,4 @@ RUN go mod download
 
 COPY worker/dev/build/.air.toml .air.toml
 
-WORKDIR /workspace/worker
-
 CMD ["air", "-c", "/workspace/.air.toml"]


### PR DESCRIPTION
frontend is largely unchanged.
Backend/Worker now use `air` to rebuild directly inside of the container.