### PR TITLE
tweaks pg index query, changes schema init ordering

### DIFF
--- a/backend/gen/go/db/dbschemas/postgresql/system.sql.go
+++ b/backend/gen/go/db/dbschemas/postgresql/system.sql.go
@@ -887,8 +887,7 @@ FROM
     JOIN pg_catalog.pg_namespace ns ON t.relnamespace = ns.oid
 LEFT JOIN pg_catalog.pg_constraint con ON con.conindid = ix.indexrelid
 WHERE
-    con.conindid IS NULL -- Excludes indexes created as part of constraints
-    AND (ns.nspname || '.' || t.relname) = ANY($1::TEXT[])
+    (ns.nspname || '.' || t.relname) = ANY($1::TEXT[])
 GROUP BY
     ns.nspname, t.relname, i.relname, ix.indexrelid
 ORDER BY

--- a/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
+++ b/backend/pkg/dbschemas/sql/postgresql/queries/system.sql
@@ -411,8 +411,7 @@ FROM
     JOIN pg_catalog.pg_namespace ns ON t.relnamespace = ns.oid
 LEFT JOIN pg_catalog.pg_constraint con ON con.conindid = ix.indexrelid
 WHERE
-    con.conindid IS NULL -- Excludes indexes created as part of constraints
-    AND (ns.nspname || '.' || t.relname) = ANY(sqlc.arg('schematables')::TEXT[])
+    (ns.nspname || '.' || t.relname) = ANY(sqlc.arg('schematables')::TEXT[])
 GROUP BY
     ns.nspname, t.relname, i.relname, ix.indexrelid
 ORDER BY

--- a/backend/pkg/sqlmanager/mysql/mysql-manager.go
+++ b/backend/pkg/sqlmanager/mysql/mysql-manager.go
@@ -713,8 +713,8 @@ func (m *MysqlManager) GetSchemaInitStatements(
 		{Label: "data types"},
 		{Label: "create table", Statements: createTables},
 		{Label: "non-fk alter table", Statements: nonFkAlterStmts},
-		{Label: "fk alter table", Statements: fkAlterStmts},
 		{Label: "table index", Statements: idxStmts},
+		{Label: "fk alter table", Statements: fkAlterStmts},
 		{Label: "table triggers", Statements: tableTriggerStmts},
 	}, nil
 }

--- a/backend/pkg/sqlmanager/postgres/postgres-manager.go
+++ b/backend/pkg/sqlmanager/postgres/postgres-manager.go
@@ -632,8 +632,8 @@ func (p *PostgresManager) GetSchemaInitStatements(
 		{Label: "data types", Statements: dataTypeStmts},
 		{Label: "create table", Statements: createTables},
 		{Label: "non-fk alter table", Statements: nonFkAlterStmts},
-		{Label: "fk alter table", Statements: fkAlterStmts},
 		{Label: "table index", Statements: idxStmts},
+		{Label: "fk alter table", Statements: fkAlterStmts},
 		{Label: "table triggers", Statements: tableTriggerStmts},
 	}, nil
 }

--- a/internal/ee/mssql-manager/ee-mssql-manager.go
+++ b/internal/ee/mssql-manager/ee-mssql-manager.go
@@ -227,8 +227,8 @@ func (m *Manager) GetSchemaInitStatements(ctx context.Context, tables []*sqlmana
 		{Label: "create table", Statements: createTables},
 		{Label: ViewsFunctionsLabel, Statements: viewAndFuncStmts},
 		{Label: "non-fk alter table", Statements: nonFkAlterStmts},
-		{Label: "fk alter table", Statements: fkAlterStmts},
 		{Label: TableIndexLabel, Statements: idxStmts},
+		{Label: "fk alter table", Statements: fkAlterStmts},
 		{Label: "table triggers", Statements: tableTriggerStmts},
 	}, nil
 }

--- a/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder_test.go
+++ b/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder_test.go
@@ -671,8 +671,8 @@ func Test_InitStatementBuilder_Pg_InitSchema(t *testing.T) {
 		{Label: "data types", Statements: []string{}},
 		{Label: "create table", Statements: []string{"test-create-statement"}},
 		{Label: "non-fk alter table", Statements: []string{"test-pk-statement"}},
-		{Label: "fk alter table", Statements: []string{"test-fk-statement"}},
 		{Label: "table index", Statements: []string{"test-idx-statement"}},
+		{Label: "fk alter table", Statements: []string{"test-fk-statement"}},
 		{Label: "table triggers", Statements: []string{"test-trigger-statement"}},
 	}, nil)
 


### PR DESCRIPTION
Swaps indexes to run before foreign keys due to unique indexes.

Tweaks the postgres query to remove extra indices being filtered. They are idempotent anyways.