### PR TITLE
[MIGRATION] fixes job hook name unique constraint

### DIFF
--- a/backend/sql/postgresql/schema/20250221001204_job-hooks-name-unique-update.down.sql
+++ b/backend/sql/postgresql/schema/20250221001204_job-hooks-name-unique-update.down.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS job_hooks_name_unique;
+
+CREATE UNIQUE INDEX job_hooks_name_unique ON job_hooks (name);

--- a/backend/sql/postgresql/schema/20250221001204_job-hooks-name-unique-update.up.sql
+++ b/backend/sql/postgresql/schema/20250221001204_job-hooks-name-unique-update.up.sql
@@ -1,0 +1,3 @@
+DROP INDEX IF EXISTS job_hooks_name_unique;
+
+CREATE UNIQUE INDEX job_hooks_name_unique ON job_hooks (name, job_id);


### PR DESCRIPTION
Accidentally made job hook names globally unique (across accounts!) - not desirable. 
This fixes the constraint to be bound to the job