### PR TITLE
fix(mysql): correct default value handling for VARCHAR columns in Ini…

### DIFF
--- a/backend/pkg/sqlmanager/shared/types.go
+++ b/backend/pkg/sqlmanager/shared/types.go
@@ -14,6 +14,7 @@ type DatabaseSchemaRow struct {
 	ColumnName             string
 	DataType               string
 	ColumnDefault          string
+	ColumnDefaultType      *string
 	IsNullable             string
 	CharacterMaximumLength int
 	NumericPrecision       int


### PR DESCRIPTION
Hello,
When using the "Init Table Schema" option in Neosync to synchronize two MySQL 8.0.33 databases, a table creation error occurs if a VARCHAR column has a default value containing slashes (e.g., '/ranking/').
![Error](https://github.com/user-attachments/assets/c906669b-0b73-436a-a192-e0634c4a61ed)

In this example, the dir_path_dist column has a default value of '/ranking/'. When attempting to create the table using Neosync, an SQL error occurs. This error is caused by the default value being surrounded by parentheses, which is not allowed by MySQL for a VARCHAR default value.

**Source of the problem**
The issue lies in the file neosync/backend/pkg/sqlmanager/mysql/mysql-manager.go at line 356:
`if record.ColumnDefault != "" {
    pieces = append(pieces, fmt.Sprintf("DEFAULT (%s)", record.ColumnDefault));
}
`
This line wraps the default value in parentheses, which leads to an SQL syntax error when MySQL tries to create the table.

**Proposed Solution**
Replace the problematic line with the correct syntax that removes the parentheses and wraps the default value in single quotes:
`if record.ColumnDefault != "" {
    pieces = append(pieces, fmt.Sprintf("DEFAULT '%s'", record.ColumnDefault));
}
`
This change prevents the SQL syntax error when creating tables with default values.

After applying the modification, the table creation worked correctly without errors.
