### PR TITLE
NEOS-1561: updates logic to use presidio defined default if no user provided value

### DIFF
--- a/internal/ee/transformers/functions/functions.go
+++ b/internal/ee/transformers/functions/functions.go
@@ -38,16 +38,18 @@ func TransformPiiText(
 		return "", fmt.Errorf("received non-200 response from analyzer: %s %d %s", analyzeResp.Status(), analyzeResp.StatusCode(), string(analyzeResp.Body))
 	}
 
-	defaultAnon, err := getDefaultAnonymizer(config.GetDefaultAnonymizer())
+	defaultAnon, ok, err := getDefaultAnonymizer(config.GetDefaultAnonymizer())
 	if err != nil {
 		return "", fmt.Errorf("unable to build default anonymizer: %w", err)
+	}
+	anonymizers := map[string]presidioapi.AnonymizeRequest_Anonymizers_AdditionalProperties{}
+	if ok {
+		anonymizers["DEFAULT"] = *defaultAnon
 	}
 	anonResp, err := anonymizeClient.PostAnonymizeWithResponse(ctx, presidioapi.AnonymizeRequest{
 		AnalyzerResults: presidioapi.ToAnonymizeRecognizerResults(*analyzeResp.JSON200),
 		Text:            value,
-		Anonymizers: &map[string]presidioapi.AnonymizeRequest_Anonymizers_AdditionalProperties{
-			"DEFAULT": *defaultAnon,
-		},
+		Anonymizers:     &anonymizers,
 	})
 	if err != nil {
 		return "", fmt.Errorf("unable to anonymize input: %w", err)
@@ -74,26 +76,32 @@ func buildAdhocRecognizers(dtos []*mgmtv1alpha1.PiiDenyRecognizer) []presidioapi
 	return output
 }
 
-func getDefaultAnonymizer(dto *mgmtv1alpha1.PiiAnonymizer) (*presidioapi.AnonymizeRequest_Anonymizers_AdditionalProperties, error) {
-	ap := &presidioapi.AnonymizeRequest_Anonymizers_AdditionalProperties{}
+func getDefaultAnonymizer(dto *mgmtv1alpha1.PiiAnonymizer) (*presidioapi.AnonymizeRequest_Anonymizers_AdditionalProperties, bool, error) {
 	switch cfg := dto.GetConfig().(type) {
 	case *mgmtv1alpha1.PiiAnonymizer_Redact_:
+		ap := &presidioapi.AnonymizeRequest_Anonymizers_AdditionalProperties{}
 		err := ap.FromRedact(presidioapi.Redact{Type: "redact"})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		return ap, true, nil
 	case *mgmtv1alpha1.PiiAnonymizer_Replace_:
+		ap := &presidioapi.AnonymizeRequest_Anonymizers_AdditionalProperties{}
 		err := ap.FromReplace(presidioapi.Replace{Type: "replace", NewValue: cfg.Replace.GetValue()})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		return ap, true, nil
 	case *mgmtv1alpha1.PiiAnonymizer_Hash_:
+		ap := &presidioapi.AnonymizeRequest_Anonymizers_AdditionalProperties{}
 		hashtype := toPresidioHashType(cfg.Hash.GetAlgo())
 		err := ap.FromHash(presidioapi.Hash{Type: "hash", HashType: &hashtype})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
+		return ap, true, nil
 	case *mgmtv1alpha1.PiiAnonymizer_Mask_:
+		ap := &presidioapi.AnonymizeRequest_Anonymizers_AdditionalProperties{}
 		fromend := cfg.Mask.GetFromEnd()
 		err := ap.FromMask(presidioapi.Mask{
 			Type:        "mask",
@@ -102,15 +110,11 @@ func getDefaultAnonymizer(dto *mgmtv1alpha1.PiiAnonymizer) (*presidioapi.Anonymi
 			MaskingChar: cfg.Mask.GetMaskingChar(),
 		})
 		if err != nil {
-			return nil, err
+			return nil, false, err
 		}
-	default:
-		err := ap.FromReplace(presidioapi.Replace{Type: "replace", NewValue: "<REDACTED>"})
-		if err != nil {
-			return nil, err
-		}
+		return ap, true, nil
 	}
-	return ap, nil
+	return nil, false, nil
 }
 
 func toPresidioHashType(dto mgmtv1alpha1.PiiAnonymizer_Hash_HashType) presidioapi.HashHashType {

--- a/internal/ee/transformers/functions/functions_test.go
+++ b/internal/ee/transformers/functions/functions_test.go
@@ -80,18 +80,19 @@ func Test_TransformPiiText(t *testing.T) {
 
 func Test_getDefaultAnonymizer(t *testing.T) {
 	t.Run("redact", func(t *testing.T) {
-		actual, err := getDefaultAnonymizer(&mgmtv1alpha1.PiiAnonymizer{
+		actual, ok, err := getDefaultAnonymizer(&mgmtv1alpha1.PiiAnonymizer{
 			Config: &mgmtv1alpha1.PiiAnonymizer_Redact_{
 				Redact: &mgmtv1alpha1.PiiAnonymizer_Redact{},
 			},
 		})
 		require.NoError(t, err)
 		require.NotNil(t, actual)
+		require.True(t, ok)
 	})
 
 	t.Run("replace", func(t *testing.T) {
 		newval := "newval"
-		actual, err := getDefaultAnonymizer(&mgmtv1alpha1.PiiAnonymizer{
+		actual, ok, err := getDefaultAnonymizer(&mgmtv1alpha1.PiiAnonymizer{
 			Config: &mgmtv1alpha1.PiiAnonymizer_Replace_{
 				Replace: &mgmtv1alpha1.PiiAnonymizer_Replace{
 					Value: &newval,
@@ -100,11 +101,12 @@ func Test_getDefaultAnonymizer(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, actual)
+		require.True(t, ok)
 	})
 
 	t.Run("hash", func(t *testing.T) {
 		sha256 := mgmtv1alpha1.PiiAnonymizer_Hash_HASH_TYPE_SHA512
-		actual, err := getDefaultAnonymizer(&mgmtv1alpha1.PiiAnonymizer{
+		actual, ok, err := getDefaultAnonymizer(&mgmtv1alpha1.PiiAnonymizer{
 			Config: &mgmtv1alpha1.PiiAnonymizer_Hash_{
 				Hash: &mgmtv1alpha1.PiiAnonymizer_Hash{
 					Algo: &sha256,
@@ -113,13 +115,14 @@ func Test_getDefaultAnonymizer(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, actual)
+		require.True(t, ok)
 	})
 
 	t.Run("mask", func(t *testing.T) {
 		maskingChar := "*"
 		charsTomask := int32(5)
 		fromend := false
-		actual, err := getDefaultAnonymizer(&mgmtv1alpha1.PiiAnonymizer{
+		actual, ok, err := getDefaultAnonymizer(&mgmtv1alpha1.PiiAnonymizer{
 			Config: &mgmtv1alpha1.PiiAnonymizer_Mask_{
 				Mask: &mgmtv1alpha1.PiiAnonymizer_Mask{
 					MaskingChar: &maskingChar,
@@ -130,12 +133,14 @@ func Test_getDefaultAnonymizer(t *testing.T) {
 		})
 		require.NoError(t, err)
 		require.NotNil(t, actual)
+		require.True(t, ok)
 	})
 
 	t.Run("default", func(t *testing.T) {
-		actual, err := getDefaultAnonymizer(nil)
+		actual, ok, err := getDefaultAnonymizer(nil)
 		require.NoError(t, err)
-		require.NotNil(t, actual)
+		require.Nil(t, actual)
+		require.False(t, ok)
 	})
 }
 


### PR DESCRIPTION
- We were providing our own default anonymizer which did a replace with `<REDACTED>` this updates it to use the system default which replaces with the named entity.