### PR TITLE
NEOS-1724: updates runs logs query to use close time if workflow has ended

### DIFF
--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -608,12 +608,15 @@ func (s *Service) streamLokiWorkerLogs(
 	}
 	workflowExecution, err := s.temporalmgr.GetWorkflowExecutionById(ctx, req.GetAccountId(), req.GetJobRunId(), logger)
 	if err != nil {
-		return err
+		return fmt.Errorf("unable to retrieve workflow execution: %w", err)
 	}
 
 	lokiclient := loki.New(s.cfg.RunLogConfig.LokiRunLogConfig.BaseUrl, http.DefaultClient)
 	direction := loki.BACKWARD
 	end := time.Now()
+	if workflowExecution.CloseTime != nil {
+		end = workflowExecution.CloseTime.AsTime()
+	}
 	start := getLogFilterTime(req.GetWindow(), end)
 	query := buildLokiQuery(
 		s.cfg.RunLogConfig.LokiRunLogConfig.LabelsQuery,

--- a/internal/javascript/vm/vm_test.go
+++ b/internal/javascript/vm/vm_test.go
@@ -53,7 +53,7 @@ func TestRunner(t *testing.T) {
 			wg.Add(1)
 			go func() {
 				defer wg.Done()
-				_, err = runner.Run(context.Background(), program)
+				_, err := runner.Run(context.Background(), program)
 				require.NoError(t, err)
 			}()
 		}


### PR DESCRIPTION
this way users can come back to a job and always see the logs, at least longer than the current day.