### PR TITLE
NEOS-1662: update GetJobRunEvents to properly parse metadata

### DIFF
--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -166,7 +166,6 @@ func (s *Service) GetJobRunEvents(
 				}
 
 				jobRunEvent.Metadata = metadata
-
 			}
 			activityMap[event.EventId] = jobRunEvent
 		case enums.EVENT_TYPE_ACTIVITY_TASK_STARTED:

--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -148,7 +148,7 @@ func (s *Service) GetJobRunEvents(
 				var rawMap map[string]string
 				err := converter.GetDefaultDataConverter().FromPayload(attributes.Input.Payloads[1], &rawMap)
 				if err != nil {
-					logger.Error(fmt.Errorf("unable to convert to map: %w", err).Error())
+					logger.Error(fmt.Errorf("unable to convert to event input payload: %w", err).Error())
 				}
 
 				schema, schemaExists := rawMap["Schema"]

--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -147,7 +147,7 @@ func (s *Service) GetJobRunEvents(
 			}
 			if len(attributes.Input.Payloads) > 1 {
 				var rawMap map[string]string
-				err = converter.GetDefaultDataConverter().FromPayload(attributes.Input.Payloads[1], &rawMap)
+				err := converter.GetDefaultDataConverter().FromPayload(attributes.Input.Payloads[1], &rawMap)
 				if err != nil {
 					logger.Error(fmt.Errorf("unable to convert to map: %w", err).Error())
 				}

--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -131,7 +131,6 @@ func (s *Service) GetJobRunEvents(
 		if err != nil {
 			return nil, err
 		}
-		println("event", event)
 
 		switch event.EventType {
 		case enums.EVENT_TYPE_ACTIVITY_TASK_SCHEDULED:


### PR DESCRIPTION
This fixes a backend bug that was causing the sql query button to not render in the Runs page.