### PR TITLE
adds fix that filters out duplicate serials

### DIFF
--- a/backend/gen/go/db/dbschemas/postgresql/system.sql.go
+++ b/backend/gen/go/db/dbschemas/postgresql/system.sql.go
@@ -454,7 +454,7 @@ WITH linked_to_serial AS (
     JOIN
         pg_catalog.pg_attrdef ad ON dep.refobjid = ad.adrelid AND dep.refobjsubid = ad.adnum
     WHERE
-        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%'
+        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%' AND cl.relkind = 'S'
 ),
 column_defaults AS (
     SELECT
@@ -652,7 +652,7 @@ WITH linked_to_serial AS (
     JOIN
         pg_catalog.pg_attrdef ad ON dep.refobjid = ad.adrelid AND dep.refobjsubid = ad.adnum
     WHERE
-        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%'
+        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%' AND cl.relkind = 'S'
 ),
 column_defaults AS (
     SELECT

--- a/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
@@ -16,7 +16,7 @@ WITH linked_to_serial AS (
     JOIN
         pg_catalog.pg_attrdef ad ON dep.refobjid = ad.adrelid AND dep.refobjsubid = ad.adnum
     WHERE
-        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%'
+        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%' AND cl.relkind = 'S'
 ),
 column_defaults AS (
     SELECT
@@ -146,7 +146,7 @@ WITH linked_to_serial AS (
     JOIN
         pg_catalog.pg_attrdef ad ON dep.refobjid = ad.adrelid AND dep.refobjsubid = ad.adnum
     WHERE
-        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%'
+        pg_catalog.pg_get_expr(ad.adbin, ad.adrelid) LIKE 'nextval%' AND cl.relkind = 'S'
 ),
 column_defaults AS (
     SELECT


### PR DESCRIPTION
this was causing a composite index to be returned as a duplicate value in the `linked_to_serial` query which was causing the `id` column to appear multiple times.