### PR TITLE
removes forceful stop channel in temporal activity

### DIFF
--- a/worker/pkg/workflows/datasync/activities/gen-benthos-configs/activity.go
+++ b/worker/pkg/workflows/datasync/activities/gen-benthos-configs/activity.go
@@ -70,8 +70,6 @@ func (a *Activity) GenerateBenthosConfigs(
 			select {
 			case <-time.After(1 * time.Second):
 				activity.RecordHeartbeat(ctx)
-			case <-activity.GetWorkerStopChannel(ctx):
-				return
 			case <-ctx.Done():
 				return
 			}

--- a/worker/pkg/workflows/datasync/activities/jobhooks-by-timing/activity.go
+++ b/worker/pkg/workflows/datasync/activities/jobhooks-by-timing/activity.go
@@ -73,8 +73,6 @@ func (a *Activity) RunJobHooksByTiming(
 			select {
 			case <-time.After(1 * time.Second):
 				activity.RecordHeartbeat(ctx)
-			case <-activity.GetWorkerStopChannel(ctx):
-				return
 			case <-ctx.Done():
 				return
 			}


### PR DESCRIPTION
This causes the activity to stop too quickly instead of giving the worker time to gracefully shut down by letting the activities complete.