### PR TITLE
NEOS-1449: adds a running timer to the run id page

### DIFF
--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -6,7 +6,7 @@ include:
       - ./compose/temporal/.env
   - path: ./compose/compose-db.yml
   # - path: ./compose/compose-db-mysql.yml
-  - path: ./compose/compose-db-mongo.yml
+  # - path: ./compose/compose-db-mongo.yml
   # - path: ./compose/compose-db-dynamo.yml
   # - path: ./compose/compose-db-mssql.yml
 

--- a/compose.dev.yml
+++ b/compose.dev.yml
@@ -6,7 +6,7 @@ include:
       - ./compose/temporal/.env
   - path: ./compose/compose-db.yml
   # - path: ./compose/compose-db-mysql.yml
-  # - path: ./compose/compose-db-mongo.yml
+  - path: ./compose/compose-db-mongo.yml
   # - path: ./compose/compose-db-dynamo.yml
   # - path: ./compose/compose-db-mssql.yml
 

--- a/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
@@ -132,7 +132,7 @@ export default function Page({ params }: PageProps): ReactElement {
       };
 
       updateDuration();
-      // sets up an internval to call the timer ever second
+      // sets up an interval to call the timer every second
       timer = setInterval(updateDuration, 1000);
     } else if (jobRun?.completedAt && jobRun?.startedAt) {
       setDuration(

--- a/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
@@ -115,16 +115,8 @@ export default function Page({ params }: PageProps): ReactElement {
     let timer: NodeJS.Timeout;
     if (jobRun?.startedAt && jobRun?.status === JobRunStatusEnum.RUNNING) {
       const updateDuration = () => {
-        const now = new Date();
-        const startTime = jobRun?.startedAt?.toDate();
-        if (startTime) {
-          const diffInSeconds = Math.floor(
-            (now.getTime() - startTime.getTime()) / 1000
-          );
-          const minutes = Math.floor(diffInSeconds / 60);
-          const seconds = diffInSeconds % 60;
-          // handle plural minutes and seconds and set the duration
-          setDuration(formatDuration({ minutes: minutes, seconds: seconds }));
+        if (jobRun?.startedAt?.toDate()) {
+          setDuration(getDuration(new Date(), jobRun?.startedAt?.toDate()));
         }
       };
 

--- a/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
@@ -42,6 +42,7 @@ import {
   terminateJobRun,
 } from '@neosync/sdk/connectquery';
 import { ArrowRightIcon, Cross2Icon, TrashIcon } from '@radix-ui/react-icons';
+import { formatDuration, intervalToDuration } from 'date-fns';
 import { useRouter } from 'next/navigation';
 import { ReactElement, useEffect, useState } from 'react';
 import { toast } from 'sonner';
@@ -123,11 +124,7 @@ export default function Page({ params }: PageProps): ReactElement {
           const minutes = Math.floor(diffInSeconds / 60);
           const seconds = diffInSeconds % 60;
           // handle plural minutes and seconds and set the duration
-          setDuration(
-            minutes > 0
-              ? `${minutes} minute${minutes > 1 ? 's' : ''} ${seconds} second${seconds !== 1 ? 's' : ''}`
-              : `${seconds} second${seconds !== 1 ? 's' : ''}`
-          );
+          setDuration(formatDuration({ minutes: minutes, seconds: seconds }));
         }
       };
 
@@ -470,16 +467,11 @@ function getDuration(completedAt?: Date, startedAt?: Date): string {
   if (!startedAt || !completedAt) {
     return '';
   }
-  var diff = (completedAt.getTime() - startedAt.getTime()) / 1000;
-  const minutes = Math.floor(diff / 60);
-  const seconds = Math.round(diff % 60);
-  // handle plural minutes and seconds
-  if (minutes === 0) {
-    return `${seconds} second${seconds !== 1 ? 's' : ''}`;
-  }
-  return `${minutes} minute${minutes > 1 ? 's' : ''} ${seconds} second${seconds !== 1 ? 's' : ''}`;
-}
 
+  const duration = intervalToDuration({ start: startedAt, end: completedAt });
+
+  return formatDuration(duration, { format: ['minutes', 'seconds'] });
+}
 interface AlertProps {
   title: string;
   description: string;

--- a/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
@@ -321,7 +321,7 @@ export default function Page({ params }: PageProps): ReactElement {
               header="Completion Time"
               content={formatDateTime(jobRun?.completedAt?.toDate())}
             />
-            <StatCard header="Duratfewfewion" content={duration} />
+            <StatCard header="Duration" content={duration} />
           </div>
           <div className="space-y-4">
             {jobRun?.pendingActivities.map((a) => {

--- a/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/page.tsx
@@ -122,6 +122,7 @@ export default function Page({ params }: PageProps): ReactElement {
           );
           const minutes = Math.floor(diffInSeconds / 60);
           const seconds = diffInSeconds % 60;
+          // handle plural minutes and seconds and set the duration
           setDuration(
             minutes > 0
               ? `${minutes} minute${minutes > 1 ? 's' : ''} ${seconds} second${seconds !== 1 ? 's' : ''}`
@@ -131,13 +132,14 @@ export default function Page({ params }: PageProps): ReactElement {
       };
 
       updateDuration();
+      // sets up an internval to call the timer ever second
       timer = setInterval(updateDuration, 1000);
     } else if (jobRun?.completedAt && jobRun?.startedAt) {
       setDuration(
         getDuration(jobRun.completedAt.toDate(), jobRun.startedAt.toDate())
       );
     }
-
+    // cleans up and restarts the interval if the job isn't done yet
     return () => {
       if (timer) clearInterval(timer);
     };
@@ -464,14 +466,14 @@ function StatCard(props: StatCardProps): ReactElement {
   );
 }
 
-function getDuration(dateTimeValue2?: Date, dateTimeValue1?: Date): string {
-  if (!dateTimeValue1 || !dateTimeValue2) {
+function getDuration(completedAt?: Date, startedAt?: Date): string {
+  if (!startedAt || !completedAt) {
     return '';
   }
-  var differenceValue =
-    (dateTimeValue2.getTime() - dateTimeValue1.getTime()) / 1000;
-  const minutes = Math.floor(differenceValue / 60);
-  const seconds = Math.round(differenceValue % 60);
+  var diff = (completedAt.getTime() - startedAt.getTime()) / 1000;
+  const minutes = Math.floor(diff / 60);
+  const seconds = Math.round(diff % 60);
+  // handle plural minutes and seconds
   if (minutes === 0) {
     return `${seconds} second${seconds !== 1 ? 's' : ''}`;
   }


### PR DESCRIPTION
This feature adds a running timer to the duration stat card in the run/[id] page. Gives users an idea of how long a job is taking. I noticed this when I was working with a customer that they were looking at the timer as a way of seeing if they were getting past the issue i.e. the last job failed at 25 seconds, now that we're at 40 seconds, we likely resolved that. 

The timer is pretty close but not perfect, in that it usually goes over by 2-3 seconds but then updates to the final time once it's there. That's also just locally, in prod it likely is better. 

This handles the minutes and seconds conversions as well so if it goes over 59 seconds it will change from '59 seconds' to '1 minute 1 second'. It also handles plural seconds and minutes. It does not go into hours. Can make that a fast follow. 

https://www.loom.com/share/f14d4c15bf244fd59c67c915c8b6ab7d