### PR TITLE
NEOS-1462: Add transformer links to app

### DIFF
--- a/docs/docs/transformers/system.md
+++ b/docs/docs/transformers/system.md
@@ -20,7 +20,7 @@ Neosync ships with 40+ System Transformers to give you an easy way to get starte
 | --------------------------------------------------------------------------------- | ------- | -------------------------------------------------------------------------------------------------------------------------------- |
 | [Generate Categorical](/transformers/system#generate-categorical)                 | string  | Randomly selects a value from a defined set of categorical values                                                                |
 | [Generate Email](/transformers/system#generate-email)                             | string  | Generates a new randomized email address.                                                                                        |
-| [Generate Boolean](/transformers/system#generate-boolean)                         | boolean | Generates a boolean value at random.                                                                                             |
+| [Generate Boolean](/transformers/system#generate-bool)                            | boolean | Generates a boolean value at random.                                                                                             |
 | [Generate Card Number](/transformers/system#generate-card-number)                 | int64   | Generates a card number.                                                                                                         |
 | [Generate City](/transformers/system#generate-city)                               | string  | Randomly selects a city from a list of predefined US cities.                                                                     |
 | [Generate Country](/transformers/system#generate-country)                         | string  | Randomly selects a country and returns it as a 2-letter country code or the full country name                                    |
@@ -32,17 +32,17 @@ Neosync ships with 40+ System Transformers to give you an easy way to get starte
 | [Generate Gender](/transformers/system#generate-gender)                           | string  | Randomly generates one of the following genders: female, male, undefined, nonbinary.                                             |
 | [Generate Javascript](/transformers/system#generate-javascript)                   | any     | Executes provided javascript code in the transformer for every row                                                               |
 | [Generate Int64 Phone Number](/transformers/system#generate-int64-phone-number)   | int64   | Generates a new phone number of type int64 with a default length of 10.                                                          |
-| [Generate Random Int64](/transformers/system#generate-random-int64)               | int64   | Generates a random integer value with a default length of 4 unless the Integer Length or Preserve Length parameters are defined. |
+| [Generate Random Int64](/transformers/system#generate-int64)                      | int64   | Generates a random integer value with a default length of 4 unless the Integer Length or Preserve Length parameters are defined. |
 | [Generate Last Name](/transformers/system#generate-last-name)                     | int64   | Generates a random last name.                                                                                                    |
-| [Generate SHA256 Hash](/transformers/system#generate-sha256-hash)                 | string  | SHA256 hashes a randomly generated value.                                                                                        |
+| [Generate SHA256 Hash](/transformers/system#generate-sha256hash)                  | string  | SHA256 hashes a randomly generated value.                                                                                        |
 | [Generate SSN](/transformers/system#generate-ssn)                                 | string  | Generates a completely random social security numbers including the hyphens in the format `xxx-xx-xxxx`.                         |
 | [Generate State](/transformers/system#generate-state)                             | string  | Randomly selects a US state and returns the two-character state code.                                                            |
 | [Generate Street Address](/transformers/system#generate-street-address)           | string  | Randomly generates a street address.                                                                                             |
 | [Generate String Phone Number](/transformers/system#generate-string-phone-number) | string  | Generates a Generate phone number and returns it as a string.                                                                    |
 | [Generate Random String](/transformers/system#generate-random-string)             | string  | Creates a randomly ordered alphanumeric string with a default length of 10 unless the String Length parameter are defined.       |
-| [Generate Unix Timestamp](/transformers/system#generate-unix-timestamp)           | int64   | Randomly generates a Unix timestamp.                                                                                             |
+| [Generate Unix Timestamp](/transformers/system#generate-unixtimestamp)            | int64   | Randomly generates a Unix timestamp.                                                                                             |
 | [Generate Username](/transformers/system#generate-username)                       | string  | Randomly generates a username                                                                                                    |
-| [Generate UTC Timestamp](/transformers/system#generate-utc-timestamp)             | time    | Randomly generates a UTC timestamp.                                                                                              |
+| [Generate UTC Timestamp](/transformers/system#generate-utctimestamp)              | time    | Randomly generates a UTC timestamp.                                                                                              |
 | [Generate UUID](/transformers/system#generate-uuid)                               | uuid    | Generates a new UUIDv4 id.                                                                                                       |
 | [Generate Zip code](/transformers/system#generate-zipcode)                        | string  | Randomly selects a zip code from a list of predefined US zip codes.                                                              |
 | [Transform Email](/transformers/system#transform-email)                           | string  | Transforms an existing email address.                                                                                            |
@@ -58,8 +58,8 @@ Neosync ships with 40+ System Transformers to give you an easy way to get starte
 | [Transform String](/transformers/system#transform-string)                         | string  | Transforms an existing string value.                                                                                             |
 | [Transform Character Scramble](/transformers/system#transform-character-scramble) | string  | Transforms an existing string value by scrambling the characters while maintaining the format.                                   |
 | [Passthrough](/transformers/system#passthrough)                                   | string  | Passes the input value through to the destination with no changes.                                                               |
-| [Null](/transformers/system#null)                                                 | string  | Inserts a `null` string instead of the source value.                                                                             |
-| [Use Column Default](/transformers/system#use-column-default)                     | any     | Applies the predefined default value of a column as specified in the SQL database schema                                         |
+| [Null](/transformers/system#generate-null)                                        | string  | Inserts a `null` string instead of the source value.                                                                             |
+| [Use Column Default](/transformers/system#generate-default)                       | any     | Applies the predefined default value of a column as specified in the SQL database schema                                         |
 
 ### Generate Categorical\{#generate-categorical}
 
@@ -99,7 +99,7 @@ By default, the transformer randomizes the username, domain and top-level domain
 | `ab6b676b-0d0e-4e38-b98a-3935a832da7d` |
 | `jFrankd@msn.com`                      |
 
-### Generate Boolean\{#generate-boolean}
+### Generate Boolean\{#generate-bool}
 
 Randomly generates a boolean value.
 
@@ -319,8 +319,8 @@ Allows the user to define Javascript code and then execute that on every row tha
 **Configurations**
 
 | Name | Description                               | Default         | Example Output |
-| ---- | ----------------------------------------- | --------------- | -------------- | --- |
-| Code | The javascript code that will be executed | `return 'test'` | `test`         | \   |
+| ---- | ----------------------------------------- | --------------- | -------------- |
+| Code | The javascript code that will be executed | `return 'test'` | `test`         |
 
 **Example**
 
@@ -328,7 +328,7 @@ Allows the user to define Javascript code and then execute that on every row tha
 | --------------- | -------------- |
 | `return 'test'` | `test`         |
 
-### Generate Random Int64\{#generate-random-int64}
+### Generate Random Int64\{#generate-int64}
 
 Generates a random integer and returns it as a int64 type.
 
@@ -369,7 +369,7 @@ There are no configurations for this transformer.
 | Sporer         |
 | Rodriguezon    |
 
-### Generate SHA256 Hash\{#generate-sha256-hash}
+### Generate SHA256 Hash\{#generate-sha256hash}
 
 Generates a random SHA256 hash and hex encodes the resulting value and returns it as a string.
 
@@ -475,7 +475,7 @@ By default, the random string transformer generates a string of 10 characters lo
 | 1   | 20  | 29h23rega9     |
 | 5   | 5   | h2dni          |
 
-### Generate Unix Timestamp\{#generate-unix-timestamp}
+### Generate Unix Timestamp\{#generate-unixtimestamp}
 
 Randomly generates a unix timestamp in UTC timezone and returns back an int64 representation of that timestamp.
 
@@ -507,7 +507,7 @@ There are no configurations for this transformer.
 | jdoe           |
 | lsmith         |
 
-### Generate UTC Timestamp\{#generate-utc-timestamp}
+### Generate UTC Timestamp\{#generate-utctimestamp}
 
 Randomly generates a utc timestamp in UTC timezone and returns back a time.Time representation of that timestamp.
 
@@ -821,7 +821,7 @@ Note that this does not work for hex values: 0x00 -> 0x1F such as chinese charac
 
 Passes the input data out to the output without making any modifications to it. This is useful in many circumstances but cautious of accidentally leaking sensitive data through this transformer.
 
-### Null\{#null}
+### Null\{#generate-null}
 
 Simply returns a null value. This may be useful if you a column that can't be null but don't have a specific value that you want to insert.
 
@@ -837,7 +837,7 @@ Here are some examples of what an output null value may look like.
 | ------------- | -------------- |
 | N/A           | null           |
 
-### Use Column Default\{#use-column-default}
+### Use Column Default\{#generate-default}
 
 Automatically applies the predefined default value of a column as specified in the SQL database schema. This means whenever new data is added without specifying a value for this column, the system will insert the default value set for that column in the database. This is typically used in conjunction with `GENERATED` columns.
 

--- a/docs/docs/transformers/system.md
+++ b/docs/docs/transformers/system.md
@@ -4,7 +4,7 @@ description: Learn about Neosync's System Transformers that come out of the box 
 id: system
 hide_title: false
 slug: /transformers/system
-# cSpell:words luhn,huntingon,dach,sporer,rodriguezon,rega,jdoe,lsmith,aidan,kunze,littel,johnsonston
+# cSpell:words luhn,huntingon,dach,sporer,rodriguezon,rega,jdoe,lsmith,aidan,kunze,littel,johnsonston,unixtimestamp,utctimestamp
 ---
 
 ## Introduction

--- a/frontend/apps/web/app/(mgmt)/[account]/connections/[id]/permissions/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/connections/[id]/permissions/page.tsx
@@ -4,7 +4,7 @@ import ResourceId from '@/components/ResourceId';
 import Spinner from '@/components/Spinner';
 import { SubNav } from '@/components/SubNav';
 import OverviewContainer from '@/components/containers/OverviewContainer';
-import LearnMoreTag from '@/components/labels/LearnMoreTag';
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import PermissionsDataTable from '@/components/permissions/PermissionsDataTable';
 import { TestConnectionResult } from '@/components/permissions/PermissionsDialog';
 import {
@@ -209,7 +209,7 @@ function PermissionsPageContainer(props: PermissionsPageContainerProps) {
       <div className="flex flex-row justify-between items-center w-full">
         <div className="text-muted-foreground text-sm">
           Review the permissions that Neosync needs for your connection.{' '}
-          <LearnMoreTag href="https://docs.neosync.dev/connections/postgres#permissions" />
+          <LearnMoreLink href="https://docs.neosync.dev/connections/postgres#permissions" />
         </div>
       </div>
 

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateJavascriptForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateJavascriptForm.tsx
@@ -4,7 +4,7 @@ import { FormLabel } from '@/components/ui/form';
 import ButtonText from '@/components/ButtonText';
 import FormErrorMessage from '@/components/FormErrorMessage';
 import Spinner from '@/components/Spinner';
-import LearnMoreTag from '@/components/labels/LearnMoreTag';
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { useAccount } from '@/components/providers/account-provider';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -83,9 +83,9 @@ export default function GenerateJavascriptForm(props: Props): ReactElement {
       <div className="flex flex-row items-center justify-between">
         <div className="space-y-0.5">
           <FormLabel>Transformer Code</FormLabel>
-          <div className="text-[0.8rem] text-muted-foreground">
-            Define your own Transformation below using Javascript.
-            <LearnMoreTag href="https://docs.neosync.dev/transformers/user-defined#custom-code-transformers" />
+          <div className="text-sm text-muted-foreground">
+            Define your own Transformation below using Javascript.{' '}
+            <LearnMoreLink href="https://docs.neosync.dev/transformers/user-defined#custom-code-transformers" />
           </div>
         </div>
         <div className="flex flex-row gap-2">

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateJavascriptForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/GenerateJavascriptForm.tsx
@@ -4,7 +4,6 @@ import { FormLabel } from '@/components/ui/form';
 import ButtonText from '@/components/ButtonText';
 import FormErrorMessage from '@/components/FormErrorMessage';
 import Spinner from '@/components/Spinner';
-import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { useAccount } from '@/components/providers/account-provider';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -84,8 +83,7 @@ export default function GenerateJavascriptForm(props: Props): ReactElement {
         <div className="space-y-0.5">
           <FormLabel>Transformer Code</FormLabel>
           <div className="text-sm text-muted-foreground">
-            Define your own Transformation below using Javascript.{' '}
-            <LearnMoreLink href="https://docs.neosync.dev/transformers/user-defined#custom-code-transformers" />
+            Define your own Transformation below using Javascript
           </div>
         </div>
         <div className="flex flex-row gap-2">

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformCharacterScrambleForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformCharacterScrambleForm.tsx
@@ -1,7 +1,6 @@
 'use client';
 import ButtonText from '@/components/ButtonText';
 import Spinner from '@/components/Spinner';
-import LearnMoreTag from '@/components/labels/LearnMoreTag';
 import { useAccount } from '@/components/providers/account-provider';
 import { Badge } from '@/components/ui/badge';
 import { FormDescription, FormLabel } from '@/components/ui/form';
@@ -9,6 +8,7 @@ import { Input } from '@/components/ui/input';
 import { CheckCircledIcon, CrossCircledIcon } from '@radix-ui/react-icons';
 
 import FormErrorMessage from '@/components/FormErrorMessage';
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { Button } from '@/components/ui/button';
 import { PlainMessage } from '@bufbuild/protobuf';
 import { useMutation } from '@connectrpc/connect-query';
@@ -95,7 +95,7 @@ export default function TransformCharacterScrambleForm(
             Provide a Go regular expression to match and transform a substring
             of the value. Leave this blank to transform the entire value. Note:
             the regex needs to compile in Go.{' '}
-            <LearnMoreTag href="https://docs.neosync.dev/transformers/system#transform-character-scramble" />
+            <LearnMoreLink href="https://docs.neosync.dev/transformers/system#transform-character-scramble" />
           </FormDescription>
         </div>
         <div className="flex flex-col">

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformJavascriptForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformJavascriptForm.tsx
@@ -4,7 +4,6 @@ import { FormLabel } from '@/components/ui/form';
 import ButtonText from '@/components/ButtonText';
 import FormErrorMessage from '@/components/FormErrorMessage';
 import Spinner from '@/components/Spinner';
-import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { useAccount } from '@/components/providers/account-provider';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -94,8 +93,7 @@ export default function TransformJavascriptForm(props: Props): ReactElement {
             <code className="bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-300 px-1 py-0.5 rounded">
               input.{'{'}column_name{'}'}
             </code>
-            .{' '}
-            <LearnMoreLink href="https://docs.neosync.dev/transformers/user-defined#custom-code-transformers" />
+            .
           </div>
         </div>
         <div className="flex flex-row gap-2">

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformJavascriptForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformJavascriptForm.tsx
@@ -4,7 +4,7 @@ import { FormLabel } from '@/components/ui/form';
 import ButtonText from '@/components/ButtonText';
 import FormErrorMessage from '@/components/FormErrorMessage';
 import Spinner from '@/components/Spinner';
-import LearnMoreTag from '@/components/labels/LearnMoreTag';
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { useAccount } from '@/components/providers/account-provider';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -84,7 +84,7 @@ export default function TransformJavascriptForm(props: Props): ReactElement {
       <div className="flex flex-row items-center justify-between">
         <div className="space-y-0.5">
           <FormLabel>Transformer Code</FormLabel>
-          <div className="text-[0.8rem] text-muted-foreground w-[90%]">
+          <div className="text-sm text-muted-foreground w-[90%]">
             Define your own Transformation below using Javascript. The source
             column value will be available at the{' '}
             <code className="bg-gray-200 dark:bg-gray-800 text-gray-800 dark:text-gray-300 px-1 py-0.5 rounded">
@@ -95,7 +95,7 @@ export default function TransformJavascriptForm(props: Props): ReactElement {
               input.{'{'}column_name{'}'}
             </code>
             .{' '}
-            <LearnMoreTag href="https://docs.neosync.dev/transformers/user-defined#custom-code-transformers" />
+            <LearnMoreLink href="https://docs.neosync.dev/transformers/user-defined#custom-code-transformers" />
           </div>
         </div>
         <div className="flex flex-row gap-2">

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
@@ -2,6 +2,7 @@
 
 import OverviewContainer from '@/components/containers/OverviewContainer';
 import PageHeader from '@/components/headers/PageHeader';
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { useAccount } from '@/components/providers/account-provider';
 import { Button } from '@/components/ui/button';
 import {
@@ -53,6 +54,7 @@ import {
   CreateUserDefinedTransformerFormContext,
   CreateUserDefinedTransformerFormValues,
 } from '../../../../../yup-validations/transformer-validations';
+import { constructDocsLink } from '../../transformers/EditTransformerOptions';
 import TransformerForm from './TransformerForms/TransformerForm';
 
 function getTransformerSource(sourceStr: string): TransformerSource {
@@ -180,7 +182,17 @@ export default function NewTransformer(): ReactElement {
               <FormItem>
                 <FormLabel>Source Transformer</FormLabel>
                 <FormDescription>
-                  The system transformer to clone.
+                  The system transformer to clone.{' '}
+                  {formSource !== 0 &&
+                    formSource !== null &&
+                    TransformerSource[formSource ?? 0] !=
+                      'GENERATE_JAVASCRIPT' &&
+                    TransformerSource[formSource ?? 0] !=
+                      'TRANSFORM_JAVASCRIPT' && (
+                      <LearnMoreLink
+                        href={constructDocsLink(formSource ?? 0)}
+                      />
+                    )}
                 </FormDescription>
                 <FormControl>
                   <Select

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
@@ -183,17 +183,13 @@ export default function NewTransformer(): ReactElement {
                 <FormLabel>Source Transformer</FormLabel>
                 <FormDescription>
                   The system transformer to clone.{' '}
-                  {formSource !== 0 &&
-                    formSource !== null &&
-                    TransformerSource[formSource ?? 0] !=
-                      'GENERATE_JAVASCRIPT' &&
-                    TransformerSource[formSource ?? 0] !=
-                      'TRANSFORM_JAVASCRIPT' && (
-                      <LearnMoreLink
-                        href={constructDocsLink(formSource ?? 0)}
-                        classNames={'text-[0.8rem]'}
-                      />
-                    )}
+                  {formSource !== 0 && formSource !== null && (
+                    <LearnMoreLink
+                      href={constructDocsLink(
+                        getTransformerSource(String(formSource))
+                      )}
+                    />
+                  )}
                 </FormDescription>
                 <FormControl>
                   <Select

--- a/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/transformer/page.tsx
@@ -191,6 +191,7 @@ export default function NewTransformer(): ReactElement {
                       'TRANSFORM_JAVASCRIPT' && (
                       <LearnMoreLink
                         href={constructDocsLink(formSource ?? 0)}
+                        classNames={'text-[0.8rem]'}
                       />
                     )}
                 </FormDescription>

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
@@ -1,3 +1,4 @@
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { useAccount } from '@/components/providers/account-provider';
 import { Alert, AlertDescription } from '@/components/ui/alert';
 import { Badge } from '@/components/ui/badge';
@@ -25,7 +26,7 @@ import {
 } from '@/yup-validations/jobs';
 import { useMutation } from '@connectrpc/connect-query';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { TransformerConfig } from '@neosync/sdk';
+import { TransformerConfig, TransformerSource } from '@neosync/sdk';
 import { validateUserJavascriptCode } from '@neosync/sdk/connectquery';
 import {
   EyeOpenIcon,
@@ -79,6 +80,7 @@ export default function EditTransformerOptions(props: Props): ReactElement {
       <DialogContent
         className="max-w-3xl"
         onPointerDownOutside={(e) => e.preventDefault()}
+        onEscapeKeyDown={(e) => e.preventDefault()}
       >
         <DialogHeader>
           <div className="flex flex-row w-full">
@@ -93,7 +95,20 @@ export default function EditTransformerOptions(props: Props): ReactElement {
                   </Badge>
                 </div>
               </div>
-              <DialogDescription>{transformer?.description}</DialogDescription>
+              <div className="flex flex-row items-center gap-2">
+                <DialogDescription>
+                  {transformer?.description}{' '}
+                  {/* dont render the learn more link for the js transformers since they have their own special link */}
+                  {TransformerSource[transformer.source] !=
+                    'GENERATE_JAVASCRIPT' &&
+                    TransformerSource[transformer.source] !=
+                      'TRANSFORM_JAVASCRIPT' && (
+                      <LearnMoreLink
+                        href={constructDocsLink(transformer.source)}
+                      />
+                    )}
+                </DialogDescription>
+              </div>
             </div>
           </div>
           <Separator />
@@ -215,4 +230,15 @@ function NoAdditionalTransformerConfigurations(): ReactElement {
       </div>
     </Alert>
   );
+}
+
+function constructDocsLink(source: number): string {
+  console.log('s', TransformerSource[source]);
+  const name: string = TransformerSource[source]
+    .toLowerCase()
+    .replaceAll('_', '-');
+
+  console.log('name', name);
+
+  return `https://docs.neosync.dev/transformers/system#${name}`;
 }

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
@@ -18,7 +18,10 @@ import {
   isUserDefinedTransformer,
   Transformer,
 } from '@/shared/transformers';
-import { getTransformerDataTypesString } from '@/util/util';
+import {
+  getTransformerDataTypesString,
+  getTransformerSourceString,
+} from '@/util/util';
 import {
   convertTransformerConfigSchemaToTransformerConfig,
   convertTransformerConfigToForm,
@@ -98,16 +101,7 @@ export default function EditTransformerOptions(props: Props): ReactElement {
               <div className="flex flex-row items-center gap-2">
                 <DialogDescription>
                   {transformer?.description}{' '}
-                  {/* don't render the learn more link for the js transformers since they have their own special link && only render for system transformers*/}
-                  {TransformerSource[transformer.source] !=
-                    'GENERATE_JAVASCRIPT' &&
-                    TransformerSource[transformer.source] !=
-                      'TRANSFORM_JAVASCRIPT' &&
-                    isSystemTransformer(transformer) && (
-                      <LearnMoreLink
-                        href={constructDocsLink(transformer.source)}
-                      />
-                    )}
+                  <LearnMoreLink href={constructDocsLink(transformer.source)} />
                 </DialogDescription>
               </div>
             </div>
@@ -233,10 +227,15 @@ function NoAdditionalTransformerConfigurations(): ReactElement {
   );
 }
 
-export function constructDocsLink(source: number): string {
-  const name: string = TransformerSource[source]
-    .toLowerCase()
-    .replaceAll('_', '-');
+export function constructDocsLink(source: TransformerSource): string {
+  const name = getTransformerSourceString(source).replaceAll('_', '-');
 
-  return `https://docs.neosync.dev/transformers/system#${name}`;
+  if (
+    source == TransformerSource.GENERATE_JAVASCRIPT ||
+    source == TransformerSource.TRANSFORM_JAVASCRIPT
+  ) {
+    return `https://docs.neosync.dev/guides/custom-code-transformers`;
+  } else {
+    return `https://docs.neosync.dev/transformers/system#${name}`;
+  }
 }

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
@@ -98,11 +98,12 @@ export default function EditTransformerOptions(props: Props): ReactElement {
               <div className="flex flex-row items-center gap-2">
                 <DialogDescription>
                   {transformer?.description}{' '}
-                  {/* dont render the learn more link for the js transformers since they have their own special link */}
+                  {/* don't render the learn more link for the js transformers since they have their own special link && only render for system transformers*/}
                   {TransformerSource[transformer.source] !=
                     'GENERATE_JAVASCRIPT' &&
                     TransformerSource[transformer.source] !=
-                      'TRANSFORM_JAVASCRIPT' && (
+                      'TRANSFORM_JAVASCRIPT' &&
+                    isSystemTransformer(transformer) && (
                       <LearnMoreLink
                         href={constructDocsLink(transformer.source)}
                       />

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
@@ -234,12 +234,9 @@ function NoAdditionalTransformerConfigurations(): ReactElement {
 }
 
 function constructDocsLink(source: number): string {
-  console.log('s', TransformerSource[source]);
   const name: string = TransformerSource[source]
     .toLowerCase()
     .replaceAll('_', '-');
-
-  console.log('name', name);
 
   return `https://docs.neosync.dev/transformers/system#${name}`;
 }

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/EditTransformerOptions.tsx
@@ -233,7 +233,7 @@ function NoAdditionalTransformerConfigurations(): ReactElement {
   );
 }
 
-function constructDocsLink(source: number): string {
+export function constructDocsLink(source: number): string {
   const name: string = TransformerSource[source]
     .toLowerCase()
     .replaceAll('_', '-');

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/[id]/components/UpdateTransformerForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/[id]/components/UpdateTransformerForm.tsx
@@ -118,6 +118,7 @@ export default function UpdateTransformerForm(props: Props): ReactElement {
                     'TRANSFORM_JAVASCRIPT' && (
                     <LearnMoreLink
                       href={constructDocsLink(currentTransformer.source ?? 0)}
+                      classNames={'text-[0.8rem]'}
                     />
                   )}
               </FormDescription>

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/[id]/components/UpdateTransformerForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/[id]/components/UpdateTransformerForm.tsx
@@ -1,5 +1,6 @@
 'use client';
 import TransformerForm from '@/app/(mgmt)/[account]/new/transformer/TransformerForms/TransformerForm';
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { useAccount } from '@/components/providers/account-provider';
 import { Button } from '@/components/ui/button';
 import {
@@ -24,7 +25,7 @@ import {
 } from '@/yup-validations/transformer-validations';
 import { useMutation } from '@connectrpc/connect-query';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { UserDefinedTransformer } from '@neosync/sdk';
+import { TransformerSource, UserDefinedTransformer } from '@neosync/sdk';
 import {
   isTransformerNameAvailable,
   updateUserDefinedTransformer,
@@ -34,6 +35,7 @@ import NextLink from 'next/link';
 import { ReactElement } from 'react';
 import { useForm } from 'react-hook-form';
 import { toast } from 'sonner';
+import { constructDocsLink } from '../../EditTransformerOptions';
 
 interface Props {
   currentTransformer: UserDefinedTransformer;
@@ -106,7 +108,19 @@ export default function UpdateTransformerForm(props: Props): ReactElement {
           render={() => (
             <FormItem>
               <FormLabel>Source Transformer</FormLabel>
-              <FormDescription>The system transformer source.</FormDescription>
+              <FormDescription>
+                The system transformer source.{' '}
+                {currentTransformer.source !== 0 &&
+                  currentTransformer.source !== null &&
+                  TransformerSource[currentTransformer.source ?? 0] !=
+                    'GENERATE_JAVASCRIPT' &&
+                  TransformerSource[currentTransformer.source ?? 0] !=
+                    'TRANSFORM_JAVASCRIPT' && (
+                    <LearnMoreLink
+                      href={constructDocsLink(currentTransformer.source ?? 0)}
+                    />
+                  )}
+              </FormDescription>
               <FormControl>
                 <Select disabled={true}>
                   <SelectTrigger>

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/[id]/components/UpdateTransformerForm.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/[id]/components/UpdateTransformerForm.tsx
@@ -25,7 +25,7 @@ import {
 } from '@/yup-validations/transformer-validations';
 import { useMutation } from '@connectrpc/connect-query';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { TransformerSource, UserDefinedTransformer } from '@neosync/sdk';
+import { UserDefinedTransformer } from '@neosync/sdk';
 import {
   isTransformerNameAvailable,
   updateUserDefinedTransformer,
@@ -110,17 +110,9 @@ export default function UpdateTransformerForm(props: Props): ReactElement {
               <FormLabel>Source Transformer</FormLabel>
               <FormDescription>
                 The system transformer source.{' '}
-                {currentTransformer.source !== 0 &&
-                  currentTransformer.source !== null &&
-                  TransformerSource[currentTransformer.source ?? 0] !=
-                    'GENERATE_JAVASCRIPT' &&
-                  TransformerSource[currentTransformer.source ?? 0] !=
-                    'TRANSFORM_JAVASCRIPT' && (
-                    <LearnMoreLink
-                      href={constructDocsLink(currentTransformer.source ?? 0)}
-                      classNames={'text-[0.8rem]'}
-                    />
-                  )}
+                <LearnMoreLink
+                  href={constructDocsLink(currentTransformer.source)}
+                />
               </FormDescription>
               <FormControl>
                 <Select disabled={true}>

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/systemTransformers/[source]/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/systemTransformers/[source]/page.tsx
@@ -3,6 +3,7 @@ import TransformerForm from '@/app/(mgmt)/[account]/new/transformer/TransformerF
 import ButtonText from '@/components/ButtonText';
 import OverviewContainer from '@/components/containers/OverviewContainer';
 import PageHeader from '@/components/headers/PageHeader';
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { useAccount } from '@/components/providers/account-provider';
 import { PageProps } from '@/components/types';
 import { Button } from '@/components/ui/button';
@@ -32,6 +33,7 @@ import Error from 'next/error';
 import NextLink from 'next/link';
 import { ReactElement } from 'react';
 import { useForm } from 'react-hook-form';
+import { constructDocsLink } from '../../EditTransformerOptions';
 
 function getTransformerSource(sourceStr: string): TransformerSource {
   const sourceNum = parseInt(sourceStr, 10);
@@ -87,79 +89,81 @@ export default function ViewSystemTransformers({
       containerClassName="px-12 md:px-24 lg:px-32"
     >
       <Form {...form}>
-        <form className="space-y-8">
-          <div>
-            <FormField
-              control={form.control}
-              name="name"
-              disabled={true}
-              render={({ field }) => (
-                <FormItem>
-                  <FormLabel>Name</FormLabel>
-                  <FormDescription>The Transformer name</FormDescription>
-                  <FormControl>
-                    <Input placeholder="Transformer Name" {...field} />
-                  </FormControl>
-                  <FormMessage />
-                </FormItem>
-              )}
-            />
-            <div className="pt-10">
-              <FormField
-                control={form.control}
-                name="description"
-                disabled={true}
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Description</FormLabel>
-                    <FormDescription>
-                      The Transformer decription.
-                    </FormDescription>
-                    <FormControl>
-                      <Input placeholder="Transformer Name" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-            <div className="pt-10">
-              <FormField
-                control={form.control}
-                disabled={true}
-                name="type"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Data Type</FormLabel>
-                    <FormDescription>The Transformer type.</FormDescription>
-                    <FormControl>
-                      <Input placeholder="Transformer type" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-            <div className="pt-10">
-              <FormField
-                control={form.control}
-                disabled={true}
-                name="source"
-                render={({ field }) => (
-                  <FormItem>
-                    <FormLabel>Source</FormLabel>
-                    <FormDescription>
-                      The unique key associated with the transformer.
-                    </FormDescription>
-                    <FormControl>
-                      <Input placeholder="Transformer Source" {...field} />
-                    </FormControl>
-                    <FormMessage />
-                  </FormItem>
-                )}
-              />
-            </div>
-          </div>
+        <form>
+          <FormField
+            control={form.control}
+            name="name"
+            disabled={true}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Name</FormLabel>
+                <FormDescription>
+                  The Transformer name.{' '}
+                  {sourceParam !== 0 &&
+                    sourceParam !== null &&
+                    TransformerSource[sourceParam ?? 0] !=
+                      'GENERATE_JAVASCRIPT' &&
+                    TransformerSource[sourceParam ?? 0] !=
+                      'TRANSFORM_JAVASCRIPT' && (
+                      <LearnMoreLink
+                        href={constructDocsLink(sourceParam ?? 0)}
+                      />
+                    )}
+                </FormDescription>
+                <FormControl>
+                  <Input placeholder="Transformer Name" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            name="description"
+            disabled={true}
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Description</FormLabel>
+                <FormDescription>The Transformer decription.</FormDescription>
+                <FormControl>
+                  <Input placeholder="Transformer Name" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            disabled={true}
+            name="type"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Data Type</FormLabel>
+                <FormDescription>The Transformer type.</FormDescription>
+                <FormControl>
+                  <Input placeholder="Transformer type" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
+          <FormField
+            control={form.control}
+            disabled={true}
+            name="source"
+            render={({ field }) => (
+              <FormItem>
+                <FormLabel>Source</FormLabel>
+                <FormDescription>
+                  The unique key associated with the transformer.
+                </FormDescription>
+                <FormControl>
+                  <Input placeholder="Transformer Source" {...field} />
+                </FormControl>
+                <FormMessage />
+              </FormItem>
+            )}
+          />
           <div>
             <TransformerForm
               value={convertTransformerConfigSchemaToTransformerConfig(cfg)}
@@ -167,7 +171,7 @@ export default function ViewSystemTransformers({
               disabled={true}
             />
           </div>
-          <div className="flex flex-row justify-start">
+          <div className="flex flex-row justify-start pt-10">
             <NextLink href={`/${account?.name}/transformers?tab=system`}>
               <Button type="button">Back</Button>
             </NextLink>

--- a/frontend/apps/web/app/(mgmt)/[account]/transformers/systemTransformers/[source]/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/transformers/systemTransformers/[source]/page.tsx
@@ -99,16 +99,11 @@ export default function ViewSystemTransformers({
                 <FormLabel>Name</FormLabel>
                 <FormDescription>
                   The Transformer name.{' '}
-                  {sourceParam !== 0 &&
-                    sourceParam !== null &&
-                    TransformerSource[sourceParam ?? 0] !=
-                      'GENERATE_JAVASCRIPT' &&
-                    TransformerSource[sourceParam ?? 0] !=
-                      'TRANSFORM_JAVASCRIPT' && (
-                      <LearnMoreLink
-                        href={constructDocsLink(sourceParam ?? 0)}
-                      />
+                  <LearnMoreLink
+                    href={constructDocsLink(
+                      getTransformerSource(String(sourceParam))
                     )}
+                  />
                 </FormDescription>
                 <FormControl>
                   <Input placeholder="Transformer Name" {...field} />

--- a/frontend/apps/web/components/headers/PageHeader.tsx
+++ b/frontend/apps/web/components/headers/PageHeader.tsx
@@ -37,7 +37,7 @@ export default function PageHeader(props: Props) {
         <div className="flex flex-col md:flex-row items-center gap-3">
           {leftIcon ? leftIcon : null}
           <div className="flex flex-row items-center gap-4">
-            <h1 className="text-2xl font-bold tracking-tight truncate   max-w-[300px] lg:max-w-[600px]">
+            <h1 className="text-2xl font-bold tracking-tight truncate max-w-[300px] lg:max-w-[600px]">
               {header}
             </h1>
             {leftBadgeValue && (

--- a/frontend/apps/web/components/labels/LearnMoreLink.tsx
+++ b/frontend/apps/web/components/labels/LearnMoreLink.tsx
@@ -1,22 +1,24 @@
+import { cn } from '@/libs/utils';
 import { ArrowTopRightIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
 import { ReactElement } from 'react';
 
 interface Props {
   href: string;
+  classNames?: string;
 }
 
 export default function LearnMoreLink(props: Props): ReactElement {
-  const { href } = props;
+  const { href, classNames } = props;
 
   return (
     <Link
       href={href}
       target="_blank"
-      className="underline inline-block text-gray-600"
+      className={cn('underline inline-block text-gray-600 text-sm', classNames)}
     >
       <div className="flex flex-row items-center gap-1">
-        <div className="text-sm text-muted-foreground">Learn more</div>
+        <div className="text-muted-foreground">Learn more</div>
         <ArrowTopRightIcon className="w-3 h-3" />
       </div>
     </Link>

--- a/frontend/apps/web/components/labels/LearnMoreLink.tsx
+++ b/frontend/apps/web/components/labels/LearnMoreLink.tsx
@@ -1,4 +1,4 @@
-import { ExternalLinkIcon } from '@radix-ui/react-icons';
+import { ArrowTopRightIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
 import { ReactElement } from 'react';
 
@@ -6,14 +6,18 @@ interface Props {
   href: string;
 }
 
-export default function LearnMoreTag(props: Props): ReactElement {
+export default function LearnMoreLink(props: Props): ReactElement {
   const { href } = props;
 
   return (
-    <Link href={href} target="_blank" className="underline inline-block">
+    <Link
+      href={href}
+      target="_blank"
+      className="underline inline-block text-gray-600"
+    >
       <div className="flex flex-row items-center gap-1">
         <div className="text-sm text-muted-foreground">Learn more</div>
-        <ExternalLinkIcon />
+        <ArrowTopRightIcon className="w-3 h-3" />
       </div>
     </Link>
   );

--- a/frontend/apps/web/components/permissions/PermissionsDialog.tsx
+++ b/frontend/apps/web/components/permissions/PermissionsDialog.tsx
@@ -15,7 +15,7 @@ import {
 import { ReactElement, useMemo } from 'react';
 import { IoWarning } from 'react-icons/io5';
 import Spinner from '../Spinner';
-import LearnMoreTag from '../labels/LearnMoreTag';
+import LearnMoreLink from '../labels/LearnMoreLink';
 import { Button } from '../ui/button';
 import PermissionsDataTable from './PermissionsDataTable';
 import { PermissionConnectionType, getPermissionColumns } from './columns';
@@ -54,7 +54,7 @@ export default function PermissionsDialog(props: Props): ReactElement {
           </div>
           <div className="text-muted-foreground text-sm">
             Review the permissions that Neosync needs for your connection.{' '}
-            <LearnMoreTag href="https://docs.neosync.dev/connections/postgres#permissions" />{' '}
+            <LearnMoreLink href="https://docs.neosync.dev/connections/postgres#permissions" />{' '}
           </div>
         </DialogHeader>
         <PermissionsDataTable


### PR DESCRIPTION
This features adds a "Learn More" link that points to the specific Transformer being inspected/selected. 

Updated:
1. System Transformers [id] page
2. Custom Transformers [id] page
3. Create new Custom Transformer page
4. Transformer Dialog in Mapping page

https://www.loom.com/share/632ff6d558954d86a411166f679f2659?sid=c9c5dc70-295c-45c8-ab5d-0b2cc788899d