### PR TITLE
sets versioning strat on frontend to force package updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -12,6 +12,8 @@ updates:
         update-types:
           - minor
           - patch
+    reviewers:
+      - nickzelei
 
   - package-ecosystem: "npm"
     directory: "frontend"
@@ -30,6 +32,9 @@ updates:
         update-types:
           - minor
           - patch
+    reviewers:
+      - nickzelei
+    versioning-strategy: increase
 
   - package-ecosystem: "npm"
     directory: "docs"
@@ -48,6 +53,8 @@ updates:
         update-types:
           - minor
           - patch
+    reviewers:
+      - nickzelei
 
   # Maintain dependencies for GitHub Actions
   - package-ecosystem: "github-actions"
@@ -61,3 +68,5 @@ updates:
         update-types:
           - minor
           - patch
+    reviewers:
+      - nickzelei


### PR DESCRIPTION
adds myself as a reviewer so i'm aware of request.

Specifies versioning strategy on frontend to get dependabot working again for the monorepo.