### PR TITLE
Adds extraEnvVars to api deployment init container for db migrations

### DIFF
--- a/backend/charts/api/README.md
+++ b/backend/charts/api/README.md
@@ -36,7 +36,7 @@ A Helm chart for the Neosync Backend API
 | db.port | int | `5432` | The database port |
 | db.username | string | `nil` | The username that will be used for authentication |
 | deploymentAnnotations | object | `{}` | Provide a map of deployment annotations that will be attached to the deployment's annotations |
-| extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the deployment. |
+| extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the deployment's user-container. |
 | fullnameOverride | string | `nil` | Fully overrides the chart name |
 | host | string | `"0.0.0.0"` | Sets the host that the backend will listen on. 0.0.0.0 is common for Kubernetes workloads. |
 | image.pullPolicy | string | `nil` | Overrides the default K8s pull policy |
@@ -58,7 +58,7 @@ A Helm chart for the Neosync Backend API
 | migrations.db.port | int | `5432` | The database port |
 | migrations.db.schemaDir | string | `"/migrations"` | The directory where the migrations are located. |
 | migrations.db.username | string | `nil` | The username that will be used for authentication |
-| migrations.extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the deployment. |
+| migrations.extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the migration init container. |
 | nameOverride | string | `nil` | Override the name specified on the Chart, which defaults to .Chart.Name |
 | neosyncCloud.enabled | bool | `false` | Whether or not this is NeosyncCloud |
 | neosyncCloud.workerApiKeys | list | `[]` | Worker API keys that have been allowlisted to for use |

--- a/backend/charts/api/README.md
+++ b/backend/charts/api/README.md
@@ -58,6 +58,7 @@ A Helm chart for the Neosync Backend API
 | migrations.db.port | int | `5432` | The database port |
 | migrations.db.schemaDir | string | `"/migrations"` | The directory where the migrations are located. |
 | migrations.db.username | string | `nil` | The username that will be used for authentication |
+| migrations.extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the deployment. |
 | nameOverride | string | `nil` | Override the name specified on the Chart, which defaults to .Chart.Name |
 | neosyncCloud.enabled | bool | `false` | Whether or not this is NeosyncCloud |
 | neosyncCloud.workerApiKeys | list | `[]` | Worker API keys that have been allowlisted to for use |

--- a/backend/charts/api/templates/deployment.yaml
+++ b/backend/charts/api/templates/deployment.yaml
@@ -80,7 +80,7 @@ spec:
             - migrate
             - up
 
-          {{- with .Values.extraEnvVars }}
+          {{- with .Values.migrations.extraEnvVars }}
           {{- range .}}
           - name: {{ .name }}
             {{- if .value }}

--- a/backend/charts/api/templates/deployment.yaml
+++ b/backend/charts/api/templates/deployment.yaml
@@ -80,6 +80,31 @@ spec:
             - migrate
             - up
 
+          {{- with .Values.extraEnvVars }}
+          {{- range .}}
+          - name: {{ .name }}
+            {{- if .value }}
+            value: {{ .value | quote }}
+            {{- else if .valueFrom }}
+            valueFrom:
+              {{- if .valueFrom.secretKeyRef }}
+              secretKeyRef:
+                name: {{ .valueFrom.secretKeyRef.name }}
+                key: {{ .valueFrom.secretKeyRef.key }}
+              {{- end }}
+              {{- if .valueFrom.configMapKeyRef }}
+              configMapKeyRef:
+                name: {{ .valueFrom.configMapKeyRef.name }}
+                key: {{ .valueFrom.configMapKeyRef.key }}
+              {{- end }}
+              {{- if .valueFrom.fieldRef }}
+              fieldRef:
+                fieldPath: {{ .valueFrom.fieldRef.fieldPath }}
+              {{- end }}
+            {{- end }}
+          {{- end }}
+          {{- end }}
+
           envFrom:
             - secretRef:
                 name: {{ template "neosync-api.fullname" . }}-migration-evs

--- a/backend/charts/api/templates/deployment.yaml
+++ b/backend/charts/api/templates/deployment.yaml
@@ -80,35 +80,30 @@ spec:
             - migrate
             - up
           env:
-            - name: HOST_IP
+            {{- with .Values.migrations.extraEnvVars }}
+            {{- range .}}
+            - name: {{ .name }}
+              {{- if .value }}
+              value: {{ .value | quote }}
+              {{- else if .valueFrom }}
               valueFrom:
+                {{- if .valueFrom.secretKeyRef }}
+                secretKeyRef:
+                  name: {{ .valueFrom.secretKeyRef.name }}
+                  key: {{ .valueFrom.secretKeyRef.key }}
+                {{- end }}
+                {{- if .valueFrom.configMapKeyRef }}
+                configMapKeyRef:
+                  name: {{ .valueFrom.configMapKeyRef.name }}
+                  key: {{ .valueFrom.configMapKeyRef.key }}
+                {{- end }}
+                {{- if .valueFrom.fieldRef }}
                 fieldRef:
-                  fieldPath: status.hostIP
-
-          {{- with .Values.migrations.extraEnvVars }}
-          {{- range .}}
-          - name: {{ .name }}
-            {{- if .value }}
-            value: {{ .value | quote }}
-            {{- else if .valueFrom }}
-            valueFrom:
-              {{- if .valueFrom.secretKeyRef }}
-              secretKeyRef:
-                name: {{ .valueFrom.secretKeyRef.name }}
-                key: {{ .valueFrom.secretKeyRef.key }}
-              {{- end }}
-              {{- if .valueFrom.configMapKeyRef }}
-              configMapKeyRef:
-                name: {{ .valueFrom.configMapKeyRef.name }}
-                key: {{ .valueFrom.configMapKeyRef.key }}
-              {{- end }}
-              {{- if .valueFrom.fieldRef }}
-              fieldRef:
-                fieldPath: {{ .valueFrom.fieldRef.fieldPath }}
+                  fieldPath: {{ .valueFrom.fieldRef.fieldPath }}
+                {{- end }}
               {{- end }}
             {{- end }}
-          {{- end }}
-          {{- end }}
+            {{- end }}
 
           envFrom:
             - secretRef:

--- a/backend/charts/api/templates/deployment.yaml
+++ b/backend/charts/api/templates/deployment.yaml
@@ -79,6 +79,11 @@ spec:
           args:
             - migrate
             - up
+          env:
+            - name: HOST_IP
+              valueFrom:
+                fieldRef:
+                  fieldPath: status.hostIP
 
           {{- with .Values.migrations.extraEnvVars }}
           {{- range .}}

--- a/backend/charts/api/values.yaml
+++ b/backend/charts/api/values.yaml
@@ -81,7 +81,7 @@ migrations:
     migrationsTableQuoted: false
     # -- Extra database options that will be appended to the query string
     options:
-  # -- Provide extra environment variables that will be applied to the deployment.
+  # -- Provide extra environment variables that will be applied to the migration init container.
   extraEnvVars: []
 
 # Set requests and limits on the backend to change its performance
@@ -239,7 +239,7 @@ protometrics:
 # -- The strategy to use when rolling out new replicas
 updateStrategy:
 
-# -- Provide extra environment variables that will be applied to the deployment.
+# -- Provide extra environment variables that will be applied to the deployment's user-container.
 extraEnvVars: []
 
 # -- Provide sidecars that will be appended directly to the deployment next to the user-container

--- a/backend/charts/api/values.yaml
+++ b/backend/charts/api/values.yaml
@@ -81,6 +81,8 @@ migrations:
     migrationsTableQuoted: false
     # -- Extra database options that will be appended to the query string
     options:
+  # -- Provide extra environment variables that will be applied to the deployment.
+  extraEnvVars: []
 
 # Set requests and limits on the backend to change its performance
 resources:

--- a/backend/dev/helm/api/values.yaml
+++ b/backend/dev/helm/api/values.yaml
@@ -21,9 +21,6 @@ migrations:
     password: foofar
     disableSsl: true
     schemaDir: /app/migrations
-  extraEnvVars:
-    - name: foo
-      value: bar
 
 terminationGracePeriodSeconds: 300
 shutdownTimeoutSeconds: 5

--- a/backend/dev/helm/api/values.yaml
+++ b/backend/dev/helm/api/values.yaml
@@ -21,6 +21,9 @@ migrations:
     password: foofar
     disableSsl: true
     schemaDir: /app/migrations
+  extraEnvVars:
+    - name: foo
+      value: bar
 
 terminationGracePeriodSeconds: 300
 shutdownTimeoutSeconds: 5

--- a/charts/neosync/README.md
+++ b/charts/neosync/README.md
@@ -66,6 +66,7 @@ A Helm chart for Neosync that contains the api, app, and worker
 | api.migrations.db.port | int | `5432` | The database port |
 | api.migrations.db.schemaDir | string | `"/migrations"` | The directory where the migrations are located. |
 | api.migrations.db.username | string | `nil` | The username that will be used for authentication |
+| api.migrations.extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the deployment. |
 | api.nameOverride | string | `nil` | Override the name specified on the Chart, which defaults to .Chart.Name |
 | api.neosyncCloud.enabled | bool | `false` | Whether or not this is NeosyncCloud |
 | api.neosyncCloud.workerApiKeys | list | `[]` | Worker API keys that have been allowlisted to for use |

--- a/charts/neosync/README.md
+++ b/charts/neosync/README.md
@@ -44,7 +44,7 @@ A Helm chart for Neosync that contains the api, app, and worker
 | api.db.port | int | `5432` | The database port |
 | api.db.username | string | `nil` | The username that will be used for authentication |
 | api.deploymentAnnotations | object | `{}` | Provide a map of deployment annotations that will be attached to the deployment's annotations |
-| api.extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the deployment. |
+| api.extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the deployment's user-container. |
 | api.fullnameOverride | string | `nil` | Fully overrides the chart name |
 | api.host | string | `"0.0.0.0"` | Sets the host that the backend will listen on. 0.0.0.0 is common for Kubernetes workloads. |
 | api.image.pullPolicy | string | `nil` | Overrides the default K8s pull policy |
@@ -66,7 +66,7 @@ A Helm chart for Neosync that contains the api, app, and worker
 | api.migrations.db.port | int | `5432` | The database port |
 | api.migrations.db.schemaDir | string | `"/migrations"` | The directory where the migrations are located. |
 | api.migrations.db.username | string | `nil` | The username that will be used for authentication |
-| api.migrations.extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the deployment. |
+| api.migrations.extraEnvVars | list | `[]` | Provide extra environment variables that will be applied to the migration init container. |
 | api.nameOverride | string | `nil` | Override the name specified on the Chart, which defaults to .Chart.Name |
 | api.neosyncCloud.enabled | bool | `false` | Whether or not this is NeosyncCloud |
 | api.neosyncCloud.workerApiKeys | list | `[]` | Worker API keys that have been allowlisted to for use |


### PR DESCRIPTION
Took https://github.com/nucleuscloud/neosync/pull/2602 over the line to get the feature in.

Should also help out https://github.com/nucleuscloud/neosync/pull/2714