### PR TITLE
Update the Datastream endpoint GCS connection to retrieve the most recent run ID from storage instead of Temporal.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,6 +8,7 @@ bin
 .env.stage.secrets
 .env.prod.secrets
 .env.*.secrets
+.env.*.local
 
 *.log
 

--- a/backend/internal/cmds/mgmt/serve/connect/cmd.go
+++ b/backend/internal/cmds/mgmt/serve/connect/cmd.go
@@ -598,7 +598,6 @@ func serve(ctx context.Context) error {
 		sqlmanager,
 		jobhookService,
 		userdataclient,
-		connectiondatabuilder,
 	)
 	api.Handle(
 		mgmtv1alpha1connect.NewJobServiceHandler(

--- a/backend/internal/cmds/mgmt/serve/connect/cmd.go
+++ b/backend/internal/cmds/mgmt/serve/connect/cmd.go
@@ -24,6 +24,7 @@ import (
 	connectionmanager "github.com/nucleuscloud/neosync/internal/connection-manager"
 	"github.com/nucleuscloud/neosync/internal/connectrpc/validate"
 	http_client "github.com/nucleuscloud/neosync/internal/http/client"
+	neosynctypes "github.com/nucleuscloud/neosync/internal/neosync-types"
 	pyroscope_env "github.com/nucleuscloud/neosync/internal/pyroscope"
 	"go.opentelemetry.io/otel/exporters/otlp/otlpmetric/otlpmetricgrpc"
 	"go.opentelemetry.io/otel/exporters/otlp/otlptrace/otlptracegrpc"
@@ -72,7 +73,6 @@ import (
 	"github.com/nucleuscloud/neosync/internal/ee/rbac"
 	"github.com/nucleuscloud/neosync/internal/ee/rbac/enforcer"
 	neomigrate "github.com/nucleuscloud/neosync/internal/migrate"
-	neosynctypes "github.com/nucleuscloud/neosync/internal/neosync-types"
 	"github.com/nucleuscloud/neosync/internal/neosyncdb"
 	neosyncotel "github.com/nucleuscloud/neosync/internal/otel"
 	"github.com/nucleuscloud/neosync/internal/temporal/clientmanager"
@@ -534,6 +534,18 @@ func serve(ctx context.Context) error {
 		sql_manager.WithConnectionManagerOpts(connectionmanager.WithCloseOnRelease()),
 	)
 	mongoconnector := mongoconnect.NewConnector()
+	neosynctyperegistry := neosynctypes.NewTypeRegistry(slogger)
+	gcpmanager := neosync_gcp.NewManager()
+	connectiondatabuilder := connectiondata.NewConnectionDataBuilder(
+		sqlConnector,
+		sqlmanager,
+		pgquerier,
+		mysqlquerier,
+		awsManager,
+		gcpmanager,
+		mongoconnector,
+		neosynctyperegistry,
+	)
 
 	connectionService := v1alpha1_connectionservice.New(
 		&v1alpha1_connectionservice.Config{IsNeosyncCloud: ncloudlicense.IsValid()},
@@ -586,6 +598,7 @@ func serve(ctx context.Context) error {
 		sqlmanager,
 		jobhookService,
 		userdataclient,
+		connectiondatabuilder,
 	)
 	api.Handle(
 		mgmtv1alpha1connect.NewJobServiceHandler(
@@ -650,19 +663,6 @@ func serve(ctx context.Context) error {
 		),
 	)
 
-	neosynctyperegistry := neosynctypes.NewTypeRegistry(slogger)
-	gcpmanager := neosync_gcp.NewManager()
-	connectiondatabuilder := connectiondata.NewConnectionDataBuilder(
-		sqlConnector,
-		sqlmanager,
-		pgquerier,
-		mysqlquerier,
-		awsManager,
-		gcpmanager,
-		mongoconnector,
-		neosynctyperegistry,
-		jobService,
-	)
 	connectionDataService := v1alpha1_connectiondataservice.New(
 		&v1alpha1_connectiondataservice.Config{},
 		connectionService,

--- a/backend/internal/connectiondata/connectiondata.go
+++ b/backend/internal/connectiondata/connectiondata.go
@@ -9,7 +9,6 @@ import (
 	mysql_queries "github.com/nucleuscloud/neosync/backend/gen/go/db/dbschemas/mysql"
 	pg_queries "github.com/nucleuscloud/neosync/backend/gen/go/db/dbschemas/postgresql"
 	mgmtv1alpha1 "github.com/nucleuscloud/neosync/backend/gen/go/protos/mgmt/v1alpha1"
-	"github.com/nucleuscloud/neosync/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect"
 	neosync_gcp "github.com/nucleuscloud/neosync/backend/internal/gcp"
 	"github.com/nucleuscloud/neosync/backend/pkg/mongoconnect"
 	"github.com/nucleuscloud/neosync/backend/pkg/sqlconnect"
@@ -45,7 +44,6 @@ type DefaultConnectionDataBuilder struct {
 	gcpmanager          neosync_gcp.ManagerInterface
 	mongoconnector      mongoconnect.Interface
 	neosynctyperegistry neosynctypes.NeosyncTypeRegistry
-	jobservice          mgmtv1alpha1connect.JobServiceHandler // TODO: remove this dependency
 }
 
 func NewConnectionDataBuilder(
@@ -57,7 +55,6 @@ func NewConnectionDataBuilder(
 	gcpmanager neosync_gcp.ManagerInterface,
 	mongoconnector mongoconnect.Interface,
 	neosynctyperegistry neosynctypes.NeosyncTypeRegistry,
-	jobservice mgmtv1alpha1connect.JobServiceHandler,
 ) ConnectionDataBuilder {
 	return &DefaultConnectionDataBuilder{
 		sqlconnector:        sqlconnector,
@@ -68,7 +65,6 @@ func NewConnectionDataBuilder(
 		gcpmanager:          gcpmanager,
 		mongoconnector:      mongoconnector,
 		neosynctyperegistry: neosynctyperegistry,
-		jobservice:          jobservice,
 	}
 }
 
@@ -83,7 +79,7 @@ func (b *DefaultConnectionDataBuilder) NewDataConnection(
 	case *mgmtv1alpha1.ConnectionConfig_AwsS3Config:
 		return NewAwsS3ConnectionDataService(logger, b.awsmanager, b.neosynctyperegistry, connection), nil
 	case *mgmtv1alpha1.ConnectionConfig_GcpCloudstorageConfig:
-		return NewGcpConnectionDataService(logger, b.gcpmanager, connection, b.jobservice), nil
+		return NewGcpConnectionDataService(logger, b.gcpmanager, connection), nil
 	case *mgmtv1alpha1.ConnectionConfig_DynamodbConfig:
 		return NewAwsDynamodbConnectionDataService(logger, b.awsmanager, connection), nil
 	case *mgmtv1alpha1.ConnectionConfig_MongoConfig:

--- a/backend/pkg/integration-test/mux.go
+++ b/backend/pkg/integration-test/mux.go
@@ -235,7 +235,6 @@ func (s *NeosyncApiTestClient) setupMux(
 		gcpmanager,
 		mongoconnector,
 		neosynctyperegistry,
-		jobService,
 	)
 	connectionDataService := v1alpha1_connectiondataservice.New(
 		&v1alpha1_connectiondataservice.Config{},

--- a/backend/services/mgmt/v1alpha1/job-service/service.go
+++ b/backend/services/mgmt/v1alpha1/job-service/service.go
@@ -2,7 +2,6 @@ package v1alpha1_jobservice
 
 import (
 	"github.com/nucleuscloud/neosync/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect"
-	"github.com/nucleuscloud/neosync/backend/internal/connectiondata"
 	jobhooks "github.com/nucleuscloud/neosync/backend/internal/ee/hooks/jobs"
 	"github.com/nucleuscloud/neosync/backend/internal/userdata"
 	sql_manager "github.com/nucleuscloud/neosync/backend/pkg/sqlmanager"
@@ -19,8 +18,7 @@ type Service struct {
 
 	temporalmgr clientmanager.Interface
 
-	hookService           jobhooks.Interface
-	connectiondatabuilder connectiondata.ConnectionDataBuilder
+	hookService jobhooks.Interface
 }
 
 type RunLogType string
@@ -65,16 +63,14 @@ func New(
 	sqlmanager sql_manager.SqlManagerClient,
 	jobhookService jobhooks.Interface,
 	userdataclient userdata.Interface,
-	connectiondatabuilder connectiondata.ConnectionDataBuilder,
 ) *Service {
 	return &Service{
-		cfg:                   cfg,
-		db:                    db,
-		temporalmgr:           temporalWfManager,
-		connectionService:     connectionService,
-		sqlmanager:            sqlmanager,
-		hookService:           jobhookService,
-		userdataclient:        userdataclient,
-		connectiondatabuilder: connectiondatabuilder,
+		cfg:               cfg,
+		db:                db,
+		temporalmgr:       temporalWfManager,
+		connectionService: connectionService,
+		sqlmanager:        sqlmanager,
+		hookService:       jobhookService,
+		userdataclient:    userdataclient,
 	}
 }

--- a/backend/services/mgmt/v1alpha1/job-service/service.go
+++ b/backend/services/mgmt/v1alpha1/job-service/service.go
@@ -2,6 +2,7 @@ package v1alpha1_jobservice
 
 import (
 	"github.com/nucleuscloud/neosync/backend/gen/go/protos/mgmt/v1alpha1/mgmtv1alpha1connect"
+	"github.com/nucleuscloud/neosync/backend/internal/connectiondata"
 	jobhooks "github.com/nucleuscloud/neosync/backend/internal/ee/hooks/jobs"
 	"github.com/nucleuscloud/neosync/backend/internal/userdata"
 	sql_manager "github.com/nucleuscloud/neosync/backend/pkg/sqlmanager"
@@ -18,7 +19,8 @@ type Service struct {
 
 	temporalmgr clientmanager.Interface
 
-	hookService jobhooks.Interface
+	hookService           jobhooks.Interface
+	connectiondatabuilder connectiondata.ConnectionDataBuilder
 }
 
 type RunLogType string
@@ -63,14 +65,16 @@ func New(
 	sqlmanager sql_manager.SqlManagerClient,
 	jobhookService jobhooks.Interface,
 	userdataclient userdata.Interface,
+	connectiondatabuilder connectiondata.ConnectionDataBuilder,
 ) *Service {
 	return &Service{
-		cfg:               cfg,
-		db:                db,
-		temporalmgr:       temporalWfManager,
-		connectionService: connectionService,
-		sqlmanager:        sqlmanager,
-		hookService:       jobhookService,
-		userdataclient:    userdataclient,
+		cfg:                   cfg,
+		db:                    db,
+		temporalmgr:           temporalWfManager,
+		connectionService:     connectionService,
+		sqlmanager:            sqlmanager,
+		hookService:           jobhookService,
+		userdataclient:        userdataclient,
+		connectiondatabuilder: connectiondatabuilder,
 	}
 }

--- a/internal/benthos/benthos-builder/builders/gcp-cloud-storage.go
+++ b/internal/benthos/benthos-builder/builders/gcp-cloud-storage.go
@@ -29,7 +29,7 @@ func (b *gcpCloudStorageSyncBuilder) BuildDestinationConfig(ctx context.Context,
 	if benthosConfig.RunType == tabledependency.RunTypeUpdate {
 		return config, nil
 	}
-	destinationOpts := params.DestinationOpts.GetAwsS3Options()
+	destinationOpts := params.DestinationOpts.GetGcpCloudstorageOptions()
 	gcpCloudStorageConfig := params.DestConnection.GetConnectionConfig().GetGcpCloudstorageConfig()
 
 	if destinationOpts == nil {


### PR DESCRIPTION
this is tech debt that removes jobservice as dependency to connection data builder which I need to use in the job service