### PR TITLE
Introducing Neosync Guru on Gurubase.io

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,9 @@ Open Source Data Anonymization and Synthetic Data Orchestration
   <a href="https://artifacthub.io/packages/search?repo=neosync">
     <img alt="ArtifactHub Neosync" src="https://img.shields.io/endpoint?url=https://artifacthub.io/badge/repository/neosync" />
   </a>
+  <a href="https://gurubase.io/g/neosync">
+    <img alt="Gurubase" src="https://img.shields.io/badge/Gurubase-Ask%20Neosync%20Guru-006BFF" />
+  </a>
 </div>
 
 ## Introduction


### PR DESCRIPTION
Hello team,

I'm the maintainer of [Anteon](https://github.com/getanteon/anteon). We have created Gurubase.io with the mission of building a centralized, open-source tool-focused knowledge base. Essentially, each "guru" is equipped with custom knowledge to answer user questions based on collected data related to that tool.

I wanted to update you that I've manually added the [Neosync Guru](https://gurubase.io/g/neosync) to Gurubase. Neosync Guru uses the data from this repo and data from the [docs](https://docs.neosync.dev) to answer questions by leveraging the LLM.

In this PR, I showcased the "Neosync Guru", which highlights that Neosync now has an AI assistant available to help users with their questions. Please let me know your thoughts on this contribution.

Additionally, if you want me to disable Neosync Guru in Gurubase, just let me know that's totally fine.
