### PR TITLE
NEOS-1731: Fixes init types to properly handle python type hints

### DIFF
--- a/python/src/neosync/__init__.py
+++ b/python/src/neosync/__init__.py
@@ -5,13 +5,13 @@ import os
 sys.path.insert(0, os.path.abspath(os.path.dirname(__file__)))
 
 # Exports root files so they are importable from just "neosync" without having to specify the file name
-from client import Neosync as Neosync
+from neosync.client import Neosync as Neosync
 
-from mgmt.v1alpha1.anonymization_pb2 import *
-from mgmt.v1alpha1.api_key_pb2 import *
-from mgmt.v1alpha1.connection_data_pb2 import *
-from mgmt.v1alpha1.connection_pb2 import *
-from mgmt.v1alpha1.job_pb2 import *
-from mgmt.v1alpha1.metrics_pb2 import *
-from mgmt.v1alpha1.transformer_pb2 import *
-from mgmt.v1alpha1.user_account_pb2 import *
+from neosync.mgmt.v1alpha1.anonymization_pb2 import *
+from neosync.mgmt.v1alpha1.api_key_pb2 import *
+from neosync.mgmt.v1alpha1.connection_data_pb2 import *
+from neosync.mgmt.v1alpha1.connection_pb2 import *
+from neosync.mgmt.v1alpha1.job_pb2 import *
+from neosync.mgmt.v1alpha1.metrics_pb2 import *
+from neosync.mgmt.v1alpha1.transformer_pb2 import *
+from neosync.mgmt.v1alpha1.user_account_pb2 import *

--- a/python/src/neosync/__init__.pyi
+++ b/python/src/neosync/__init__.pyi
@@ -1,10 +1,10 @@
-from client import Neosync as Neosync
+from neosync.client import Neosync as Neosync
 
-from mgmt.v1alpha1.anonymization_pb2 import *
-from mgmt.v1alpha1.api_key_pb2 import *
-from mgmt.v1alpha1.connection_data_pb2 import *
-from mgmt.v1alpha1.connection_pb2 import *
-from mgmt.v1alpha1.job_pb2 import *
-from mgmt.v1alpha1.metrics_pb2 import *
-from mgmt.v1alpha1.transformer_pb2 import *
-from mgmt.v1alpha1.user_account_pb2 import *
+from neosync.mgmt.v1alpha1.anonymization_pb2 import *
+from neosync.mgmt.v1alpha1.api_key_pb2 import *
+from neosync.mgmt.v1alpha1.connection_data_pb2 import *
+from neosync.mgmt.v1alpha1.connection_pb2 import *
+from neosync.mgmt.v1alpha1.job_pb2 import *
+from neosync.mgmt.v1alpha1.metrics_pb2 import *
+from neosync.mgmt.v1alpha1.transformer_pb2 import *
+from neosync.mgmt.v1alpha1.user_account_pb2 import *


### PR DESCRIPTION
I debugged this by installing neosync from pypi and noticing that the type hints werent really working.

I edited the module locally until vscode was able to properly find the type hints.

For whatever stupid reason both of these work, but only this diff fixes the type hints.

Tested with this script:
```
from neosync import Neosync, GetJobsRequest

client = Neosync(
    api_url="localhost:8080",
    insecure=True,
)
print(client)

jobs = client.jobs.GetJobs(
    GetJobsRequest(account_id="c79eca6c-a9f8-40f4-9ca8-b0b8eb0d1a21")
)
print(jobs)

```