### PR TITLE
NEOS-1472: add frontend banner that displays account status

### DIFF
--- a/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
@@ -7,7 +7,9 @@ import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGetSystemAppConfig } from '@/libs/hooks/useGetSystemAppConfig';
 import { toTitleCase } from '@/util/util';
+import { useQuery } from '@connectrpc/connect-query';
 import { UserAccountType } from '@neosync/sdk';
+import { getAccountStatus } from '@neosync/sdk/connectquery';
 import { CheckCircledIcon, DiscordLogoIcon } from '@radix-ui/react-icons';
 import Error from 'next/error';
 import Link from 'next/link';
@@ -245,4 +247,19 @@ function PlanButton(props: PlanButtonProps): ReactElement {
         );
       }
   }
+}
+
+interface AccountStatusProps {
+  accountId: string;
+}
+
+function AccountStatus(props: AccountStatusProps): ReactElement {
+  const { accountId } = props;
+  const { data: accountStatusResp } = useQuery(
+    getAccountStatus,
+    { accountId },
+    { enabled: !!accountId }
+  );
+
+  return <div />;
 }

--- a/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
@@ -1,4 +1,5 @@
 'use client';
+import SubPageHeader from '@/components/headers/SubPageHeader';
 import { useAccount } from '@/components/providers/account-provider';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
@@ -12,11 +13,20 @@ import Error from 'next/error';
 import Link from 'next/link';
 import { ReactElement } from 'react';
 
-const plans = [
+type PlanName = 'Personal' | 'Team' | 'Enterprise';
+
+interface Plan {
+  name: PlanName;
+  features: string[];
+  price: string;
+  planType: UserAccountType;
+}
+
+const ALL_PLANS: Plan[] = [
   {
     name: 'Personal',
     features: [
-      '100k records/month',
+      '20k records/month',
       'Unlimited Jobs',
       '1 user',
       'US Region',
@@ -25,6 +35,7 @@ const plans = [
       'Community Discord',
     ],
     price: 'Free',
+    planType: UserAccountType.PERSONAL,
   },
   {
     name: 'Team',
@@ -38,6 +49,7 @@ const plans = [
       'Private Discord/Slack',
     ],
     price: 'Contact us',
+    planType: UserAccountType.TEAM,
   },
   {
     name: 'Enterprise',
@@ -51,6 +63,7 @@ const plans = [
       'Private Discord/Slack',
     ],
     price: 'Contact Us',
+    planType: UserAccountType.ENTERPRISE,
   },
 ];
 
@@ -68,21 +81,19 @@ export default function Billing(): ReactElement {
   }
 
   return (
-    <div>
-      <div className="flex flex-col gap-10">
-        <div>
-          <div className="text-xl font-seminold">Billing</div>
-          <div className="text-sm">
-            {`Manage your workspace's plan and billing information`}
-          </div>
-          <Separator />
-        </div>
+    <div className="flex flex-col gap-5">
+      <SubPageHeader
+        header="Billing"
+        description="Manage your workspace's plan and billing information"
+      />
+      <div className="py-4">
         <NeedHelp />
-        <Plans
-          planType={account.type ?? UserAccountType.PERSONAL}
-          upgradeHref={systemAppConfigData?.calendlyUpgradeLink ?? ''}
-        />
       </div>
+      <Plans
+        accountType={account.type}
+        upgradeHref={systemAppConfigData.calendlyUpgradeLink}
+        plans={ALL_PLANS}
+      />
     </div>
   );
 }
@@ -110,80 +121,92 @@ function NeedHelp(): ReactElement {
   );
 }
 
-interface PlanProps {
-  planType: UserAccountType;
+interface PlansProps {
+  accountType: UserAccountType;
+  plans: Plan[];
   upgradeHref: string;
 }
 
-function Plans({ planType, upgradeHref }: PlanProps): ReactElement {
+function Plans({ accountType, upgradeHref, plans }: PlansProps): ReactElement {
   return (
-    <div>
-      <div className="border border-gray-200 rounded-xl p-6 flex flex-col gap-4">
-        <div className="flex flex-row items-center gap-2 text-sm">
-          <div className="font-semibold">Current Plan:</div>
-          <div>
-            <Badge>{toTitleCase(UserAccountType[planType])} Plan</Badge>
-          </div>
-        </div>
+    <div className="border border-gray-200 rounded-xl">
+      <div className="flex flex-col gap-6">
         <div>
-          <div className="flex flex-row justify-between items-center"></div>
-        </div>
-        <Separator />
-        <div className="flex flex-row items-center gap-2 justify-center">
-          <div className="flex flex-col lg:flex-row gap-2 pt-6">
-            {plans.map((plan, ind) => (
-              <div key={plan.name}>
-                {planType == ind + 1 && (
-                  <div className="flex justify-center bg-gradient-to-t from-[#191919] to-[#484848] text-white p-4 shadow-lg rounded-t-xl">
-                    Current Plan
-                  </div>
-                )}
-                <div
-                  className={
-                    planType == ind + 1
-                      ? `flex flex-col items-center gap-2 border-4 border-gray-800 p-6 rounded-b-xl lg:w-[350px] h-[459px]`
-                      : `flex flex-col items-center gap-2 border border-gray-300 p-6 rounded-xl lg:w-[350px] mt-[56px] h-[459px]`
-                  }
-                >
-                  <div className="flex flex-col gap-6">
-                    <div className="flex justify-center">
-                      <Badge variant="outline">{plan.name} Plan</Badge>
-                    </div>
-                    <div className="flex justify-center flex-row gap-2">
-                      <div className="text-3xl ">{plan.price}</div>
-                      {plan.name == 'Team' && (
-                        <div className="text-sm self-end pb-1">/mo</div>
-                      )}
-                    </div>
-                    <div className="flex flex-col gap-2">
-                      {plan.features.map((feat) => (
-                        <div
-                          key={feat}
-                          className="flex flex-row items-center gap-2"
-                        >
-                          <CheckCircledIcon className="w-4 h-4 text-green-800 bg-green-200 rounded-full" />
-                          <div>{feat}</div>
-                        </div>
-                      ))}
-                    </div>
-                    <PlanButton
-                      plan={plan.name}
-                      planType={planType}
-                      upgradeHref={upgradeHref}
-                    />
-                  </div>
-                </div>
-              </div>
-            ))}
+          <div className="flex flex-row items-center gap-2 text-sm p-6">
+            <p className="font-semibold">Current Plan:</p>
+            <Badge>{toTitleCase(UserAccountType[accountType])} Plan</Badge>
           </div>
+          <Separator />
+        </div>
+        <div className="flex flex-col lg:flex-row gap-2 justify-center pb-6">
+          {plans.map((plan) => (
+            <PlanInfo
+              key={plan.name}
+              plan={plan}
+              activePlan={accountType}
+              upgradeHref={upgradeHref}
+            />
+          ))}
         </div>
       </div>
     </div>
   );
 }
 
+interface PlanInfoProps {
+  plan: Plan;
+  activePlan: UserAccountType;
+  upgradeHref: string;
+}
+function PlanInfo(props: PlanInfoProps): ReactElement {
+  const { plan, activePlan, upgradeHref } = props;
+  const isCurrentPlan = activePlan === plan.planType;
+  return (
+    <div>
+      {isCurrentPlan && <CurrentPlan />}
+      <div
+        className={
+          isCurrentPlan
+            ? `flex flex-col items-center gap-2 border-4 border-gray-800 p-6 rounded-b-xl lg:w-[350px] h-[459px]`
+            : `flex flex-col items-center gap-2 border border-gray-300 p-6 rounded-xl lg:w-[350px] mt-[56px] h-[459px]`
+        }
+      >
+        <div className="flex flex-col gap-6">
+          <div className="flex justify-center">
+            <Badge variant="outline">{plan.name} Plan</Badge>
+          </div>
+          <div className="flex justify-center flex-row gap-2">
+            <div className="text-3xl ">{plan.price}</div>
+          </div>
+          <div className="flex flex-col gap-2">
+            {plan.features.map((feat) => (
+              <div key={feat} className="flex flex-row items-center gap-2">
+                <CheckCircledIcon className="w-4 h-4 text-green-800 bg-green-200 rounded-full" />
+                <div>{feat}</div>
+              </div>
+            ))}
+          </div>
+          <PlanButton
+            plan={plan.name}
+            planType={activePlan}
+            upgradeHref={upgradeHref}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}
+
+function CurrentPlan(): ReactElement {
+  return (
+    <div className="flex justify-center bg-gradient-to-t from-[#191919] to-[#484848] text-white p-4 shadow-lg rounded-t-xl">
+      <p>Current Plan</p>
+    </div>
+  );
+}
+
 interface PlanButtonProps {
-  plan: string;
+  plan: PlanName;
   planType: UserAccountType;
   upgradeHref: string;
 }
@@ -195,14 +218,14 @@ function PlanButton(props: PlanButtonProps): ReactElement {
       if (planType == UserAccountType.PERSONAL) {
         return <div></div>;
       } else {
-        return <Button>Get Started</Button>;
+        return <Button type="button">Get Started</Button>;
       }
     case 'Team':
       if (planType == UserAccountType.TEAM) {
         return <div></div>;
       } else {
         return (
-          <Button>
+          <Button type="button">
             <Link href={upgradeHref} className="w-[242px]" target="_blank">
               Get in touch
             </Link>
@@ -214,7 +237,7 @@ function PlanButton(props: PlanButtonProps): ReactElement {
         return <div></div>;
       } else {
         return (
-          <Button>
+          <Button type="button">
             <Link href={upgradeHref} className="w-[242px]" target="_blank">
               Get in touch
             </Link>
@@ -222,5 +245,4 @@ function PlanButton(props: PlanButtonProps): ReactElement {
         );
       }
   }
-  return <div />;
 }

--- a/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
@@ -130,7 +130,7 @@ interface PlansProps {
 function Plans({ accountType, upgradeHref, plans }: PlansProps): ReactElement {
   return (
     <div className="border border-gray-200 rounded-xl">
-      <div className="flex flex-col gap-6">
+      <div className="flex flex-col gap-3">
         <div>
           <div className="flex flex-row items-center gap-2 text-sm p-6">
             <p className="font-semibold">Current Plan:</p>
@@ -138,7 +138,7 @@ function Plans({ accountType, upgradeHref, plans }: PlansProps): ReactElement {
           </div>
           <Separator />
         </div>
-        <div className="flex flex-col lg:flex-row gap-2 justify-center pb-6">
+        <div className="flex flex-col xl:flex-row gap-2 justify-center p-6">
           {plans.map((plan) => (
             <PlanInfo
               key={plan.name}
@@ -167,8 +167,8 @@ function PlanInfo(props: PlanInfoProps): ReactElement {
       <div
         className={
           isCurrentPlan
-            ? `flex flex-col items-center gap-2 border-4 border-gray-800 p-6 rounded-b-xl lg:w-[350px] h-[459px]`
-            : `flex flex-col items-center gap-2 border border-gray-300 p-6 rounded-xl lg:w-[350px] mt-[56px] h-[459px]`
+            ? `flex flex-col items-center gap-2 border-4 border-gray-800 p-6 rounded-b-xl xl:w-[350px] h-[459px]`
+            : `flex flex-col items-center gap-2 border border-gray-300 p-6 rounded-xl xl:w-[350px] mt-[56px] h-[459px]`
         }
       >
         <div className="flex flex-col gap-6">
@@ -176,7 +176,7 @@ function PlanInfo(props: PlanInfoProps): ReactElement {
             <Badge variant="outline">{plan.name} Plan</Badge>
           </div>
           <div className="flex justify-center flex-row gap-2">
-            <div className="text-3xl ">{plan.price}</div>
+            <div className="text-3xl">{plan.price}</div>
           </div>
           <div className="flex flex-col gap-2">
             {plan.features.map((feat) => (

--- a/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
@@ -7,9 +7,7 @@ import { Separator } from '@/components/ui/separator';
 import { Skeleton } from '@/components/ui/skeleton';
 import { useGetSystemAppConfig } from '@/libs/hooks/useGetSystemAppConfig';
 import { toTitleCase } from '@/util/util';
-import { useQuery } from '@connectrpc/connect-query';
 import { UserAccountType } from '@neosync/sdk';
-import { getAccountStatus } from '@neosync/sdk/connectquery';
 import { CheckCircledIcon, DiscordLogoIcon } from '@radix-ui/react-icons';
 import Error from 'next/error';
 import Link from 'next/link';
@@ -247,19 +245,4 @@ function PlanButton(props: PlanButtonProps): ReactElement {
         );
       }
   }
-}
-
-interface AccountStatusProps {
-  accountId: string;
-}
-
-function AccountStatus(props: AccountStatusProps): ReactElement {
-  const { accountId } = props;
-  const { data: accountStatusResp } = useQuery(
-    getAccountStatus,
-    { accountId },
-    { enabled: !!accountId }
-  );
-
-  return <div />;
 }

--- a/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/settings/billing/page.tsx
@@ -136,7 +136,7 @@ function Plans({ accountType, upgradeHref, plans }: PlansProps): ReactElement {
             <p className="font-semibold">Current Plan:</p>
             <Badge>{toTitleCase(UserAccountType[accountType])} Plan</Badge>
           </div>
-          <Separator />
+          <Separator className="dark:bg-gray-600" />
         </div>
         <div className="flex flex-col xl:flex-row gap-2 justify-center p-6">
           {plans.map((plan) => (

--- a/frontend/apps/web/components/headers/SubPageHeader.tsx
+++ b/frontend/apps/web/components/headers/SubPageHeader.tsx
@@ -1,3 +1,4 @@
+import { cn } from '@/libs/utils';
 import { ReactNode } from 'react';
 import { Separator } from '../ui/separator';
 
@@ -10,7 +11,7 @@ interface Props {
 export default function SubPageHeader(props: Props) {
   const { header, description, extraHeading } = props;
   return (
-    <div>
+    <div className={cn('page-subheader-container flex flex-col gap-2')}>
       <div className="flex flex-col md:flex-row flex-wrap justify-between gap-4 md:gap-0">
         <div className="flex flex-col gap-0.5">
           <h2 className="text-xl font-semibold tracking-tight">{header}</h2>
@@ -18,7 +19,7 @@ export default function SubPageHeader(props: Props) {
         </div>
         {extraHeading ? <div>{extraHeading}</div> : null}
       </div>
-      <Separator className="my-4" />
+      <Separator className="dark:bg-gray-600" />
     </div>
   );
 }

--- a/frontend/apps/web/components/site-header/SiteHeader.tsx
+++ b/frontend/apps/web/components/site-header/SiteHeader.tsx
@@ -10,14 +10,14 @@ import {
   SheetTitle,
   SheetTrigger,
 } from '@/components/ui/sheet';
-import { ArrowUpIcon, QuestionMarkCircledIcon } from '@radix-ui/react-icons';
-import Link from 'next/link';
+import { QuestionMarkCircledIcon } from '@radix-ui/react-icons';
 import { ReactElement } from 'react';
 import SupportDrawer from '../SupportDrawer';
 import AccountSwitcher from './AccountSwitcher';
 import { MainNav } from './MainNav';
 import { MobileNav } from './MobileNav';
 import { ModeToggle } from './ModeToggle';
+import Upgrade from './Upgrade';
 import { UserNav } from './UserNav';
 
 export default function SiteHeader(): ReactElement {
@@ -28,9 +28,10 @@ export default function SiteHeader(): ReactElement {
         <MainNav />
         <MobileNav />
         <div className="flex flex-1 justify-end items-center space-x-2">
-          {!systemAppConfig?.isNeosyncCloud && (
-            <UpgradeButton href={systemAppConfig.calendlyUpgradeLink} />
-          )}
+          <Upgrade
+            buttonHref={systemAppConfig.calendlyUpgradeLink}
+            isNeosyncCloud={systemAppConfig.isNeosyncCloud}
+          />
           <SupportSheet />
           {systemAppConfig.isAuthEnabled && <AccountSwitcher />}
           <ModeToggle />
@@ -38,25 +39,6 @@ export default function SiteHeader(): ReactElement {
         </div>
       </div>
     </header>
-  );
-}
-
-interface UpgradeButtonProps {
-  href: string;
-}
-function UpgradeButton(props: UpgradeButtonProps): ReactElement {
-  const { href } = props;
-  return (
-    <div>
-      <Button variant="outline" size="sm">
-        <div className="flex flex-row gap-2 items-center">
-          <Link href={href} target="_blank">
-            <div>Upgrade</div>
-          </Link>
-          <ArrowUpIcon />{' '}
-        </div>
-      </Button>
-    </div>
   );
 }
 

--- a/frontend/apps/web/components/site-header/Upgrade.tsx
+++ b/frontend/apps/web/components/site-header/Upgrade.tsx
@@ -42,7 +42,13 @@ export default function Upgrade(props: UpgradeProps): ReactElement | null {
 
   return (
     <div className="flex flex-row gap-1 items-center">
-      <UpgradeInfoDialog upgradeHref={buttonHref} />
+      <UpgradeInfoDialog
+        upgradeHref={buttonHref}
+        reason={
+          isAccountStatusValidResp?.reason ??
+          'this will be the reason that comes back from the API server that describes why their account is not currently in a valid state.'
+        }
+      />
       <UpgradeButton href={buttonHref} />
     </div>
   );
@@ -54,7 +60,7 @@ interface UpgradeInfoDialogProps {
 }
 
 function UpgradeInfoDialog(props: UpgradeInfoDialogProps): ReactElement {
-  const { upgradeHref } = props;
+  const { upgradeHref, reason } = props;
   return (
     <Dialog>
       <DialogTrigger asChild>
@@ -64,12 +70,15 @@ function UpgradeInfoDialog(props: UpgradeInfoDialogProps): ReactElement {
       </DialogTrigger>
       <DialogContent>
         <DialogHeader className="gap-3">
-          <DialogTitle>Upgrade to continue using Neosync</DialogTitle>
-          <DialogDescription className="tracking-tight">
+          <DialogTitle className="text-xl tracking-tight">
+            Upgrade to continue using Neosync
+          </DialogTitle>
+          <DialogDescription className="text-lg tracking-tight">
             The plan you are on has expired or has used up all of its available
             records for the current cycle.
           </DialogDescription>
         </DialogHeader>
+        {!!reason && <IncludedReason reason={reason} />}
         <DialogFooter className="md:justify-between">
           <DialogClose asChild>
             <Button type="button" variant="secondary">
@@ -80,5 +89,19 @@ function UpgradeInfoDialog(props: UpgradeInfoDialogProps): ReactElement {
         </DialogFooter>
       </DialogContent>
     </Dialog>
+  );
+}
+
+interface IncludedReasonProps {
+  reason: string;
+}
+
+function IncludedReason(props: IncludedReasonProps): ReactElement {
+  const { reason } = props;
+  return (
+    <div className="flex flex-col gap-2">
+      <span className="text-lg">Reason</span>
+      <p>{reason}</p>
+    </div>
   );
 }

--- a/frontend/apps/web/components/site-header/Upgrade.tsx
+++ b/frontend/apps/web/components/site-header/Upgrade.tsx
@@ -1,0 +1,84 @@
+'use client';
+import { useQuery } from '@connectrpc/connect-query';
+import { isAccountStatusValid } from '@neosync/sdk/connectquery';
+import { ExclamationTriangleIcon } from '@radix-ui/react-icons';
+import { ReactElement } from 'react';
+import { useAccount } from '../providers/account-provider';
+import { Button } from '../ui/button';
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+  DialogTrigger,
+} from '../ui/dialog';
+import UpgradeButton from './UpgradeButton';
+
+interface UpgradeProps {
+  buttonHref: string;
+  isNeosyncCloud: boolean;
+}
+
+export default function Upgrade(props: UpgradeProps): ReactElement | null {
+  const { buttonHref, isNeosyncCloud } = props;
+  const { account } = useAccount();
+  const accountId = account?.id;
+  const { data: isAccountStatusValidResp, isLoading } = useQuery(
+    isAccountStatusValid,
+    { accountId },
+    { enabled: !!accountId && isNeosyncCloud }
+  );
+
+  // always surface the upgrade button for non-neosynccloud users
+  if (!isNeosyncCloud) {
+    return <UpgradeButton href={buttonHref} />;
+  }
+  if (isLoading || isAccountStatusValidResp?.isValid) {
+    return null;
+  }
+
+  return (
+    <div className="flex flex-row gap-1 items-center">
+      <UpgradeInfoDialog upgradeHref={buttonHref} />
+      <UpgradeButton href={buttonHref} />
+    </div>
+  );
+}
+
+interface UpgradeInfoDialogProps {
+  upgradeHref: string;
+  reason?: string;
+}
+
+function UpgradeInfoDialog(props: UpgradeInfoDialogProps): ReactElement {
+  const { upgradeHref } = props;
+  return (
+    <Dialog>
+      <DialogTrigger asChild>
+        <Button type="button" variant="ghost">
+          <ExclamationTriangleIcon className="w-4 h-4 text-yellow-600 dark:text-yellow-400" />
+        </Button>
+      </DialogTrigger>
+      <DialogContent>
+        <DialogHeader className="gap-3">
+          <DialogTitle>Upgrade to continue using Neosync</DialogTitle>
+          <DialogDescription className="tracking-tight">
+            The plan you are on has expired or has used up all of its available
+            records for the current cycle.
+          </DialogDescription>
+        </DialogHeader>
+        <DialogFooter className="md:justify-between">
+          <DialogClose asChild>
+            <Button type="button" variant="secondary">
+              Close
+            </Button>
+          </DialogClose>
+          <UpgradeButton href={upgradeHref} />
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/frontend/apps/web/components/site-header/Upgrade.tsx
+++ b/frontend/apps/web/components/site-header/Upgrade.tsx
@@ -44,10 +44,7 @@ export default function Upgrade(props: UpgradeProps): ReactElement | null {
     <div className="flex flex-row gap-1 items-center">
       <UpgradeInfoDialog
         upgradeHref={buttonHref}
-        reason={
-          isAccountStatusValidResp?.reason ??
-          'this will be the reason that comes back from the API server that describes why their account is not currently in a valid state.'
-        }
+        reason={isAccountStatusValidResp?.reason}
       />
       <UpgradeButton href={buttonHref} />
     </div>

--- a/frontend/apps/web/components/site-header/UpgradeButton.tsx
+++ b/frontend/apps/web/components/site-header/UpgradeButton.tsx
@@ -1,0 +1,25 @@
+import { ArrowUpIcon } from '@radix-ui/react-icons';
+import Link from 'next/link';
+import { ReactElement } from 'react';
+import { Button } from '../ui/button';
+
+interface Props {
+  href: string;
+}
+
+export default function UpgradeButton(props: Props): ReactElement {
+  const { href } = props;
+
+  return (
+    <div>
+      <Button type="button" variant="outline" size="sm">
+        <div className="flex flex-row gap-2 items-center">
+          <Link href={href} target="_blank">
+            <div>Upgrade</div>
+          </Link>
+          <ArrowUpIcon />
+        </div>
+      </Button>
+    </div>
+  );
+}

--- a/frontend/apps/web/components/ui/dialog.tsx
+++ b/frontend/apps/web/components/ui/dialog.tsx
@@ -12,6 +12,8 @@ const DialogTrigger = DialogPrimitive.Trigger;
 
 const DialogPortal = DialogPrimitive.Portal;
 
+const DialogClose = DialogPrimitive.Close;
+
 const DialogOverlay = React.forwardRef<
   React.ElementRef<typeof DialogPrimitive.Overlay>,
   React.ComponentPropsWithoutRef<typeof DialogPrimitive.Overlay>
@@ -19,7 +21,7 @@ const DialogOverlay = React.forwardRef<
   <DialogPrimitive.Overlay
     ref={ref}
     className={cn(
-      'fixed inset-0 z-50 bg-background/80 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
+      'fixed inset-0 z-50 bg-background/80 dark:bg-black/40 backdrop-blur-sm data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0',
       className
     )}
     {...props}
@@ -36,7 +38,7 @@ const DialogContent = React.forwardRef<
     <DialogPrimitive.Content
       ref={ref}
       className={cn(
-        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg md:w-full',
+        'fixed left-[50%] top-[50%] z-50 grid w-full max-w-lg translate-x-[-50%] translate-y-[-50%] gap-4 border bg-background p-6 shadow-lg duration-200 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0 data-[state=closed]:zoom-out-95 data-[state=open]:zoom-in-95 data-[state=closed]:slide-out-to-left-1/2 data-[state=closed]:slide-out-to-top-[48%] data-[state=open]:slide-in-from-left-1/2 data-[state=open]:slide-in-from-top-[48%] sm:rounded-lg',
         className
       )}
       {...props}
@@ -108,6 +110,7 @@ DialogDescription.displayName = DialogPrimitive.Description.displayName;
 
 export {
   Dialog,
+  DialogClose,
   DialogContent,
   DialogDescription,
   DialogFooter,


### PR DESCRIPTION
* Updated billing page to be more responsive
* Updated billing header to use page sub header to render more like other pages
* Updates upgrade button in site header to include a new account status dialog
* Text could probably use some word smithing

Demo: https://www.loom.com/share/d81586a5a2fb4bf19aa0b4dee70837bb