### PR TITLE
Removes worker stop channel for sync activity

### DIFF
--- a/worker/pkg/workflows/datasync/activities/sync/activity.go
+++ b/worker/pkg/workflows/datasync/activities/sync/activity.go
@@ -135,20 +135,6 @@ func (a *Activity) Sync(ctx context.Context, req *SyncRequest, metadata *SyncMet
 				}
 				benthosStreamMutex.Unlock()
 				return
-			case <-activity.GetWorkerStopChannel(ctx):
-				logger.Info("received worker stop, cleaning up...")
-				resultChan <- fmt.Errorf("received worker stop signal")
-				benthosStreamMutex.Lock()
-				if benthosStream != nil {
-					// this must be here because stream.Run(ctx) doesn't seem to fully obey a canceled context when
-					// a sink is in an error state. We want to explicitly call stop here because the workflow has been canceled.
-					err := benthosStream.StopWithin(1 * time.Millisecond)
-					if err != nil {
-						logger.Error(err.Error())
-					}
-				}
-				benthosStreamMutex.Unlock()
-				return
 			case <-ctx.Done():
 				logger.Info("received context done, cleaning up...")
 				benthosStreamMutex.Lock()

--- a/worker/pkg/workflows/datasync/activities/sync/activity.go
+++ b/worker/pkg/workflows/datasync/activities/sync/activity.go
@@ -137,6 +137,8 @@ func (a *Activity) Sync(ctx context.Context, req *SyncRequest, metadata *SyncMet
 				return
 			case <-ctx.Done():
 				logger.Info("received context done, cleaning up...")
+				resultChan <- fmt.Errorf("received context done signal")
+
 				benthosStreamMutex.Lock()
 				if benthosStream != nil {
 					// this must be here because stream.Run(ctx) doesn't seem to fully obey a canceled context when


### PR DESCRIPTION
I missed this in the last PR

This allows the activity to gracefully finish when the worker has been signaled to shutdown instead of stopping immediately.
When it's actually time for a shutdown, the context will be canceled, which we are also handling.