### PR TITLE
fixes loki query to include child workflows

### DIFF
--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -782,7 +782,7 @@ func logLevelToString(loglevel mgmtv1alpha1.LogLevel) string {
 
 func buildLokiQuery(lokiLables string, keep []string, workflowId string, loglevels []string) string {
 	query := fmt.Sprintf("{%s} | json", lokiLables)
-	query = fmt.Sprintf("%s | WorkflowID=%q", query, workflowId)
+	query = fmt.Sprintf("%s | JobRunId=%q", query, workflowId)
 
 	if len(loglevels) > 0 {
 		query = fmt.Sprintf("%s | level=~%q", query, strings.Join(loglevels, "|"))


### PR DESCRIPTION
With the update to use child workflows, the loki log query needs to use the JobRunId instead of WorkflowId to get all of the children.