### PR TITLE
feat(charts): make nucleusEnv an optional label for all charts

### DIFF
--- a/backend/charts/api/templates/deployment.yaml
+++ b/backend/charts/api/templates/deployment.yaml
@@ -6,7 +6,9 @@ metadata:
   labels:
     {{- include "neosync-api.labels" . | nindent 4 }}
     {{- if eq .Values.datadog.enabled true }}
+    {{- if .Values.nucleusEnv }}
     tags.datadoghq.com/env: {{ .Values.nucleusEnv }}
+    {{- end }}
     tags.datadoghq.com/service: {{ template "neosync-api.fullname" . }}
     tags.datadoghq.com/version: {{ .Values.image.tag | default .Chart.AppVersion  }}
     {{- end }}
@@ -44,11 +46,15 @@ spec:
         {{- end }}
         {{- if eq .Values.datadog.enabled true }}
         admission.datadoghq.com/enabled: "true"
+        {{- if .Values.nucleusEnv }}
         tags.datadoghq.com/env: {{ .Values.nucleusEnv }}
+        {{- end }}
         tags.datadoghq.com/service: {{ template "neosync-api.fullname" . }}
         tags.datadoghq.com/version: {{ .Values.image.tag | default .Chart.AppVersion  }}
         {{- end }}
+        {{- if .Values.nucleusEnv }}
         tags.neosync.dev/env: {{ .Values.nucleusEnv }}
+        {{- end }}
         tags.neosync.dev/service: {{ template "neosync-api.fullname" . }}
         tags.neosync.dev/version: {{ .Values.image.tag | default .Chart.AppVersion  }}
     spec:

--- a/frontend/apps/web/charts/app/templates/deployment.yaml
+++ b/frontend/apps/web/charts/app/templates/deployment.yaml
@@ -5,7 +5,9 @@ metadata:
   namespace: {{ .Release.Namespace }}
   labels:
     {{- if eq .Values.datadog.enabled true }}
+    {{- if .Values.nucleusEnv }}
     tags.datadoghq.com/env: {{ .Values.nucleusEnv }}
+    {{- end }}
     tags.datadoghq.com/service: {{ template "neosync-app.fullname" . }}
     tags.datadoghq.com/version: {{ .Values.image.tag | default .Chart.AppVersion  }}
     {{- end }}
@@ -43,7 +45,9 @@ spec:
         {{- end }}
         {{- if eq .Values.datadog.enabled true }}
         admission.datadoghq.com/enabled: "true"
+        {{- if .Values.nucleusEnv }}
         tags.datadoghq.com/env: {{ .Values.nucleusEnv }}
+        {{- end }}
         tags.datadoghq.com/service: {{ template "neosync-app.fullname" . }}
         tags.datadoghq.com/version: {{ .Values.image.tag | default .Chart.AppVersion  }}
         {{- end }}


### PR DESCRIPTION
Related to https://github.com/nucleuscloud/neosync/pull/2715

I had only done one third of the task yesterday.