### PR TITLE
NEOS-1433 Updates javascript transformer to use patch function

### DIFF
--- a/worker/pkg/benthos/javascript/functions.go
+++ b/worker/pkg/benthos/javascript/functions.go
@@ -327,3 +327,51 @@ var _ = registerVMRunnerFunction("v0_msg_set_meta", `Set a metadata key on the p
 			return nil, nil
 		}
 	})
+
+var _ = registerVMRunnerFunction("patchMessage", `Update multiple fields in the structured data of the processed message.`).
+	Namespace(neosyncFnCtxName).
+	Param("updates", "object", "A map of field names to their new values.").
+	Example(`benthos.v0_msg_update_fields({"user_id": 12345, "timestamp": "2024-09-23T12:34:56Z"});`).
+	FnCtor(func(r *vmRunner) jsFunction {
+		return func(call goja.FunctionCall, rt *goja.Runtime, l *service.Logger) (any, error) {
+			var updates map[string]any
+			if err := parseArgs(call, &updates); err != nil {
+				return nil, err
+			}
+
+			// original structured data
+			originalData, err := r.targetMessage.AsStructuredMut()
+			if err != nil {
+				return nil, fmt.Errorf("failed to get structured data: %w", err)
+			}
+
+			originalMap, ok := originalData.(map[string]any)
+			if !ok {
+				return nil, fmt.Errorf("structured data is not a map")
+			}
+
+			for key, value := range updates {
+				setNestedProperty(originalMap, key, value)
+			}
+
+			r.targetMessage.SetStructured(originalMap)
+
+			return nil, nil
+		}
+	})
+
+func setNestedProperty(obj map[string]any, path string, value any) {
+	parts := strings.Split(path, ".")
+	current := obj
+
+	for i, part := range parts {
+		if i == len(parts)-1 {
+			current[part] = value
+		} else {
+			if _, ok := current[part]; !ok {
+				current[part] = make(map[string]any)
+			}
+			current = current[part].(map[string]any)
+		}
+	}
+}

--- a/worker/pkg/benthos/javascript/functions.go
+++ b/worker/pkg/benthos/javascript/functions.go
@@ -331,7 +331,7 @@ var _ = registerVMRunnerFunction("v0_msg_set_meta", `Set a metadata key on the p
 var _ = registerVMRunnerFunction("patchMessage", `Update multiple fields in the structured data of the processed message.`).
 	Namespace(neosyncFnCtxName).
 	Param("updates", "object", "A map of field names to their new values.").
-	Example(`benthos.v0_msg_update_fields({"user_id": 12345, "timestamp": "2024-09-23T12:34:56Z"});`).
+	Example(`neosync.patchMessage({"user_id": 12345, "timestamp": "2024-09-23T12:34:56Z"});`).
 	FnCtor(func(r *vmRunner) jsFunction {
 		return func(call goja.FunctionCall, rt *goja.Runtime, l *service.Logger) (any, error) {
 			var updates map[string]any

--- a/worker/pkg/benthos/javascript/functions.go
+++ b/worker/pkg/benthos/javascript/functions.go
@@ -328,10 +328,10 @@ var _ = registerVMRunnerFunction("v0_msg_set_meta", `Set a metadata key on the p
 		}
 	})
 
-var _ = registerVMRunnerFunction("patchMessage", `Update multiple fields in the structured data of the processed message.`).
+var _ = registerVMRunnerFunction("patchStructuredMessage", `Update multiple fields in the structured data of the processed message.`).
 	Namespace(neosyncFnCtxName).
 	Param("updates", "object", "A map of field names to their new values.").
-	Example(`neosync.patchMessage({"user_id": 12345, "timestamp": "2024-09-23T12:34:56Z"});`).
+	Example(`neosync.patchStructuredMessage({"user_id": 12345, "timestamp": "2024-09-23T12:34:56Z"});`).
 	FnCtor(func(r *vmRunner) jsFunction {
 		return func(call goja.FunctionCall, rt *goja.Runtime, l *service.Logger) (any, error) {
 			var updates map[string]any

--- a/worker/pkg/benthos/javascript/functions_test.go
+++ b/worker/pkg/benthos/javascript/functions_test.go
@@ -1,0 +1,39 @@
+package javascript
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/require"
+)
+
+func Test_setNestedProperty(t *testing.T) {
+	t.Run("Set simple property", func(t *testing.T) {
+		obj := make(map[string]any)
+		setNestedProperty(obj, "name", "John")
+		require.Equal(t, "John", obj["name"])
+	})
+
+	t.Run("Set nested property", func(t *testing.T) {
+		obj := make(map[string]any)
+		setNestedProperty(obj, "user.name", "Alice")
+		require.Equal(t, "Alice", obj["user"].(map[string]any)["name"])
+	})
+
+	t.Run("Set deeply nested property", func(t *testing.T) {
+		obj := make(map[string]any)
+		setNestedProperty(obj, "user.profile.age", 30)
+		require.Equal(t, 30, obj["user"].(map[string]any)["profile"].(map[string]any)["age"])
+	})
+
+	t.Run("Override existing property", func(t *testing.T) {
+		obj := map[string]any{"user": map[string]any{"name": "Bob"}}
+		setNestedProperty(obj, "user.name", "Charlie")
+		require.Equal(t, "Charlie", obj["user"].(map[string]any)["name"])
+	})
+
+	t.Run("Set property in existing nested structure", func(t *testing.T) {
+		obj := map[string]any{"user": map[string]any{"profile": map[string]any{}}}
+		setNestedProperty(obj, "user.profile.email", "test@example.com")
+		require.Equal(t, "test@example.com", obj["user"].(map[string]any)["profile"].(map[string]any)["email"])
+	})
+}

--- a/worker/pkg/benthos/javascript/functions_test.go
+++ b/worker/pkg/benthos/javascript/functions_test.go
@@ -36,4 +36,10 @@ func Test_setNestedProperty(t *testing.T) {
 		setNestedProperty(obj, "user.profile.email", "test@example.com")
 		require.Equal(t, "test@example.com", obj["user"].(map[string]any)["profile"].(map[string]any)["email"])
 	})
+
+	t.Run("Set nestnd property in empty structure", func(t *testing.T) {
+		obj := map[string]any{}
+		setNestedProperty(obj, "user.profile.email", "test@example.com")
+		require.Equal(t, "test@example.com", obj["user"].(map[string]any)["profile"].(map[string]any)["email"])
+	})
 }

--- a/worker/pkg/workflows/datasync/activities/gen-benthos-configs/processors.go
+++ b/worker/pkg/workflows/datasync/activities/gen-benthos-configs/processors.go
@@ -368,10 +368,9 @@ func constructBenthosJsProcessor(jsFunctions, benthosOutputs []string) string {
 (() => {
 %s
 const input = benthos.v0_msg_as_structured();
-const output = { ...input };
 const updatedValues = {}
 %s
-neosync.patchMessage(updatedValues)
+neosync.patchStructuredMessage(updatedValues)
 })();`, jsFunctionStrings, benthosOutputString)
 	return jsCode
 }

--- a/worker/pkg/workflows/datasync/activities/gen-benthos-configs/processors_test.go
+++ b/worker/pkg/workflows/datasync/activities/gen-benthos-configs/processors_test.go
@@ -83,7 +83,7 @@ const benthos = {
   v0_msg_as_structured: () => ({address: "world"}),
 };
 const neosync = {
-  patchMessage: (val) => {
+  patchStructuredMessage: (val) => {
     programOutput = val;
   }
 };
@@ -143,7 +143,7 @@ const benthos = {
   v0_msg_as_structured: () => ({}),
 };
 const neosync = {
-  patchMessage: (val) => {
+  patchStructuredMessage: (val) => {
     programOutput = val;
   }
 };
@@ -213,7 +213,7 @@ const benthos = {
   v0_msg_as_structured: () => ({"name": "world", "age": 2}),
 };
 const neosync = {
-  patchMessage: (val) => {
+  patchStructuredMessage: (val) => {
     programOutput = val;
   }
 };
@@ -284,7 +284,7 @@ const benthos = {
   v0_msg_as_structured: () => ({"name": "world"}),
 };
 const neosync = {
-  patchMessage: (val) => {
+  patchStructuredMessage: (val) => {
     programOutput = val;
   }
 };
@@ -345,7 +345,7 @@ const benthos = {
   v0_msg_as_structured: () => ({foo: {bar: {baz: "world"}}}),
 };
 const neosync = {
-  patchMessage: (val) => {
+  patchStructuredMessage: (val) => {
     programOutput = val;
   }
 };


### PR DESCRIPTION
This makes sure that only columns that have JS transformers set are updated. Prevents unnecessary conversion of all column values from Javascript back to golang