### PR TITLE
NEOS-1585: Adds deadlock retry support to SQL outputs

### DIFF
--- a/worker/pkg/benthos/config.go
+++ b/worker/pkg/benthos/config.go
@@ -383,6 +383,8 @@ type PooledSqlUpdate struct {
 	SkipForeignKeyViolations bool      `json:"skip_foreign_key_violations" yaml:"skip_foreign_key_violations"`
 	ArgsMapping              string    `json:"args_mapping" yaml:"args_mapping"`
 	Batching                 *Batching `json:"batching,omitempty" yaml:"batching,omitempty"`
+	MaxRetryAttempts         *uint     `json:"max_retry_attempts,omitempty" yaml:"max_retry_attempts,omitempty"`
+	RetryAttemptDelay        *string   `json:"retry_attempt_delay,omitempty" yaml:"retry_attempt_delay,omitempty"`
 }
 
 type ColumnDefaultProperties struct {
@@ -406,6 +408,8 @@ type PooledSqlInsert struct {
 	Batching                 *Batching                           `json:"batching,omitempty" yaml:"batching,omitempty"`
 	Prefix                   *string                             `json:"prefix,omitempty" yaml:"prefix,omitempty"`
 	Suffix                   *string                             `json:"suffix,omitempty" yaml:"suffix,omitempty"`
+	MaxRetryAttempts         *uint                               `json:"max_retry_attempts,omitempty" yaml:"max_retry_attempts,omitempty"`
+	RetryAttemptDelay        *string                             `json:"retry_attempt_delay,omitempty" yaml:"retry_attempt_delay,omitempty"`
 }
 
 type SqlInsert struct {

--- a/worker/pkg/benthos/sql/deadlock.go
+++ b/worker/pkg/benthos/sql/deadlock.go
@@ -1,0 +1,80 @@
+package neosync_benthos_sql
+
+import (
+	"strings"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+)
+
+const (
+	// MySQL error codes
+	// 1213 - Deadlock found when trying to get lock
+	mysqlDeadlock = 1213
+	// 1205 - Lock wait timeout exceeded
+	mysqlLockTimeout = 1205
+
+	// PostgreSQL error codes
+	pqDeadlockDetected = "40P01"
+)
+
+func isDeadlockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return isMysqlDeadlockError(err) || isPostgresDeadlock(err) || isMSSQLDeadlock(err)
+}
+
+func isMysqlDeadlockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	mysqlErr, ok := err.(*mysql.MySQLError)
+	if ok {
+		return mysqlErr.Number == mysqlDeadlock || mysqlErr.Number == mysqlLockTimeout
+	}
+	return false
+}
+
+func isPostgresDeadlock(err error) bool {
+	if err == nil {
+		return false
+	}
+	pqErr, ok := err.(*pq.Error)
+	if ok {
+		return pqErr.Code == pqDeadlockDetected
+	}
+	return false
+}
+
+// isMSSQLDeadlock checks specifically for SQL Server deadlock errors
+func isMSSQLDeadlock(err error) bool {
+	if err == nil {
+		return false
+	}
+	// SQL Server deadlocks can be detected in two ways:
+	// 1. Error number 1205
+	// 2. Error message containing specific text
+
+	// First check for specific error number in message
+	if strings.Contains(err.Error(), "Error 1205") {
+		return true
+	}
+
+	// Also check for common deadlock message patterns
+	deadlockPatterns := []string{
+		"deadlock victim",
+		"Transaction (Process ID",
+		"was deadlocked",
+		"has been chosen as the deadlock victim",
+	}
+
+	msg := strings.ToLower(err.Error())
+	for _, pattern := range deadlockPatterns {
+		if strings.Contains(msg, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+
+	return false
+}

--- a/worker/pkg/benthos/sql/deadlock_test.go
+++ b/worker/pkg/benthos/sql/deadlock_test.go
@@ -1,0 +1,219 @@
+package neosync_benthos_sql
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/go-sql-driver/mysql"
+	"github.com/lib/pq"
+)
+
+func TestIsDeadlockError(t *testing.T) {
+	t.Run("nil error", func(t *testing.T) {
+		if isDeadlockError(nil) {
+			t.Error("expected false for nil error")
+		}
+	})
+
+	t.Run("MySQL", func(t *testing.T) {
+		t.Run("deadlock error", func(t *testing.T) {
+			err := &mysql.MySQLError{Number: mysqlDeadlock}
+			if !isDeadlockError(err) {
+				t.Error("expected true for MySQL deadlock error")
+			}
+		})
+
+		t.Run("lock timeout error", func(t *testing.T) {
+			err := &mysql.MySQLError{Number: mysqlLockTimeout}
+			if !isDeadlockError(err) {
+				t.Error("expected true for MySQL lock timeout error")
+			}
+		})
+
+		t.Run("non-deadlock error", func(t *testing.T) {
+			err := &mysql.MySQLError{Number: 1000}
+			if isDeadlockError(err) {
+				t.Error("expected false for non-deadlock MySQL error")
+			}
+		})
+	})
+
+	t.Run("PostgreSQL", func(t *testing.T) {
+		t.Run("deadlock error", func(t *testing.T) {
+			err := &pq.Error{Code: pqDeadlockDetected}
+			if !isDeadlockError(err) {
+				t.Error("expected true for PostgreSQL deadlock error")
+			}
+		})
+
+		t.Run("non-deadlock error", func(t *testing.T) {
+			err := &pq.Error{Code: "23505"} // unique violation error
+			if isDeadlockError(err) {
+				t.Error("expected false for non-deadlock PostgreSQL error")
+			}
+		})
+	})
+
+	t.Run("MSSQL", func(t *testing.T) {
+		t.Run("error 1205", func(t *testing.T) {
+			err := errors.New("SQL Server Error 1205: Transaction (Process ID 52) was deadlocked")
+			if !isDeadlockError(err) {
+				t.Error("expected true for MSSQL error 1205")
+			}
+		})
+
+		t.Run("deadlock victim message", func(t *testing.T) {
+			err := errors.New("Transaction was chosen as the deadlock victim")
+			if !isDeadlockError(err) {
+				t.Error("expected true for MSSQL deadlock victim message")
+			}
+		})
+
+		t.Run("process ID message", func(t *testing.T) {
+			err := errors.New("Transaction (Process ID 64) was involved in a deadlock")
+			if !isDeadlockError(err) {
+				t.Error("expected true for MSSQL process ID message")
+			}
+		})
+
+		t.Run("non-deadlock error", func(t *testing.T) {
+			err := errors.New("SQL Server Error 1234: General error")
+			if isDeadlockError(err) {
+				t.Error("expected false for non-deadlock MSSQL error")
+			}
+		})
+	})
+
+	t.Run("generic error", func(t *testing.T) {
+		err := errors.New("some random error")
+		if isDeadlockError(err) {
+			t.Error("expected false for generic error")
+		}
+	})
+}
+
+func TestIsMysqlDeadlockError(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "deadlock error",
+			err:      &mysql.MySQLError{Number: mysqlDeadlock},
+			expected: true,
+		},
+		{
+			name:     "lock timeout error",
+			err:      &mysql.MySQLError{Number: mysqlLockTimeout},
+			expected: true,
+		},
+		{
+			name:     "non-deadlock MySQL error",
+			err:      &mysql.MySQLError{Number: 1000},
+			expected: false,
+		},
+		{
+			name:     "non-MySQL error",
+			err:      errors.New("generic error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMysqlDeadlockError(tt.err); got != tt.expected {
+				t.Errorf("isMysqlDeadlockError() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsPostgresDeadlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "deadlock error",
+			err:      &pq.Error{Code: pqDeadlockDetected},
+			expected: true,
+		},
+		{
+			name:     "non-deadlock postgres error",
+			err:      &pq.Error{Code: "23505"},
+			expected: false,
+		},
+		{
+			name:     "non-postgres error",
+			err:      errors.New("generic error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isPostgresDeadlock(tt.err); got != tt.expected {
+				t.Errorf("isPostgresDeadlock() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}
+
+func TestIsMSSQLDeadlock(t *testing.T) {
+	tests := []struct {
+		name     string
+		err      error
+		expected bool
+	}{
+		{
+			name:     "nil error",
+			err:      nil,
+			expected: false,
+		},
+		{
+			name:     "error 1205",
+			err:      errors.New("SQL Server Error 1205: Transaction was deadlocked"),
+			expected: true,
+		},
+		{
+			name:     "deadlock victim message",
+			err:      errors.New("Transaction was chosen as the deadlock victim"),
+			expected: true,
+		},
+		{
+			name:     "process ID message",
+			err:      errors.New("Transaction (Process ID 64) was deadlocked"),
+			expected: true,
+		},
+		{
+			name:     "case insensitive check",
+			err:      errors.New("TRANSACTION WAS CHOSEN AS THE DEADLOCK VICTIM"),
+			expected: true,
+		},
+		{
+			name:     "non-deadlock error",
+			err:      errors.New("SQL Server Error 1234: General error"),
+			expected: false,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := isMSSQLDeadlock(tt.err); got != tt.expected {
+				t.Errorf("isMSSQLDeadlock() = %v, want %v", got, tt.expected)
+			}
+		})
+	}
+}

--- a/worker/pkg/benthos/sql/output_sql_insert.go
+++ b/worker/pkg/benthos/sql/output_sql_insert.go
@@ -190,12 +190,13 @@ func newInsertOutput(conf *service.ParsedConfig, mgr *service.Resources, provide
 		}
 	}
 
-	retryAttempts, err := conf.FieldInt("max_retry_attempts")
+	retryAttemptsConf, err := conf.FieldInt("max_retry_attempts")
 	if err != nil {
 		return nil, err
 	}
-	if retryAttempts < 1 {
-		retryAttempts = 1
+	retryAttempts := uint(1)
+	if retryAttemptsConf > 1 {
+		retryAttempts = uint(retryAttemptsConf)
 	}
 	retryAttemptDelay, err := conf.FieldString("retry_attempt_delay")
 	if err != nil {
@@ -225,7 +226,7 @@ func newInsertOutput(conf *service.ParsedConfig, mgr *service.Resources, provide
 		prefix:                   prefix,
 		suffix:                   suffix,
 		isRetry:                  isRetry,
-		maxRetryAttempts:         uint(retryAttempts),
+		maxRetryAttempts:         retryAttempts,
 		retryDelay:               retryDelay,
 	}
 	return output, nil

--- a/worker/pkg/benthos/sql/output_sql_insert.go
+++ b/worker/pkg/benthos/sql/output_sql_insert.go
@@ -7,10 +7,12 @@ import (
 	"log/slog"
 	"strings"
 	"sync"
+	"time"
 
 	"github.com/Jeffail/shutdown"
 	_ "github.com/doug-martin/goqu/v9/dialect/mysql"
 	_ "github.com/doug-martin/goqu/v9/dialect/postgres"
+	"github.com/lib/pq"
 	mysql_queries "github.com/nucleuscloud/neosync/backend/gen/go/db/dbschemas/mysql"
 	sqlmanager_postgres "github.com/nucleuscloud/neosync/backend/pkg/sqlmanager/postgres"
 	sqlmanager_shared "github.com/nucleuscloud/neosync/backend/pkg/sqlmanager/shared"
@@ -19,6 +21,8 @@ import (
 	querybuilder "github.com/nucleuscloud/neosync/worker/pkg/query-builder"
 	"github.com/warpstreamlabs/bento/public/bloblang"
 	"github.com/warpstreamlabs/bento/public/service"
+
+	"github.com/go-sql-driver/mysql"
 )
 
 func sqlInsertOutputSpec() *service.ConfigSpec {
@@ -37,7 +41,9 @@ func sqlInsertOutputSpec() *service.ConfigSpec {
 		Field(service.NewIntField("max_in_flight").Default(64)).
 		Field(service.NewBatchPolicyField("batching")).
 		Field(service.NewStringField("prefix").Optional()).
-		Field(service.NewStringField("suffix").Optional())
+		Field(service.NewStringField("suffix").Optional()).
+		Field(service.NewStringField("max_retry_attempts").Default(3)).
+		Field(service.NewStringField("retry_attempt_delay").Default("300ms"))
 }
 
 // Registers an output on a benthos environment called pooled_sql_raw
@@ -88,6 +94,9 @@ type pooledInsertOutput struct {
 	argsMapping *bloblang.Executor
 	shutSig     *shutdown.Signaller
 	isRetry     bool
+
+	maxRetryAttempts uint
+	retryDelay       time.Duration
 }
 
 func newInsertOutput(conf *service.ParsedConfig, mgr *service.Resources, provider DbPoolProvider, isRetry bool, logger *slog.Logger) (*pooledInsertOutput, error) {
@@ -184,6 +193,22 @@ func newInsertOutput(conf *service.ParsedConfig, mgr *service.Resources, provide
 		}
 	}
 
+	retryAttempts, err := conf.FieldInt("max_retry_attempts")
+	if err != nil {
+		return nil, err
+	}
+	if retryAttempts < 1 {
+		retryAttempts = 1
+	}
+	retryAttemptDelay, err := conf.FieldString("retry_attempt_delay")
+	if err != nil {
+		return nil, err
+	}
+	retryDelay, err := time.ParseDuration(retryAttemptDelay)
+	if err != nil {
+		return nil, err
+	}
+
 	output := &pooledInsertOutput{
 		driver:                   driver,
 		dsn:                      dsn,
@@ -203,6 +228,8 @@ func newInsertOutput(conf *service.ParsedConfig, mgr *service.Resources, provide
 		prefix:                   prefix,
 		suffix:                   suffix,
 		isRetry:                  isRetry,
+		maxRetryAttempts:         uint(retryAttempts),
+		retryDelay:               retryDelay,
 	}
 	return output, nil
 }
@@ -312,7 +339,7 @@ func (s *pooledInsertOutput) WriteBatch(ctx context.Context, batch service.Messa
 	}
 
 	if _, err := s.db.ExecContext(ctx, insertQuery, args...); err != nil {
-		if !s.skipForeignKeyViolations || !neosync_benthos.IsForeignKeyViolationError(err.Error()) {
+		if !isDeadlockError(err) || !s.skipForeignKeyViolations || !neosync_benthos.IsForeignKeyViolationError(err.Error()) {
 			return err
 		}
 		err = s.RetryInsertRowByRow(ctx, processedCols, processedRows, columnDefaults)
@@ -321,6 +348,78 @@ func (s *pooledInsertOutput) WriteBatch(ctx context.Context, batch service.Messa
 		}
 	}
 	return nil
+}
+
+const (
+	// MySQL error codes
+	// 1213 - Deadlock found when trying to get lock
+	mysqlDeadlock = 1213
+	// 1205 - Lock wait timeout exceeded
+	mysqlLockTimeout = 1205
+
+	// PostgreSQL error codes
+	pqDeadlockDetected = "40P01"
+)
+
+func isDeadlockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	return isMysqlDeadlockError(err) || isPostgresDeadlock(err) || isMSSQLDeadlock(err)
+}
+
+func isMysqlDeadlockError(err error) bool {
+	if err == nil {
+		return false
+	}
+	mysqlErr, ok := err.(*mysql.MySQLError)
+	if ok {
+		return mysqlErr.Number == mysqlDeadlock || mysqlErr.Number == mysqlLockTimeout
+	}
+	return false
+}
+
+func isPostgresDeadlock(err error) bool {
+	if err == nil {
+		return false
+	}
+	pqErr, ok := err.(*pq.Error)
+	if ok {
+		return pqErr.Code == pqDeadlockDetected
+	}
+	return false
+}
+
+// isMSSQLDeadlock checks specifically for SQL Server deadlock errors
+func isMSSQLDeadlock(err error) bool {
+	if err == nil {
+		return false
+	}
+	// SQL Server deadlocks can be detected in two ways:
+	// 1. Error number 1205
+	// 2. Error message containing specific text
+
+	// First check for specific error number in message
+	if strings.Contains(err.Error(), "Error 1205") {
+		return true
+	}
+
+	// Also check for common deadlock message patterns
+	deadlockPatterns := []string{
+		"deadlock victim",
+		"Transaction (Process ID",
+		"was deadlocked",
+		"has been chosen as the deadlock victim",
+	}
+
+	msg := strings.ToLower(err.Error())
+	for _, pattern := range deadlockPatterns {
+		if strings.Contains(msg, strings.ToLower(pattern)) {
+			return true
+		}
+	}
+
+	return false
 }
 
 func shouldOverrideColumnDefault(columnDefaults map[string]*neosync_benthos.ColumnDefaultProperties) bool {
@@ -338,7 +437,7 @@ func (s *pooledInsertOutput) RetryInsertRowByRow(
 	rows [][]any,
 	columnDefaults []*neosync_benthos.ColumnDefaultProperties,
 ) error {
-	errorCount := 0
+	fkErrorCount := 0
 	insertCount := 0
 	for _, row := range rows {
 		insertQuery, args, err := querybuilder.BuildInsertQuery(s.slogger, s.driver, s.schema, s.table, columns, s.columnDataTypes, [][]any{row}, &s.onConflictDoNothing, columnDefaults)
@@ -348,9 +447,9 @@ func (s *pooledInsertOutput) RetryInsertRowByRow(
 		if s.driver != sqlmanager_shared.PostgresDriver {
 			insertQuery = s.buildQuery(insertQuery)
 		}
-		_, err = s.db.ExecContext(ctx, insertQuery, args...)
+		err = s.execWithRetry(ctx, insertQuery, args)
 		if err != nil && neosync_benthos.IsForeignKeyViolationError(err.Error()) {
-			errorCount++
+			fkErrorCount++
 		} else if err != nil && !neosync_benthos.IsForeignKeyViolationError(err.Error()) {
 			return err
 		}
@@ -358,8 +457,44 @@ func (s *pooledInsertOutput) RetryInsertRowByRow(
 			insertCount++
 		}
 	}
-	s.logger.Infof("Completed batch insert with %d foreign key violations. Skipped rows: %d, Successfully inserted: %d", errorCount, errorCount, insertCount)
+	s.logger.Infof("Completed batch insert with %d foreign key violations. Skipped rows: %d, Successfully inserted: %d", fkErrorCount, fkErrorCount, insertCount)
 	return nil
+}
+
+func (s *pooledInsertOutput) execWithRetry(
+	ctx context.Context,
+	query string,
+	args []any,
+) error {
+	var err error
+	for attempt := uint(0); attempt < s.maxRetryAttempts; attempt++ {
+		_, err = s.db.ExecContext(ctx, query, args...)
+		if err == nil {
+			return nil
+		}
+		if !isDeadlockError(err) {
+			return err
+		}
+		s.logger.Warnf("deadlock detected, (%d/%d). Retrying in %v...", attempt+1, s.maxRetryAttempts, s.retryDelay)
+		err = sleepContext(ctx, s.retryDelay)
+		if err != nil {
+			return fmt.Errorf("encountered error while sleeping during retry delay: %w", err)
+		}
+	}
+	return fmt.Errorf("max retry attempts reached while attempting to exec db query: %w", err)
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
 }
 
 func (s *pooledInsertOutput) processRows(columnNames []string, dataRows [][]any) (columns []string, rows [][]any) {

--- a/worker/pkg/benthos/sql/output_sql_update.go
+++ b/worker/pkg/benthos/sql/output_sql_update.go
@@ -132,12 +132,13 @@ func newUpdateOutput(conf *service.ParsedConfig, mgr *service.Resources, provide
 		}
 	}
 
-	retryAttempts, err := conf.FieldInt("max_retry_attempts")
+	retryAttemptsConf, err := conf.FieldInt("max_retry_attempts")
 	if err != nil {
 		return nil, err
 	}
-	if retryAttempts < 1 {
-		retryAttempts = 1
+	retryAttempts := uint(1)
+	if retryAttemptsConf > 1 {
+		retryAttempts = uint(retryAttemptsConf)
 	}
 	retryAttemptDelay, err := conf.FieldString("retry_attempt_delay")
 	if err != nil {
@@ -160,7 +161,7 @@ func newUpdateOutput(conf *service.ParsedConfig, mgr *service.Resources, provide
 		columns:                  columns,
 		whereCols:                whereCols,
 		skipForeignKeyViolations: skipForeignKeyViolations,
-		maxRetryAttempts:         uint(retryAttempts),
+		maxRetryAttempts:         retryAttempts,
 		retryDelay:               retryDelay,
 	}
 	return output, nil

--- a/worker/pkg/benthos/sql/retry.go
+++ b/worker/pkg/benthos/sql/retry.go
@@ -1,0 +1,62 @@
+package neosync_benthos_sql
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// retryConfig holds the configuration for retry attempts
+type retryConfig struct {
+	MaxAttempts uint
+	RetryDelay  time.Duration
+	Logger      retryLogger
+	// ShouldRetry determines if a given error should trigger a retry
+	ShouldRetry func(error) bool
+}
+
+// retryLogger interface to allow for different logging implementations
+type retryLogger interface {
+	Warnf(format string, args ...any)
+}
+
+// retryOperation represents an operation that can be retried
+type retryOperation func(ctx context.Context) error
+
+// retryWithConfig executes an operation with retry logic for deadlock errors
+func retryWithConfig(ctx context.Context, config *retryConfig, operation retryOperation) error {
+	var lastErr error
+	for attempt := uint(0); attempt < config.MaxAttempts; attempt++ {
+		err := operation(ctx)
+		if err == nil {
+			return nil
+		}
+
+		if !config.ShouldRetry(err) {
+			return err
+		}
+
+		lastErr = err
+		config.Logger.Warnf("attempt failed (%d/%d). Retrying in %v... Error: %v",
+			attempt+1, config.MaxAttempts, config.RetryDelay, err)
+
+		if err := sleepContext(ctx, config.RetryDelay); err != nil {
+			return fmt.Errorf("encountered error while sleeping during retry delay: %w", err)
+		}
+	}
+
+	return fmt.Errorf("max retry attempts reached: %w", lastErr)
+}
+
+func sleepContext(ctx context.Context, d time.Duration) error {
+	if d <= 0 {
+		return nil
+	}
+
+	select {
+	case <-ctx.Done():
+		return ctx.Err()
+	case <-time.After(d):
+		return nil
+	}
+}

--- a/worker/pkg/benthos/sql/retry_test.go
+++ b/worker/pkg/benthos/sql/retry_test.go
@@ -1,0 +1,356 @@
+package neosync_benthos_sql
+
+import (
+	"context"
+	"fmt"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestRetryWithConfig(t *testing.T) {
+	t.Run("succeeds_first_try", func(t *testing.T) {
+		// Given
+		calls := 0
+		mockLogger := &mockLogger{}
+
+		operation := func(ctx context.Context) error {
+			calls++
+			return nil
+		}
+
+		config := &retryConfig{
+			MaxAttempts: 3,
+			RetryDelay:  time.Millisecond,
+			Logger:      mockLogger,
+			ShouldRetry: func(err error) bool {
+				return err.Error() == "temporary error"
+			},
+		}
+
+		// When
+		err := retryWithConfig(context.Background(), config, operation)
+
+		// Then
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("expected 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("succeeds_after_retry", func(t *testing.T) {
+		// Given
+		calls := 0
+		mockLogger := &mockLogger{}
+
+		operation := func(ctx context.Context) error {
+			calls++
+			if calls == 1 {
+				return fmt.Errorf("temporary error")
+			}
+			return nil
+		}
+
+		config := &retryConfig{
+			MaxAttempts: 3,
+			RetryDelay:  time.Millisecond,
+			Logger:      mockLogger,
+			ShouldRetry: func(err error) bool {
+				return err.Error() == "temporary error"
+			},
+		}
+
+		// When
+		err := retryWithConfig(context.Background(), config, operation)
+
+		// Then
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if calls != 2 {
+			t.Errorf("expected 2 calls, got %d", calls)
+		}
+	})
+
+	t.Run("fails_non_retryable", func(t *testing.T) {
+		// Given
+		calls := 0
+		mockLogger := &mockLogger{}
+
+		operation := func(ctx context.Context) error {
+			calls++
+			return fmt.Errorf("permanent error")
+		}
+
+		config := &retryConfig{
+			MaxAttempts: 3,
+			RetryDelay:  time.Millisecond,
+			Logger:      mockLogger,
+			ShouldRetry: func(err error) bool {
+				return err.Error() == "temporary error"
+			},
+		}
+
+		// When
+		err := retryWithConfig(context.Background(), config, operation)
+
+		// Then
+		if err == nil || !strings.Contains(err.Error(), "permanent error") {
+			t.Errorf("expected permanent error, got %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("expected 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("exceeds_max_attempts", func(t *testing.T) {
+		// Given
+		calls := 0
+		mockLogger := &mockLogger{}
+
+		operation := func(ctx context.Context) error {
+			calls++
+			return fmt.Errorf("temporary error")
+		}
+
+		config := &retryConfig{
+			MaxAttempts: 2,
+			RetryDelay:  time.Millisecond,
+			Logger:      mockLogger,
+			ShouldRetry: func(err error) bool {
+				return err.Error() == "temporary error"
+			},
+		}
+
+		// When
+		err := retryWithConfig(context.Background(), config, operation)
+
+		// Then
+		if err == nil || !strings.Contains(err.Error(), "max retry attempts reached") {
+			t.Errorf("expected max retry attempts error, got %v", err)
+		}
+		if calls != 2 {
+			t.Errorf("expected 2 calls, got %d", calls)
+		}
+	})
+
+	t.Run("context_canceled_during_operation", func(t *testing.T) {
+		// Given
+		calls := 0
+		mockLogger := &mockLogger{}
+
+		operation := func(ctx context.Context) error {
+			calls++
+			return context.Canceled
+		}
+
+		config := &retryConfig{
+			MaxAttempts: 3,
+			RetryDelay:  time.Millisecond,
+			Logger:      mockLogger,
+			ShouldRetry: func(err error) bool {
+				return err.Error() == "temporary error"
+			},
+		}
+
+		// When
+		err := retryWithConfig(context.Background(), config, operation)
+
+		// Then
+		if err != context.Canceled {
+			t.Errorf("expected context.Canceled error, got %v", err)
+		}
+		if calls != 1 {
+			t.Errorf("expected 1 call, got %d", calls)
+		}
+	})
+
+	t.Run("context_canceled_during_sleep", func(t *testing.T) {
+		// Given
+		calls := 0
+		mockLogger := &mockLogger{}
+
+		operation := func(ctx context.Context) error {
+			calls++
+			return fmt.Errorf("temporary error")
+		}
+
+		config := &retryConfig{
+			MaxAttempts: 3,
+			RetryDelay:  200 * time.Millisecond, // Long enough delay to ensure we can cancel
+			Logger:      mockLogger,
+			ShouldRetry: func(err error) bool {
+				return err.Error() == "temporary error"
+			},
+		}
+
+		ctx, cancel := context.WithCancel(context.Background())
+		// Cancel the context after a short delay
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+		defer cancel()
+
+		// When
+		err := retryWithConfig(ctx, config, operation)
+
+		// Then
+		expectedErr := "encountered error while sleeping during retry delay: context canceled"
+		if err == nil || !strings.Contains(err.Error(), expectedErr) {
+			t.Errorf("expected error containing %q, got %v", expectedErr, err)
+		}
+		if calls != 1 {
+			t.Errorf("expected 1 call, got %d", calls)
+		}
+	})
+}
+
+// mockLogger for testing
+type mockLogger struct {
+	messages []string
+}
+
+func (m *mockLogger) Warnf(format string, args ...any) {
+	m.messages = append(m.messages, fmt.Sprintf(format, args...))
+}
+
+func TestSleepContext(t *testing.T) {
+	t.Run("returns_immediately_for_zero_duration", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		duration := time.Duration(0)
+
+		// When
+		start := time.Now()
+		err := sleepContext(ctx, duration)
+		elapsed := time.Since(start)
+
+		// Then
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if elapsed > time.Millisecond {
+			t.Errorf("expected immediate return, but took %v", elapsed)
+		}
+	})
+
+	t.Run("returns_immediately_for_negative_duration", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		duration := -time.Second
+
+		// When
+		start := time.Now()
+		err := sleepContext(ctx, duration)
+		elapsed := time.Since(start)
+
+		// Then
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if elapsed > time.Millisecond {
+			t.Errorf("expected immediate return, but took %v", elapsed)
+		}
+	})
+
+	t.Run("sleeps_for_specified_duration", func(t *testing.T) {
+		// Given
+		ctx := context.Background()
+		duration := 100 * time.Millisecond
+
+		// When
+		start := time.Now()
+		err := sleepContext(ctx, duration)
+		elapsed := time.Since(start)
+
+		// Then
+		if err != nil {
+			t.Errorf("unexpected error: %v", err)
+		}
+		if elapsed < duration {
+			t.Errorf("sleep duration too short: expected >= %v, got %v", duration, elapsed)
+		}
+		// Allow some buffer for scheduling delays
+		if elapsed > duration*2 {
+			t.Errorf("sleep duration too long: expected <= %v, got %v", duration*2, elapsed)
+		}
+	})
+
+	t.Run("returns_error_when_context_already_canceled", func(t *testing.T) {
+		// Given
+		ctx, cancel := context.WithCancel(context.Background())
+		cancel() // Cancel immediately
+		duration := 100 * time.Millisecond
+
+		// When
+		start := time.Now()
+		err := sleepContext(ctx, duration)
+		elapsed := time.Since(start)
+
+		// Then
+		if err != context.Canceled {
+			t.Errorf("expected context.Canceled error, got %v", err)
+		}
+		if elapsed > time.Millisecond {
+			t.Errorf("expected immediate return, but took %v", elapsed)
+		}
+	})
+
+	t.Run("returns_error_when_context_canceled_during_sleep", func(t *testing.T) {
+		// Given
+		ctx, cancel := context.WithCancel(context.Background())
+		duration := 200 * time.Millisecond
+
+		// Cancel context after a short delay
+		go func() {
+			time.Sleep(50 * time.Millisecond)
+			cancel()
+		}()
+
+		// When
+		start := time.Now()
+		err := sleepContext(ctx, duration)
+		elapsed := time.Since(start)
+
+		// Then
+		if err != context.Canceled {
+			t.Errorf("expected context.Canceled error, got %v", err)
+		}
+		// Should have returned early due to cancellation
+		if elapsed >= duration {
+			t.Errorf("expected early return before %v, took %v", duration, elapsed)
+		}
+		// Should have waited for the cancellation
+		if elapsed < 45*time.Millisecond {
+			t.Errorf("returned too early, expected at least 45ms, got %v", elapsed)
+		}
+	})
+
+	t.Run("handles_context_with_deadline", func(t *testing.T) {
+		// Given
+		ctx, cancel := context.WithTimeout(context.Background(), 50*time.Millisecond)
+		defer cancel()
+		duration := 200 * time.Millisecond
+
+		// When
+		start := time.Now()
+		err := sleepContext(ctx, duration)
+		elapsed := time.Since(start)
+
+		// Then
+		if err != context.DeadlineExceeded {
+			t.Errorf("expected context.DeadlineExceeded error, got %v", err)
+		}
+		// Should have returned early due to deadline
+		if elapsed >= duration {
+			t.Errorf("expected early return before %v, took %v", duration, elapsed)
+		}
+		// Should have waited until close to the deadline
+		if elapsed < 45*time.Millisecond {
+			t.Errorf("returned too early, expected at least 45ms, got %v", elapsed)
+		}
+	})
+}


### PR DESCRIPTION
Deadlocks can occur in highly concurrent environments, even when inserting to a single table.

This adds support for retries to help smooth this out ahead of us adding the ability to configure the batch size, max in flight, and even the retry configurations.