### PR TITLE
feat(api-chart): allow setting extraEnvVars from values in initContainer

### DIFF
--- a/backend/charts/api/templates/deployment.yaml
+++ b/backend/charts/api/templates/deployment.yaml
@@ -83,6 +83,33 @@ spec:
             - migrate
             - up
 
+          env:
+
+            {{- with .Values.extraEnvVars }}
+            {{- range .}}
+            - name: {{ .name }}
+              {{- if .value }}
+              value: {{ .value | quote }}
+              {{- else if .valueFrom }}
+              valueFrom:
+                {{- if .valueFrom.secretKeyRef }}
+                secretKeyRef:
+                  name: {{ .valueFrom.secretKeyRef.name }}
+                  key: {{ .valueFrom.secretKeyRef.key }}
+                {{- end }}
+                {{- if .valueFrom.configMapKeyRef }}
+                configMapKeyRef:
+                  name: {{ .valueFrom.configMapKeyRef.name }}
+                  key: {{ .valueFrom.configMapKeyRef.key }}
+                {{- end }}
+                {{- if .valueFrom.fieldRef }}
+                fieldRef:
+                  fieldPath: {{ .valueFrom.fieldRef.fieldPath }}
+                {{- end }}
+              {{- end }}
+            {{- end }}
+            {{- end }}
+
           envFrom:
             - secretRef:
                 name: {{ template "neosync-api.fullname" . }}-migration-evs


### PR DESCRIPTION
In my use case I wished to set sensitive values like DB_PASS as environment variables loaded from secrets.

The user-container of the api makes this posible by using the values the user has defined in .Values.extraEnvVars but the same does not exist for the init-container that still needs similar sensitive value to perform the migration tasks.

This pull request is a suggestion that would fix this problem and allow setting environment variables in this way to override the ones loaded in `db-migrations-env-vars.yaml` that rely on values directly set in clear.

```
extraEnvVars:
  - name: DB_PASS
    valueFrom:
      secretKeyRef:
        name: neosync-secret
        key: DB_PASS
```