### PR TITLE
Reduces bastion host network error logs

### DIFF
--- a/backend/pkg/sshtunnel/tunnel.go
+++ b/backend/pkg/sshtunnel/tunnel.go
@@ -8,6 +8,7 @@ import (
 	"net"
 	"sync"
 	"sync/atomic"
+	"time"
 
 	"github.com/google/uuid"
 	"golang.org/x/crypto/ssh"
@@ -55,6 +56,7 @@ func New(
 			User:            tunnel.User,
 			Auth:            authmethods,
 			HostKeyCallback: getHostKeyCallback(serverPublicKey),
+			Timeout:         30 * time.Second,
 		},
 
 		shutdowns: &sync.Map{},

--- a/backend/pkg/sshtunnel/tunnel.go
+++ b/backend/pkg/sshtunnel/tunnel.go
@@ -242,9 +242,13 @@ func getSshClient(
 func copyConnection(writer, reader net.Conn, done chan<- error, logger *slog.Logger) {
 	_, err := io.Copy(writer, reader)
 	if err != nil {
-		logger.Error(fmt.Sprintf("io.Copy error: %s", err))
+		if errors.Is(err, net.ErrClosed) {
+			logger.Warn("connection was closed before reaching end of input", "error", err)
+		} else {
+			logger.Error("unexpected error while streaming through tunnel", "error", err)
+		}
 	} else {
-		logger.Debug("io.Copy returned successfully")
+		logger.Debug("ssh tunnel stream completed successfully")
 	}
 	done <- err
 }

--- a/backend/pkg/sshtunnel/tunnel.go
+++ b/backend/pkg/sshtunnel/tunnel.go
@@ -90,7 +90,9 @@ func (t *Sshtunnel) Start(logger *slog.Logger) (chan any, error) {
 func (t *Sshtunnel) serve(listener net.Listener, ready chan<- any, logger *slog.Logger) {
 	defer func() {
 		if err := listener.Close(); err != nil {
-			logger.Error("failed to close tunnel listener", "error", err)
+			if !errors.Is(err, net.ErrClosed) {
+				logger.Error("failed to close tunnel listener", "error", err)
+			}
 		}
 	}()
 


### PR DESCRIPTION
Updates a common (unavoidable) error to be a warning.
Adds more debug logging to bastion host.
Took some time to rework the host to be much easier to read and better handle connection leaks.

I've had to manually test this since we don't have reliable integration tests for tunneling yet.