### PR TITLE
fixes job run events message on frontend not surfacing enough details

### DIFF
--- a/backend/internal/dtomaps/job-runs.go
+++ b/backend/internal/dtomaps/job-runs.go
@@ -63,8 +63,12 @@ func ToJobRunEventTaskDto(event *history.HistoryEvent, taskError *mgmtv1alpha1.J
 }
 
 func ToJobRunEventTaskErrorDto(failure *temporalfailure.Failure, retryState enums.RetryState) *mgmtv1alpha1.JobRunEventTaskError {
+	msg := failure.Message
+	if failure.GetCause() != nil {
+		msg = fmt.Sprintf("%s: %s", failure.GetMessage(), failure.GetCause().GetMessage())
+	}
 	return &mgmtv1alpha1.JobRunEventTaskError{
-		Message:    failure.Message,
+		Message:    msg,
 		RetryState: retryState.String(),
 	}
 }


### PR DESCRIPTION
![image](https://github.com/user-attachments/assets/3289ce39-4fc7-4909-9753-6ab80b918069)


to

![image](https://github.com/user-attachments/assets/2e73986c-b989-47a5-b259-e75ba351fad0)
