### PR TITLE
OpenTelemetry Updates for Worker, Stripe, Backend

### DIFF
--- a/backend/internal/cmds/mgmt/serve/connect/cmd.go
+++ b/backend/internal/cmds/mgmt/serve/connect/cmd.go
@@ -169,6 +169,8 @@ func serve(ctx context.Context) error {
 	if otelconfig.IsEnabled {
 		slogger.Debug("otel is enabled")
 		otelconnopts := []otelconnect.Option{otelconnect.WithoutServerPeerAttributes()}
+		traceProviders := []neosyncotel.TracerProvider{}
+		meterProviders := []neosyncotel.MeterProvider{}
 
 		meterprovider, err := neosyncotel.NewMeterProvider(ctx, &neosyncotel.MeterProviderConfig{
 			Exporter:   otelconfig.MeterExporter,
@@ -184,6 +186,7 @@ func serve(ctx context.Context) error {
 		if meterprovider != nil {
 			slogger.Debug("otel metering has been configured")
 			otelconnopts = append(otelconnopts, otelconnect.WithMeterProvider(meterprovider))
+			meterProviders = append(meterProviders, meterprovider)
 		} else {
 			otelconnopts = append(otelconnopts, otelconnect.WithoutMetrics())
 		}
@@ -201,6 +204,7 @@ func serve(ctx context.Context) error {
 		if traceprovider != nil {
 			slogger.Debug("otel tracing has been configured")
 			otelconnopts = append(otelconnopts, otelconnect.WithTracerProvider(traceprovider))
+			traceProviders = append(traceProviders, traceprovider)
 		} else {
 			otelconnopts = append(otelconnopts, otelconnect.WithoutTracing(), otelconnect.WithoutTraceEvents())
 		}
@@ -212,8 +216,8 @@ func serve(ctx context.Context) error {
 		stdInterceptors = append(stdInterceptors, otelInterceptor)
 
 		otelshutdown := neosyncotel.SetupOtelSdk(&neosyncotel.SetupConfig{
-			TraceProviders: []neosyncotel.TracerProvider{traceprovider},
-			MeterProviders: []neosyncotel.MeterProvider{meterprovider},
+			TraceProviders: traceProviders,
+			MeterProviders: meterProviders,
 			Logger:         logr.FromSlogHandler(slogger.Handler()),
 		})
 		defer func() {

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -39,15 +39,18 @@ type MeterProvider interface {
 }
 
 type SetupConfig struct {
-	TraceProviders []TracerProvider
-	MeterProviders []MeterProvider
-	Logger         logr.Logger
+	TraceProviders    []TracerProvider
+	MeterProviders    []MeterProvider
+	TextMapPropagator propagation.TextMapPropagator
+	Logger            logr.Logger
 }
 
 func SetupOtelSdk(config *SetupConfig) func(context.Context) error {
 	otel.SetLogger(config.Logger)
 	// todo: Should probably move this out of here as it registers this globally
-	otel.SetTextMapPropagator(newPropagator())
+	if config.TextMapPropagator != nil {
+		otel.SetTextMapPropagator(NewDefaultPropagator())
+	}
 
 	var shutdownFuncs []func(context.Context) error
 
@@ -77,7 +80,7 @@ func SetupOtelSdk(config *SetupConfig) func(context.Context) error {
 	return shutdown
 }
 
-func newPropagator() propagation.TextMapPropagator {
+func NewDefaultPropagator() propagation.TextMapPropagator {
 	return propagation.NewCompositeTextMapPropagator(
 		propagation.TraceContext{},
 		propagation.Baggage{},

--- a/internal/otel/otel.go
+++ b/internal/otel/otel.go
@@ -39,17 +39,19 @@ type MeterProvider interface {
 }
 
 type SetupConfig struct {
-	TraceProviders    []TracerProvider
-	MeterProviders    []MeterProvider
+	TraceProviders []TracerProvider
+	MeterProviders []MeterProvider
+	// If provided, configures the global text map propagator
 	TextMapPropagator propagation.TextMapPropagator
-	Logger            logr.Logger
+	// Configures the global otel logger
+	Logger logr.Logger
 }
 
 func SetupOtelSdk(config *SetupConfig) func(context.Context) error {
 	otel.SetLogger(config.Logger)
-	// todo: Should probably move this out of here as it registers this globally
+
 	if config.TextMapPropagator != nil {
-		otel.SetTextMapPropagator(NewDefaultPropagator())
+		otel.SetTextMapPropagator(config.TextMapPropagator)
 	}
 
 	var shutdownFuncs []func(context.Context) error

--- a/worker/internal/cmds/worker/serve/serve.go
+++ b/worker/internal/cmds/worker/serve/serve.go
@@ -87,7 +87,7 @@ func serve(ctx context.Context) error {
 			Exporter:   otelconfig.MeterExporter,
 			AppVersion: otelconfig.ServiceVersion,
 			Opts: neosyncotel.MeterExporterOpts{
-				Otlp:    []otlpmetricgrpc.Option{neosyncotel.WithDefaultDeltaTemporalitySelector()},
+				Otlp:    []otlpmetricgrpc.Option{neosyncotel.GetBenthosMetricTemporalityOption()},
 				Console: []stdoutmetric.Option{stdoutmetric.WithPrettyPrint()},
 			},
 		})

--- a/worker/internal/cmds/worker/serve/serve.go
+++ b/worker/internal/cmds/worker/serve/serve.go
@@ -73,6 +73,7 @@ func serve(ctx context.Context) error {
 	if otelconfig.IsEnabled {
 		logger.Debug("otel is enabled")
 		meterProviders := []neosyncotel.MeterProvider{}
+		traceProviders := []neosyncotel.TracerProvider{}
 		// Meter Provider that uses delta temporality for use with Benthos metrics
 		// This meter provider is setup expire metrics after a specified time period for easy computation
 		benthosMeterProvider, err := neosyncotel.NewMeterProvider(ctx, &neosyncotel.MeterProviderConfig{
@@ -133,10 +134,11 @@ func serve(ctx context.Context) error {
 				return err
 			}
 			temporalClientInterceptors = append(temporalClientInterceptors, traceInterceptor)
+			traceProviders = append(traceProviders, traceprovider)
 		}
 
 		otelshutdown := neosyncotel.SetupOtelSdk(&neosyncotel.SetupConfig{
-			TraceProviders: []neosyncotel.TracerProvider{traceprovider},
+			TraceProviders: traceProviders,
 			MeterProviders: meterProviders,
 			Logger:         logr.FromSlogHandler(logger.Handler()),
 		})


### PR DESCRIPTION
- Fixes issue where tracer is disabled but still gets added to the shutdowns array. This was causing a nil pointer error on process shutdown
- Enables Connect Client tracing and metering for worker when it communicates to the API for better traces and more metrics
- Inverts configuration for text map propagator
- Adds new env var to allow switching temporality for benthos metrics