### PR TITLE
NEOS-1516: updates to not show any connect errors for unsupported connections

### DIFF
--- a/backend/services/mgmt/v1alpha1/connection-service/connection.go
+++ b/backend/services/mgmt/v1alpha1/connection-service/connection.go
@@ -159,7 +159,7 @@ func (s *Service) CheckConnectionConfig(
 			Privileges:      privs,
 		}), nil
 	default:
-		return nil, fmt.Errorf("this method does not support this connection type %T: %w", req.Msg.GetConnectionConfig().GetConfig(), errors.ErrUnsupported)
+		return nil, nucleuserrors.NewBadRequest(fmt.Errorf("this method does not support this connection type %T: %w", req.Msg.GetConnectionConfig().GetConfig(), errors.ErrUnsupported).Error())
 	}
 }
 

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/connect/page.tsx
@@ -28,6 +28,8 @@ import { useMutation, useQuery } from '@connectrpc/connect-query';
 import { yupResolver } from '@hookform/resolvers/yup';
 import {
   CheckConnectionConfigResponse,
+  Code,
+  ConnectError,
   Connection,
   ConnectionConfig,
 } from '@neosync/sdk';
@@ -223,15 +225,23 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                                 });
                                 setSourceValidationResponse(res);
                               } catch (err) {
-                                setSourceValidationResponse(
-                                  new CheckConnectionConfigResponse({
-                                    isConnected: false,
-                                    connectionError:
-                                      err instanceof Error
-                                        ? err.message
-                                        : 'unknown error',
-                                  })
-                                );
+                                if (
+                                  err instanceof ConnectError &&
+                                  err.code === Code.InvalidArgument &&
+                                  err.message.includes('unsupported operation')
+                                ) {
+                                  setSourceValidationResponse(undefined);
+                                } else {
+                                  setSourceValidationResponse(
+                                    new CheckConnectionConfigResponse({
+                                      isConnected: false,
+                                      connectionError:
+                                        err instanceof Error
+                                          ? err.message
+                                          : 'unknown error',
+                                    })
+                                  );
+                                }
                               } finally {
                                 setIsSourceValidating(false);
                               }
@@ -344,7 +354,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                       {form.getValues('sourceId') && !isSourceValidating && (
                         <TestConnectionBadge
                           validationResponse={sourceValidationResponse}
-                          id={form.getValues('sourceId')}
+                          connectionId={form.getValues('sourceId')}
                           accountName={account?.name ?? ''}
                         />
                       )}
@@ -476,24 +486,42 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                                             })
                                           );
                                         } catch (err) {
-                                          setDestinationValidation(
-                                            (prevState) => ({
-                                              ...prevState,
-                                              [value]: {
-                                                isValidating: false,
-                                                response:
-                                                  new CheckConnectionConfigResponse(
-                                                    {
-                                                      isConnected: false,
-                                                      connectionError:
-                                                        err instanceof Error
-                                                          ? err.message
-                                                          : 'unknown error',
-                                                    }
-                                                  ),
-                                              },
-                                            })
-                                          );
+                                          if (
+                                            err instanceof ConnectError &&
+                                            err.code === Code.InvalidArgument &&
+                                            err.message.includes(
+                                              'unsupported operation'
+                                            )
+                                          ) {
+                                            setDestinationValidation(
+                                              (prevState) => ({
+                                                ...prevState,
+                                                [value]: {
+                                                  isValidating: false,
+                                                  response: undefined,
+                                                },
+                                              })
+                                            );
+                                          } else {
+                                            setDestinationValidation(
+                                              (prevState) => ({
+                                                ...prevState,
+                                                [value]: {
+                                                  isValidating: false,
+                                                  response:
+                                                    new CheckConnectionConfigResponse(
+                                                      {
+                                                        isConnected: false,
+                                                        connectionError:
+                                                          err instanceof Error
+                                                            ? err.message
+                                                            : 'unknown error',
+                                                      }
+                                                    ),
+                                                },
+                                              })
+                                            );
+                                          }
                                         } finally {
                                           setIsSourceValidating(false);
                                         }
@@ -625,7 +653,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                                       )
                                     ]?.response
                                   }
-                                  id={form.getValues(
+                                  connectionId={form.getValues(
                                     `destinations.${index}.connectionId`
                                   )}
                                   accountName={account?.name ?? ''}

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/connect/page.tsx
@@ -28,7 +28,12 @@ import { Skeleton } from '@/components/ui/skeleton';
 import { getSingleOrUndefined, splitConnections } from '@/libs/utils';
 import { useMutation, useQuery } from '@connectrpc/connect-query';
 import { yupResolver } from '@hookform/resolvers/yup';
-import { CheckConnectionConfigResponse, ConnectionConfig } from '@neosync/sdk';
+import {
+  CheckConnectionConfigResponse,
+  Code,
+  ConnectError,
+  ConnectionConfig,
+} from '@neosync/sdk';
 import {
   checkConnectionConfigById,
   getConnections,
@@ -219,15 +224,23 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                                 });
                                 setSourceValidationResponse(res);
                               } catch (err) {
-                                setSourceValidationResponse(
-                                  new CheckConnectionConfigResponse({
-                                    isConnected: false,
-                                    connectionError:
-                                      err instanceof Error
-                                        ? err.message
-                                        : 'unknown error',
-                                  })
-                                );
+                                if (
+                                  err instanceof ConnectError &&
+                                  err.code === Code.InvalidArgument &&
+                                  err.message.includes('unsupported operation')
+                                ) {
+                                  setSourceValidationResponse(undefined);
+                                } else {
+                                  setSourceValidationResponse(
+                                    new CheckConnectionConfigResponse({
+                                      isConnected: false,
+                                      connectionError:
+                                        err instanceof Error
+                                          ? err.message
+                                          : 'unknown error',
+                                    })
+                                  );
+                                }
                               } finally {
                                 setIsSourceValidating(false);
                               }
@@ -329,15 +342,23 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                                 });
                                 setDestinationValidationResponse(res);
                               } catch (err) {
-                                setDestinationValidationResponse(
-                                  new CheckConnectionConfigResponse({
-                                    isConnected: false,
-                                    connectionError:
-                                      err instanceof Error
-                                        ? err.message
-                                        : 'unknown error',
-                                  })
-                                );
+                                if (
+                                  err instanceof ConnectError &&
+                                  err.code === Code.InvalidArgument &&
+                                  err.message.includes('unsupported operation')
+                                ) {
+                                  setDestinationValidationResponse(undefined);
+                                } else {
+                                  setDestinationValidationResponse(
+                                    new CheckConnectionConfigResponse({
+                                      isConnected: false,
+                                      connectionError:
+                                        err instanceof Error
+                                          ? err.message
+                                          : 'unknown error',
+                                    })
+                                  );
+                                }
                               } finally {
                                 setIsDestinationValidating(false);
                               }

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/connect/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/connect/page.tsx
@@ -259,7 +259,9 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                         !isSourceValidating && (
                           <TestConnectionBadge
                             validationResponse={sourceValidationResponse}
-                            id={form.getValues('fkSourceConnectionId')}
+                            connectionId={form.getValues(
+                              'fkSourceConnectionId'
+                            )}
                             accountName={account?.name ?? ''}
                           />
                         )}
@@ -371,7 +373,9 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                                 ? sourceValidationResponse
                                 : destinationValidationResponse
                             }
-                            id={form.getValues('destination.connectionId')}
+                            connectionId={form.getValues(
+                              'destination.connectionId'
+                            )}
                             accountName={account?.name ?? ''}
                           />
                         )}

--- a/frontend/apps/web/components/connections/TestConnectionBadge.tsx
+++ b/frontend/apps/web/components/connections/TestConnectionBadge.tsx
@@ -7,18 +7,18 @@ import { TiWarningOutline } from 'react-icons/ti';
 
 interface TestConnectionBadgeProps {
   validationResponse: CheckConnectionConfigResponse | undefined;
-  id: string | undefined;
+  connectionId: string | undefined;
   accountName: string;
 }
 
 export default function TestConnectionBadge(props: TestConnectionBadgeProps) {
-  const { validationResponse, id, accountName } = props;
+  const { validationResponse, connectionId, accountName } = props;
 
   return (
     <ValidationResponseBadge
       validationResponse={validationResponse}
       accountName={accountName}
-      id={id ?? ''}
+      connectionId={connectionId ?? ''}
     />
   );
 }
@@ -26,69 +26,61 @@ export default function TestConnectionBadge(props: TestConnectionBadgeProps) {
 interface ValidationResponseBadgeProps {
   validationResponse: CheckConnectionConfigResponse | undefined;
   accountName: string;
-  id: string;
+  connectionId: string;
 }
 
 function ValidationResponseBadge(props: ValidationResponseBadgeProps) {
-  const { validationResponse, accountName, id } = props;
-  const url = `/${accountName}/connections/${id}/permissions`;
+  const { validationResponse, accountName, connectionId } = props;
+  const url = `/${accountName}/connections/${connectionId}/permissions`;
 
-  if (
-    validationResponse?.isConnected &&
-    validationResponse.privileges.length > 0
-  ) {
-    return (
-      <div className="flex flex-row items-center gap-2 rounded-xl px-2 py-1 h-auto text-green-900 dark:text-green-100 border border-green-700 bg-green-100 dark:bg-green-900 transition-colors">
-        <CheckCircledIcon />
-        <div className="text-nowrap text-xs font-medium">
-          Successfully connected
-        </div>
-      </div>
-    );
-  } else if (
-    validationResponse?.isConnected &&
-    validationResponse.privileges.length === 0
-  ) {
-    return (
-      <Link href={url} passHref target="_blank">
-        <div className="flex flex-row items-center gap-2 rounded-xl px-2 py-1 h-auto text-orange-900 dark:text-orange-100 border border-orange-700 bg-orange-100 dark:bg-orange-900 hover:bg-orange-200 hover:dark:bg-orange-950/90 transition-colors">
-          <TiWarningOutline />
-          <div className="text-nowrap text-xs font-medium">
-            Connection Warning - No tables found.{' '}
-            <a
-              href={url}
-              className="underline"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              More info
-            </a>
-          </div>
-          <ArrowTopRightIcon />
-        </div>
-      </Link>
-    );
-  } else if (validationResponse && !validationResponse.isConnected) {
-    return (
-      <Link href={url} passHref target="_blank">
-        <div className="flex flex-row items-center gap-2 rounded-xl px-2 py-1 h-auto text-red-900 dark:text-red-100 border border-red-700 bg-red-100 dark:bg-red-950 hover:dark:bg-red-950/90 hover:bg-red-200 transition-colors">
-          <MdErrorOutline />
-          <div className="text-nowrap text-xs pl-2 font-medium">
-            Connection Error - Unable to connect.{' '}
-            <a
-              href={url}
-              className="underline"
-              target="_blank"
-              rel="noopener noreferrer"
-            >
-              More info
-            </a>
-          </div>
-          <ArrowTopRightIcon />
-        </div>
-      </Link>
-    );
-  } else {
+  if (!validationResponse) {
     return null;
   }
+  if (validationResponse.isConnected) {
+    if (validationResponse.privileges.length === 0) {
+      return (
+        <div className="inline-flex">
+          <Link
+            href={url}
+            passHref
+            target="_blank"
+            className="flex flex-row items-center gap-2 rounded-xl px-2 py-1 h-auto text-orange-900 dark:text-orange-100 border border-orange-700 bg-orange-100 dark:bg-orange-900 hover:bg-orange-200 hover:dark:bg-orange-950/90 transition-colors"
+          >
+            <TiWarningOutline />
+            <div className="text-nowrap text-xs pl-2 font-medium">
+              Connection Error - Unable to connect.{' '}
+              <span className="underline">More info</span>
+            </div>
+            <ArrowTopRightIcon />
+          </Link>
+        </div>
+      );
+    } else {
+      return (
+        <div className="flex flex-row items-center gap-2 rounded-xl px-2 py-1 h-auto text-green-900 dark:text-green-100 border border-green-700 bg-green-100 dark:bg-green-900 transition-colors">
+          <CheckCircledIcon />
+          <div className="text-nowrap text-xs font-medium">
+            Successfully connected
+          </div>
+        </div>
+      );
+    }
+  }
+  return (
+    <div className="inline-flex">
+      <Link
+        href={url}
+        passHref
+        target="_blank"
+        className="flex flex-row items-center gap-2 rounded-xl px-2 py-1 h-auto text-red-900 dark:text-red-100 border border-red-700 bg-red-100 dark:bg-red-950 hover:dark:bg-red-950/90 hover:bg-red-200 transition-colors"
+      >
+        <MdErrorOutline />
+        <div className="text-nowrap text-xs pl-2 font-medium">
+          Connection Error - Unable to connect.{' '}
+          <span className="underline">More info</span>
+        </div>
+        <ArrowTopRightIcon />
+      </Link>
+    </div>
+  );
 }

--- a/frontend/apps/web/components/connections/TestConnectionBadge.tsx
+++ b/frontend/apps/web/components/connections/TestConnectionBadge.tsx
@@ -2,6 +2,7 @@
 import { CheckConnectionConfigResponse } from '@neosync/sdk';
 import { ArrowTopRightIcon, CheckCircledIcon } from '@radix-ui/react-icons';
 import Link from 'next/link';
+import { ReactElement } from 'react';
 import { MdErrorOutline } from 'react-icons/md';
 import { TiWarningOutline } from 'react-icons/ti';
 
@@ -11,7 +12,9 @@ interface TestConnectionBadgeProps {
   accountName: string;
 }
 
-export default function TestConnectionBadge(props: TestConnectionBadgeProps) {
+export default function TestConnectionBadge(
+  props: TestConnectionBadgeProps
+): ReactElement {
   const { validationResponse, connectionId, accountName } = props;
 
   return (
@@ -29,7 +32,9 @@ interface ValidationResponseBadgeProps {
   connectionId: string;
 }
 
-function ValidationResponseBadge(props: ValidationResponseBadgeProps) {
+function ValidationResponseBadge(
+  props: ValidationResponseBadgeProps
+): ReactElement | null {
   const { validationResponse, accountName, connectionId } = props;
   const url = `/${accountName}/connections/${connectionId}/permissions`;
 


### PR DESCRIPTION
This PR does two things:

- Updates the UI to no longer show the Connection error for any unsupported connections
- Fixes issue in the test connection badge where we were double nested <a /> tags

![image](https://github.com/user-attachments/assets/1c61b61e-dc63-4304-b9a7-47adc5ac17c9)

What is shown today in prod for S3 destinations:
![image](https://github.com/user-attachments/assets/c58a3119-37f1-41e2-8bd2-746b5ac254c3)

Now nothing is shown:
![image](https://github.com/user-attachments/assets/5b255b83-7758-4bf4-9b58-47b66ac79bfa)

Here is an image of the failed connect badge after removing the double anchor (to show there are no style changes):
![image](https://github.com/user-attachments/assets/09d8fc27-c20a-411b-a8e5-fe0e38eb61a0)
