### PR TITLE
Fix assignment to entry in nil map when providing attributes in mysql connection string

### DIFF
--- a/backend/pkg/dbconnect-config/mysql.go
+++ b/backend/pkg/dbconnect-config/mysql.go
@@ -93,9 +93,13 @@ func NewFromMysqlConnection(
 			}
 			cfg.MultiStatements = true
 			cfg.ParseTime = parseTime
-			for k, values := range uriConfig.Query() {
-				for _, value := range values {
-					cfg.Params[k] = value
+
+			if uriConfig.RawQuery != "" {
+				cfg.Params = make(map[string]string)
+				for k, values := range uriConfig.Query() {
+					for _, value := range values {
+						cfg.Params[k] = value
+					}
 				}
 			}
 			return &mysqlConnectConfig{dsn: cfg.FormatDSN(), user: cfg.User}, nil

--- a/backend/pkg/dbconnect-config/mysql_test.go
+++ b/backend/pkg/dbconnect-config/mysql_test.go
@@ -186,6 +186,28 @@ func Test_NewFromMysqlConnection(t *testing.T) {
 			)
 			assert.Equal(t, "test-user", actual.GetUser())
 		})
+		t.Run("ok_with_attributes", func(t *testing.T) {
+			actual, err := NewFromMysqlConnection(
+				&mgmtv1alpha1.ConnectionConfig_MysqlConfig{
+					MysqlConfig: &mgmtv1alpha1.MysqlConnectionConfig{
+						ConnectionConfig: &mgmtv1alpha1.MysqlConnectionConfig_Url{
+							Url: "mysql://test-user:testpass@localhost:3309/mydb?ssl-mode=preferred",
+						},
+					},
+				},
+				&testConnectionTimeout,
+				testutil.GetTestLogger(t),
+				false,
+			)
+			assert.NoError(t, err)
+			assert.NotNil(t, actual)
+			assert.Equal(
+				t,
+				"test-user:testpass@tcp(localhost:3309)/mydb?multiStatements=true&parseTime=true&timeout=5s&ssl-mode=preferred",
+				actual.String(),
+			)
+			assert.Equal(t, "test-user", actual.GetUser())
+		})
 		t.Run("ok_no_timeout", func(t *testing.T) {
 			actual, err := NewFromMysqlConnection(
 				&mgmtv1alpha1.ConnectionConfig_MysqlConfig{


### PR DESCRIPTION
I've added a test to prove the issue, and fixed it.

Fixes #3220 