### PR TITLE
NEOS-1668. NEOS-1670: Align subset table

### DIFF
--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/subsets/components/SubsetCard.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/subsets/components/SubsetCard.tsx
@@ -13,8 +13,16 @@ import {
   buildTableRowData,
   isValidSubsetType,
 } from '@/components/jobs/subsets/utils';
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form';
 import { Separator } from '@/components/ui/separator';
 import { getErrorMessage } from '@/util/util';
@@ -50,6 +58,8 @@ interface Props {
 
 export default function SubsetCard(props: Props): ReactElement {
   const { jobId } = props;
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
   const { data, isLoading: isJobLoading } = useQuery(
     getJob,
     { id: jobId },
@@ -198,6 +208,7 @@ export default function SubsetCard(props: Props): ReactElement {
               <SubsetTable
                 data={Object.values(tableRowData)}
                 onEdit={(schema, table) => {
+                  setIsDialogOpen(true);
                   const key = buildRowKey(schema, table);
                   if (tableRowData[key]) {
                     setItemToEdit({
@@ -209,64 +220,94 @@ export default function SubsetCard(props: Props): ReactElement {
                 onReset={onLocalRowReset}
               />
             </div>
-            <div className="my-4">
-              <Separator />
+            <div
+              // this prevents the tooltips inside of the dialog from automatically opening when the dialog opens since it stops the focus from being set in the dialog component
+              onFocusCapture={(e) => {
+                e.stopPropagation();
+              }}
+            >
+              <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+                <DialogContent
+                  className="max-w-5xl"
+                  onPointerDownOutside={(e) => e.preventDefault()}
+                  onEscapeKeyDown={(e) => e.preventDefault()}
+                >
+                  <DialogHeader>
+                    <div className="flex flex-row w-full">
+                      <div className="flex flex-col space-y-2 w-full">
+                        <div className="flex flex-row justify-between items-center">
+                          <div className="flex flex-row gap-4">
+                            <DialogTitle className="text-xl">
+                              Subset Query
+                            </DialogTitle>
+                          </div>
+                        </div>
+                        <div className="flex flex-row items-center gap-2">
+                          <DialogDescription>
+                            Subset your data using SQL expressions.{' '}
+                            <LearnMoreLink href="https://docs.neosync.dev/table-constraints/subsetting" />
+                          </DialogDescription>
+                        </div>
+                      </div>
+                    </div>
+                    <Separator />
+                  </DialogHeader>
+                  <div className="pt-4">
+                    <EditItem
+                      connectionId={sourceConnectionId ?? ''}
+                      item={itemToEdit}
+                      onItem={setItemToEdit}
+                      onCancel={() => {
+                        setItemToEdit(undefined);
+                        setIsDialogOpen(false);
+                      }}
+                      columns={GetColumnsForSqlAutocomplete(
+                        data?.job?.mappings ?? [],
+                        itemToEdit
+                      )}
+                      onSave={() => {
+                        if (!itemToEdit) {
+                          return;
+                        }
+                        const key = buildRowKey(
+                          itemToEdit.schema,
+                          itemToEdit.table
+                        );
+                        const idx = form
+                          .getValues()
+                          .subsets.findIndex(
+                            (item) =>
+                              buildRowKey(item.schema, item.table) === key
+                          );
+                        if (idx >= 0) {
+                          form.setValue(`subsets.${idx}`, {
+                            schema: itemToEdit.schema,
+                            table: itemToEdit.table,
+                            whereClause: itemToEdit.where,
+                          });
+                        } else {
+                          form.setValue(
+                            `subsets`,
+                            form.getValues().subsets.concat({
+                              schema: itemToEdit.schema,
+                              table: itemToEdit.table,
+                              whereClause: itemToEdit.where,
+                            })
+                          );
+                        }
+                        setItemToEdit(undefined);
+                        setIsDialogOpen(false);
+                      }}
+                      connectionType={connectionType}
+                    />
+                  </div>
+                </DialogContent>
+              </Dialog>
             </div>
-            <div>
-              <EditItem
-                connectionId={sourceConnectionId ?? ''}
-                item={itemToEdit}
-                onItem={setItemToEdit}
-                onCancel={() => setItemToEdit(undefined)}
-                columns={GetColumnsForSqlAutocomplete(
-                  data?.job?.mappings ?? [],
-                  itemToEdit
-                )}
-                onSave={() => {
-                  if (!itemToEdit) {
-                    return;
-                  }
-                  const key = buildRowKey(itemToEdit.schema, itemToEdit.table);
-                  const idx = form
-                    .getValues()
-                    .subsets.findIndex(
-                      (item) => buildRowKey(item.schema, item.table) === key
-                    );
-                  if (idx >= 0) {
-                    form.setValue(`subsets.${idx}`, {
-                      schema: itemToEdit.schema,
-                      table: itemToEdit.table,
-                      whereClause: itemToEdit.where,
-                    });
-                  } else {
-                    form.setValue(
-                      `subsets`,
-                      form.getValues().subsets.concat({
-                        schema: itemToEdit.schema,
-                        table: itemToEdit.table,
-                        whereClause: itemToEdit.where,
-                      })
-                    );
-                  }
-                  setItemToEdit(undefined);
-                }}
-                connectionType={connectionType}
-              />
-            </div>
-            <div className="my-6">
-              <Separator />
-            </div>
-            <div className="flex flex-col gap-2">
-              <div className="flex flex-row justify-end">
-                <p className="text-sm tracking-tight">
-                  Save changes to apply any updates made to the table above
-                </p>
-              </div>
-              <div className="flex flex-row gap-1 justify-end">
-                <Button key="submit" type="submit">
-                  Save
-                </Button>
-              </div>
+            <div className="flex flex-row pt-10 justify-end">
+              <Button key="submit" type="submit">
+                Save
+              </Button>
             </div>
           </div>
         </form>

--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/subsets/components/SubsetCard.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/subsets/components/SubsetCard.tsx
@@ -189,10 +189,7 @@ export default function SubsetCard(props: Props): ReactElement {
   return (
     <div>
       <Form {...form}>
-        <form
-          onSubmit={form.handleSubmit(onSubmit)}
-          className="flex flex-col gap-8"
-        >
+        <form onSubmit={form.handleSubmit(onSubmit)} className="flex flex-col">
           {showSubsetOptions(connectionType) && (
             <SubsetOptionsForm maxColNum={2} />
           )}

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/subset/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/subset/page.tsx
@@ -13,10 +13,18 @@ import {
   GetColumnsForSqlAutocomplete,
   isValidSubsetType,
 } from '@/components/jobs/subsets/utils';
+import LearnMoreLink from '@/components/labels/LearnMoreLink';
 import { useAccount } from '@/components/providers/account-provider';
 import { PageProps } from '@/components/types';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
 import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
 import { Form } from '@/components/ui/form';
 import { Separator } from '@/components/ui/separator';
 import { getSingleOrUndefined } from '@/libs/utils';
@@ -55,6 +63,9 @@ export default function Page({ searchParams }: PageProps): ReactElement {
   const { account } = useAccount();
   const router = useRouter();
   const posthog = usePostHog();
+
+  const [isDialogOpen, setIsDialogOpen] = useState(false);
+
   useEffect(() => {
     if (!searchParams?.sessionId) {
       router.push(`/${account?.name}/new/job`);
@@ -268,6 +279,7 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                   <SubsetTable
                     data={Object.values(tableRowData)}
                     onEdit={(schema, table) => {
+                      setIsDialogOpen(true);
                       const key = buildRowKey(schema, table);
                       if (tableRowData[key]) {
                         // make copy so as to not edit in place
@@ -280,64 +292,97 @@ export default function Page({ searchParams }: PageProps): ReactElement {
                     onReset={onLocalRowReset}
                   />
                 </div>
-                <div className="my-4">
-                  <Separator />
+                <div
+                  // this prevents the tooltips inside of the dialog from automatically opening when the dialog opens since it stops the focus from being set in the dialog component
+                  onFocusCapture={(e) => {
+                    e.stopPropagation();
+                  }}
+                >
+                  <Dialog open={isDialogOpen} onOpenChange={setIsDialogOpen}>
+                    <DialogContent
+                      className="max-w-5xl"
+                      onPointerDownOutside={(e) => e.preventDefault()}
+                      onEscapeKeyDown={(e) => e.preventDefault()}
+                    >
+                      <DialogHeader>
+                        <div className="flex flex-row w-full">
+                          <div className="flex flex-col space-y-2 w-full">
+                            <div className="flex flex-row justify-between items-center">
+                              <div className="flex flex-row gap-4">
+                                <DialogTitle className="text-xl">
+                                  Subset Query
+                                </DialogTitle>
+                              </div>
+                            </div>
+                            <div className="flex flex-row items-center gap-2">
+                              <DialogDescription>
+                                Subset your data using SQL expressions.{' '}
+                                <LearnMoreLink href="https://docs.neosync.dev/table-constraints/subsetting" />
+                              </DialogDescription>
+                            </div>
+                          </div>
+                        </div>
+                        <Separator />
+                      </DialogHeader>
+                      <div className="pt-4">
+                        <EditItem
+                          connectionId={connectFormValues.sourceId}
+                          item={itemToEdit}
+                          onItem={setItemToEdit}
+                          onCancel={() => {
+                            setItemToEdit(undefined);
+                            setIsDialogOpen(false);
+                          }}
+                          columns={GetColumnsForSqlAutocomplete(
+                            schemaFormValues?.mappings.map((row) => {
+                              return new JobMapping({
+                                schema: row.schema,
+                                table: row.table,
+                                column: row.column,
+                              });
+                            }),
+                            itemToEdit
+                          )}
+                          onSave={() => {
+                            if (!itemToEdit) {
+                              return;
+                            }
+                            const key = buildRowKey(
+                              itemToEdit.schema,
+                              itemToEdit.table
+                            );
+                            const idx = form
+                              .getValues()
+                              .subsets.findIndex(
+                                (item) =>
+                                  buildRowKey(item.schema, item.table) === key
+                              );
+                            if (idx >= 0) {
+                              form.setValue(`subsets.${idx}`, {
+                                schema: itemToEdit.schema,
+                                table: itemToEdit.table,
+                                whereClause: itemToEdit.where,
+                              });
+                            } else {
+                              form.setValue(
+                                `subsets`,
+                                form.getValues().subsets.concat({
+                                  schema: itemToEdit.schema,
+                                  table: itemToEdit.table,
+                                  whereClause: itemToEdit.where,
+                                })
+                              );
+                            }
+                            setItemToEdit(undefined);
+                            setIsDialogOpen(false);
+                          }}
+                          connectionType={connectionType}
+                        />
+                      </div>
+                    </DialogContent>
+                  </Dialog>
                 </div>
-                <div>
-                  <EditItem
-                    connectionId={connectFormValues.sourceId}
-                    item={itemToEdit}
-                    onItem={setItemToEdit}
-                    onCancel={() => setItemToEdit(undefined)}
-                    columns={GetColumnsForSqlAutocomplete(
-                      schemaFormValues?.mappings.map((row) => {
-                        return new JobMapping({
-                          schema: row.schema,
-                          table: row.table,
-                          column: row.column,
-                        });
-                      }),
-                      itemToEdit
-                    )}
-                    onSave={() => {
-                      if (!itemToEdit) {
-                        return;
-                      }
-                      const key = buildRowKey(
-                        itemToEdit.schema,
-                        itemToEdit.table
-                      );
-                      const idx = form
-                        .getValues()
-                        .subsets.findIndex(
-                          (item) => buildRowKey(item.schema, item.table) === key
-                        );
-                      if (idx >= 0) {
-                        form.setValue(`subsets.${idx}`, {
-                          schema: itemToEdit.schema,
-                          table: itemToEdit.table,
-                          whereClause: itemToEdit.where,
-                        });
-                      } else {
-                        form.setValue(
-                          `subsets`,
-                          form.getValues().subsets.concat({
-                            schema: itemToEdit.schema,
-                            table: itemToEdit.table,
-                            whereClause: itemToEdit.where,
-                          })
-                        );
-                      }
-                      setItemToEdit(undefined);
-                    }}
-                    connectionType={connectionType}
-                  />
-                </div>
-
-                <div className="my-6">
-                  <Separator />
-                </div>
-                <div className="flex flex-row gap-1 justify-between">
+                <div className="flex flex-row gap-1 justify-between pt-10">
                   <Button
                     key="back"
                     type="button"

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/subset/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/subset/page.tsx
@@ -256,14 +256,14 @@ export default function Page({ searchParams }: PageProps): ReactElement {
           <Form {...form}>
             <form
               onSubmit={form.handleSubmit(onSubmit)}
-              className="flex flex-col gap-8"
+              className="flex flex-col gap-2"
             >
               <div>
                 {showSubsetOptions(connectionType) && (
                   <SubsetOptionsForm maxColNum={2} />
                 )}
               </div>
-              <div className="flex flex-col gap-2">
+              <div className="flex flex-col">
                 <div>
                   <SubsetTable
                     data={Object.values(tableRowData)}

--- a/frontend/apps/web/components/jobs/subsets/EditItem.tsx
+++ b/frontend/apps/web/components/jobs/subsets/EditItem.tsx
@@ -273,7 +273,7 @@ export default function EditItem(props: Props): ReactElement {
           )}
           {showValidateButton && (
             <TooltipProvider>
-              <Tooltip>
+              <Tooltip delayDuration={200}>
                 <TooltipTrigger asChild>
                   <Button
                     type="button"
@@ -326,25 +326,16 @@ export default function EditItem(props: Props): ReactElement {
           </TooltipProvider>
         </div>
       </div>
-      <div>
-        <div className="flex flex-col items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
-          {!item ? (
-            <div className="h-[60px] w-full text-gray-400 dark:text-gray-600 text-sm justify-center flex">
-              Click the edit button on the table that you want to subset and add
-              a table filter here. For example, country = &apos;US&apos;
-            </div>
-          ) : (
-            <Editor
-              height="60px"
-              width="100%"
-              language="sql"
-              value={constructWhere(item?.where ?? '')}
-              theme={resolvedTheme === 'dark' ? 'vs-dark' : 'light'}
-              onChange={(e) => onWhereChange(e?.replace('WHERE ', '') ?? '')}
-              options={editorOptions}
-            />
-          )}
-        </div>
+      <div className="flex flex-col items-center justify-between rounded-lg border dark:border-gray-700 p-3 shadow-sm">
+        <Editor
+          height="60px"
+          width="100%"
+          language="sql"
+          value={constructWhere(item?.where ?? '')}
+          theme={resolvedTheme === 'dark' ? 'vs-dark' : 'light'}
+          onChange={(e) => onWhereChange(e?.replace('WHERE ', '') ?? '')}
+          options={editorOptions}
+        />
       </div>
       <ValidateQueryErrorAlert
         validateResp={validateResp}

--- a/frontend/apps/web/components/jobs/subsets/EditItem.tsx
+++ b/frontend/apps/web/components/jobs/subsets/EditItem.tsx
@@ -202,29 +202,33 @@ export default function EditItem(props: Props): ReactElement {
     <div className="flex flex-col gap-4">
       <div className="flex flex-col md:flex-row justify-between gap-2 md:gap-0">
         <div className="flex flex-row gap-4">
-          <div
-            className={cn(
-              'flex flex-row gap-2 items-center',
-              showSchema(connectionType) ? undefined : 'hidden'
-            )}
-          >
-            <span className="font-semibold tracking-tight">Schema</span>
-            <Badge
-              className="px-4 py-2 dark:border-gray-700"
-              variant={item?.schema ? 'outline' : 'secondary'}
+          {item?.schema && (
+            <div
+              className={cn(
+                'flex flex-row gap-2 items-center',
+                showSchema(connectionType) ? undefined : 'hidden'
+              )}
             >
-              {item?.schema ?? ''}
-            </Badge>
-          </div>
-          <div className="flex flex-row gap-2 items-center">
-            <span className="font-semibold tracking-tight">Table</span>
-            <Badge
-              className="px-4 py-2 dark:border-gray-700"
-              variant={item?.table ? 'outline' : 'secondary'}
-            >
-              {item?.table ?? ''}
-            </Badge>
-          </div>
+              <span className="font-semibold tracking-tight">Schema</span>
+              <Badge
+                className="px-4 py-2 dark:border-gray-700"
+                variant={item?.schema ? 'outline' : 'secondary'}
+              >
+                {item?.schema ?? ''}
+              </Badge>
+            </div>
+          )}
+          {item?.table && (
+            <div className="flex flex-row gap-2 items-center">
+              <span className="font-semibold tracking-tight">Table</span>
+              <Badge
+                className="px-4 py-2 dark:border-gray-700"
+                variant={item?.table ? 'outline' : 'secondary'}
+              >
+                {item?.table ?? ''}
+              </Badge>
+            </div>
+          )}
           <div className="flex flex-row items-center">
             <ValidateQueryBadge resp={validateResp} />
           </div>

--- a/frontend/apps/web/components/jobs/subsets/subset-table/column.tsx
+++ b/frontend/apps/web/components/jobs/subsets/subset-table/column.tsx
@@ -1,5 +1,6 @@
 'use client';
 
+import TruncatedText from '@/components/TruncatedText';
 import { Badge } from '@/components/ui/badge';
 import { Button } from '@/components/ui/button';
 import {
@@ -57,6 +58,15 @@ export function getColumns(props: GetColumnsProps): ColumnDef<TableRow>[] {
       header: ({ column }) => (
         <SchemaColumnHeader column={column} title={'Table'} />
       ),
+      cell: ({ row }) => {
+        return (
+          <TruncatedText
+            text={`${row.original.schema}.${row.original.table}`}
+            maxWidth={250}
+          />
+        );
+      },
+      size: 250,
     },
     {
       accessorKey: 'isRootTable',
@@ -95,9 +105,11 @@ export function getColumns(props: GetColumnsProps): ColumnDef<TableRow>[] {
         return (
           <div className="flex justify-center">
             <span className="truncate font-medium max-w-[200px] inline-block">
-              <pre className="bg-gray-100 rounded border border-gray-300 text-xs px-2 dark:bg-transparent dark:border dark:border-gray-700 whitespace-nowrap overflow-hidden text-ellipsis max-w-[100%]">
-                {getValue<boolean>()}
-              </pre>
+              {getValue<boolean>() && (
+                <pre className="bg-gray-100 rounded border border-gray-300 text-xs px-2 dark:bg-transparent dark:border dark:border-gray-700 whitespace-nowrap overflow-hidden text-ellipsis max-w-[100%]">
+                  {getValue<boolean>()}
+                </pre>
+              )}
             </span>
           </div>
         );

--- a/frontend/apps/web/components/jobs/subsets/subset-table/data-table.tsx
+++ b/frontend/apps/web/components/jobs/subsets/subset-table/data-table.tsx
@@ -140,7 +140,7 @@ export function DataTable<TData, TValue>({
                     return (
                       <td
                         key={cell.id}
-                        className="py-2"
+                        className="py-2 items-center flex"
                         style={{
                           minWidth: cell.column.getSize(),
                         }}


### PR DESCRIPTION
This feature updates the subset page in the new job form and in the job edit form to:

1. Nests the sql editor into a dialog making it easier for customers to understand that you have to click on `Apply` and then the `Save` button instead of just clicking on Apply.
2. Fixes alignment issues in the subset table that were caused by long table names. We set the column width and the truncate text to the same width which keeps the table nicely aligned. 

Demo
https://www.loom.com/share/5831605332984d2d8968ce238e084a35