### PR TITLE
NEOS-1605: Fixes job run logs not loading, fixes inability to specify log level

### DIFF
--- a/frontend/apps/web/app/api/accounts/[accountId]/runs/[id]/logs/route.ts
+++ b/frontend/apps/web/app/api/accounts/[accountId]/runs/[id]/logs/route.ts
@@ -1,9 +1,10 @@
 import { withNeosyncContext } from '@/api-only/neosync-context';
 import { RequestContext } from '@/shared';
-import { create } from '@bufbuild/protobuf';
+import { create, toJson } from '@bufbuild/protobuf';
 import {
   GetJobRunLogsStreamRequestSchema,
   GetJobRunLogsStreamResponse,
+  GetJobRunLogsStreamResponseSchema,
   LogLevel,
   LogWindow,
 } from '@neosync/sdk';
@@ -30,7 +31,7 @@ export async function GET(
     for await (const logRes of response) {
       logs.push(logRes);
     }
-    return logs;
+    return logs.map((log) => toJson(GetJobRunLogsStreamResponseSchema, log));
   })(req);
 }
 

--- a/frontend/apps/web/app/api/accounts/[accountId]/runs/[id]/logs/route.ts
+++ b/frontend/apps/web/app/api/accounts/[accountId]/runs/[id]/logs/route.ts
@@ -1,9 +1,8 @@
 import { withNeosyncContext } from '@/api-only/neosync-context';
 import { RequestContext } from '@/shared';
-import { create, toJson } from '@bufbuild/protobuf';
+import { create, JsonValue, toJson } from '@bufbuild/protobuf';
 import {
   GetJobRunLogsStreamRequestSchema,
-  GetJobRunLogsStreamResponse,
   GetJobRunLogsStreamResponseSchema,
   LogLevel,
   LogWindow,
@@ -27,11 +26,11 @@ export async function GET(
         logLevels: [loglevel ? parseInt(loglevel, 10) : LogLevel.UNSPECIFIED],
       })
     );
-    const logs: GetJobRunLogsStreamResponse[] = [];
+    const logs: JsonValue[] = [];
     for await (const logRes of response) {
-      logs.push(logRes);
+      logs.push(toJson(GetJobRunLogsStreamResponseSchema, logRes));
     }
-    return logs.map((log) => toJson(GetJobRunLogsStreamResponseSchema, log));
+    return logs;
   })(req);
 }
 

--- a/frontend/apps/web/libs/hooks/useGetJobRunLogs.ts
+++ b/frontend/apps/web/libs/hooks/useGetJobRunLogs.ts
@@ -32,7 +32,13 @@ export function useGetJobRunLogs(
       '?',
       query.toString(),
     ],
-    queryFn: (ctx) => fetcher(ctx.queryKey.join('/')),
+    queryFn: (ctx) => {
+      const queryKey = ctx.queryKey;
+      const questionMarkIndex = queryKey.indexOf('?');
+      const baseUrl = queryKey.slice(0, questionMarkIndex).join('/');
+      const queryParams = queryKey.slice(questionMarkIndex + 1).join('');
+      return fetcher(`${baseUrl}?${queryParams}`);
+    },
     refetchInterval(query) {
       return query.state.data && refreshIntervalFn
         ? refreshIntervalFn(query.state.data)
@@ -46,7 +52,7 @@ export function useGetJobRunLogs(
           : fromJson(GetJobRunLogsStreamResponseSchema, d)
       );
     },
-    enabled: !!runId && !!accountId && !!loglevel,
+    enabled: !!runId && !!accountId,
   });
 }
 


### PR DESCRIPTION
The job run logs were totally broken, this was a regression from the migration to connection v2
Properly constructs the log query now too, which was a regression from moving to tanstack query. Now properly able to filter by log level.

This also fixes the logs not loading on initial page load because the loglevel default is 0, which marked it always as not ready.