### PR TITLE
NEOS-1663: Fixes transformer configs not updating in job mapping table

### DIFF
--- a/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
+++ b/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
@@ -250,7 +250,7 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, any>[] {
 function transformerFilterFn(
   row: Row<JobMappingRow | NosqlJobMappingRow>,
   columnId: string,
-  filterValue: any
+  filterValue: any // eslint-disable-line @typescript-eslint/no-explicit-any
 ): boolean {
   const value = row.getValue<JobMappingTransformerForm | string>(columnId);
   const loweredFilterValue = filterValue.toLowerCase();

--- a/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
+++ b/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
@@ -257,7 +257,7 @@ function transformerFilterFn(
   if (typeof value === 'string') {
     return value.includes(loweredFilterValue);
   }
-  const searchableFields = [value.config.case].filter(Boolean);
+  const searchableFields = [value?.config.case].filter(Boolean);
   return searchableFields.some((field) =>
     field.toLowerCase().includes(loweredFilterValue)
   );

--- a/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
+++ b/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
@@ -49,6 +49,7 @@ export interface NosqlJobMappingRow {
   transformer: JobMappingTransformerForm;
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getJobMappingColumns(): ColumnDef<JobMappingRow, any>[] {
   const columnHelper = createColumnHelper<JobMappingRow>();
 
@@ -262,6 +263,7 @@ function transformerFilterFn(
   );
 }
 
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
 function getNosqlJobMappingColumns(): ColumnDef<NosqlJobMappingRow, any>[] {
   const columnHelper = createColumnHelper<NosqlJobMappingRow>();
 

--- a/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
+++ b/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
@@ -7,7 +7,7 @@ import {
 } from '@/util/util';
 import { JobMappingTransformerForm } from '@/yup-validations/jobs';
 import { SystemTransformer } from '@neosync/sdk';
-import { ColumnDef, createColumnHelper } from '@tanstack/react-table';
+import { ColumnDef, createColumnHelper, Row } from '@tanstack/react-table';
 import { DataTableRowActions } from '../NosqlTable/data-table-row-actions';
 import EditCollection from '../NosqlTable/EditCollection';
 import EditDocumentKey from '../NosqlTable/EditDocumentKey';
@@ -49,7 +49,7 @@ export interface NosqlJobMappingRow {
   transformer: JobMappingTransformerForm;
 }
 
-function getJobMappingColumns(): ColumnDef<JobMappingRow, string>[] {
+function getJobMappingColumns(): ColumnDef<JobMappingRow, any>[] {
   const columnHelper = createColumnHelper<JobMappingRow>();
 
   const checkboxColumn = columnHelper.display({
@@ -176,7 +176,8 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, string>[] {
   const transformerColumn = columnHelper.accessor(
     (row) => {
       if (row.transformer.config.case) {
-        return row.transformer.config.case.toLowerCase();
+        // this needs to be the full transformer object so that memoization works correctly
+        return row.transformer;
       }
       return 'transformer';
     },
@@ -228,6 +229,7 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, string>[] {
           </div>
         );
       },
+      filterFn: transformerFilterFn,
     }
   );
 
@@ -244,7 +246,23 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, string>[] {
   ];
 }
 
-function getNosqlJobMappingColumns(): ColumnDef<NosqlJobMappingRow, string>[] {
+function transformerFilterFn(
+  row: Row<JobMappingRow | NosqlJobMappingRow>,
+  columnId: string,
+  filterValue: any
+): boolean {
+  const value = row.getValue<JobMappingTransformerForm | string>(columnId);
+  const loweredFilterValue = filterValue.toLowerCase();
+  if (typeof value === 'string') {
+    return value.includes(loweredFilterValue);
+  }
+  const searchableFields = [value.config.case].filter(Boolean);
+  return searchableFields.some((field) =>
+    field.toLowerCase().includes(loweredFilterValue)
+  );
+}
+
+function getNosqlJobMappingColumns(): ColumnDef<NosqlJobMappingRow, any>[] {
   const columnHelper = createColumnHelper<NosqlJobMappingRow>();
 
   const checkboxColumn = columnHelper.display({
@@ -330,9 +348,10 @@ function getNosqlJobMappingColumns(): ColumnDef<NosqlJobMappingRow, string>[] {
   const transformerColumn = columnHelper.accessor(
     (row) => {
       if (row.transformer.config.case) {
-        return row.transformer.config.case.toLowerCase();
+        // this needs to be the full transformer object so that memoization works correctly
+        return row.transformer;
       }
-      return 'select transformer';
+      return 'transformer';
     },
     {
       id: 'transformer',
@@ -382,6 +401,7 @@ function getNosqlJobMappingColumns(): ColumnDef<NosqlJobMappingRow, string>[] {
           </div>
         );
       },
+      filterFn: transformerFilterFn,
     }
   );
 


### PR DESCRIPTION
The value we were using for the transformer column was too stable. it only took into account the case value, not the underlying config.

We make sure all transformer updates result in a fresh object, so returning the stable object reference is sufficient to trigger re-renders whenever the transformer itself is updated.

Due to this, the filterFn for the transformer needed to be updated to properly handle searches to retain the original functionality brought on by the old valueFn.

Demo: https://www.loom.com/share/6c7e422028cc40d699a6d58744976c00