### PR TITLE
NEOS-1638: fixes table styling

### DIFF
--- a/frontend/apps/web/components/TruncatedText.tsx
+++ b/frontend/apps/web/components/TruncatedText.tsx
@@ -31,7 +31,7 @@ export default function TruncatedText(props: Props): ReactElement {
     <TooltipProvider>
       <Tooltip delayDuration={delayDuration}>
         <TooltipTrigger asChild>
-          <div className={cn(`relative max-w-[${maxWidth}px]`)}>
+          <div style={{ maxWidth: `${maxWidth}px` }} className="relative">
             <div
               className={cn(
                 'truncate font-medium',

--- a/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
+++ b/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
@@ -78,7 +78,7 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, string>[] {
         </div>
       );
     },
-    maxSize: 30,
+    maxSize: 20,
   });
 
   const schemaColumn = columnHelper.accessor('schema', {
@@ -96,7 +96,7 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, string>[] {
       return <SchemaColumnHeader column={column} title="Table" />;
     },
     cell({ getValue }) {
-      return <TruncatedText text={getValue()} />;
+      return <TruncatedText text={getValue()} maxWidth={150} />;
     },
   });
 
@@ -105,7 +105,7 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, string>[] {
       return <SchemaColumnHeader column={column} title="Column" />;
     },
     cell({ getValue }) {
-      return <TruncatedText text={getValue()} />;
+      return <TruncatedText text={getValue()} maxWidth={150} />;
     },
   });
 
@@ -178,7 +178,7 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, string>[] {
       if (row.transformer.config.case) {
         return row.transformer.config.case.toLowerCase();
       }
-      return 'select transformer';
+      return 'transformer';
     },
     {
       id: 'transformer',
@@ -201,7 +201,7 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, string>[] {
                   }
                 }
                 buttonText={getTransformerSelectButtonText(transformer)}
-                buttonClassName="w-[175px]"
+                buttonClassName="w-[140px]"
                 value={transformerForm}
                 onSelect={(updatedValue) =>
                   table.options.meta?.onTransformerUpdate(

--- a/frontend/apps/web/components/jobs/JobMappingTable/JobMappingTable.tsx
+++ b/frontend/apps/web/components/jobs/JobMappingTable/JobMappingTable.tsx
@@ -180,7 +180,12 @@ export default function JobMappingTable<TData, TValue>(
                   return (
                     <TableHead
                       key={header.id}
-                      style={{ minWidth: `${header.column.getSize()}px` }}
+                      style={{
+                        width:
+                          header.column.columnDef.id != 'isSelected'
+                            ? '187px'
+                            : '20px',
+                      }}
                       colSpan={header.colSpan}
                       className="flex items-center"
                     >
@@ -243,7 +248,7 @@ const MemoizedRow = memo(
           transform: `translateY(${virtualRow.start}px)`,
           height: `${virtualRow.size}px`,
         }}
-        className="items-center flex absolute w-full justify-between px-2"
+        className="items-center flex absolute w-full justify-between px-2 gap-0 space-x-0"
       >
         {row.getVisibleCells().map((cell) => (
           <td
@@ -251,6 +256,8 @@ const MemoizedRow = memo(
             className="py-2"
             style={{
               minWidth: cell.column.getSize(),
+              width:
+                cell.column.columnDef.id != 'isSelected' ? '187px' : '20px',
             }}
           >
             <MemoizedCell cell={cell as Cell<unknown, unknown>} />

--- a/frontend/apps/web/util/util.ts
+++ b/frontend/apps/web/util/util.ts
@@ -181,7 +181,7 @@ export function useTransformerSelectButtonText(
 
 export function getTransformerSelectButtonText(
   transformer: Transformer,
-  defaultText: string = 'Select Transformer'
+  defaultText: string = 'Transformer'
 ): string {
   return isInvalidTransformer(transformer) ? defaultText : transformer.name;
 }


### PR DESCRIPTION
This PR updates the table layout and styling to make it aligned with the headers. 

Main things I did here are: 
- fix the column header width and the row cell width to be the same so they scale the same 
- account for the checkbox width
- update the truncated text to actually work. We had a bug where taliwind doesn't recognize partial classnames with dynamic variables in the className prop. You have to use a style prop. Read more [here](https://tailwindcss.com/docs/content-configuration#dynamic-class-names). 
- updated the width of the transformer button to fit in the column header with - this meant removing the "Select" frm the "Select Transformer" button text and just truncated it to "Transformer"

I kept the cells left aligned but we can easily center them if we'd like
Demo
https://www.loom.com/share/70aaf74a230046d8beece3e1c5340ac0?sid=b3ab42b1-3e4a-4357-a107-cb77e809fcaa