### PR TITLE
NEOS-1762: reworks account provider to handle selected account more effectively

### DIFF
--- a/frontend/apps/web/app/(mgmt)/[account]/settings/members/components/MemberTable.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/settings/members/components/MemberTable.tsx
@@ -315,6 +315,8 @@ function DataTableRowActions({
   const { mutateAsync } = useMutation(
     UserAccountService.method.removeTeamAccountMember
   );
+  const { data: config } = useGetSystemAppConfig();
+  const isRbacEnabled = config?.isRbacEnabled ?? false;
 
   async function onRemove(): Promise<void> {
     if (!account?.id) {
@@ -346,18 +348,20 @@ function DataTableRowActions({
         </Button>
       </DropdownMenuTrigger>
       <DropdownMenuContent>
-        <UpdateMemberRoleDialog
-          member={member}
-          onUpdated={() => onUpdated()}
-          dialogButton={
-            <DropdownMenuItem
-              className="cursor-pointer"
-              onSelect={(e) => e.preventDefault()}
-            >
-              Update Role
-            </DropdownMenuItem>
-          }
-        />
+        {isRbacEnabled && (
+          <UpdateMemberRoleDialog
+            member={member}
+            onUpdated={() => onUpdated()}
+            dialogButton={
+              <DropdownMenuItem
+                className="cursor-pointer"
+                onSelect={(e) => e.preventDefault()}
+              >
+                Update Role
+              </DropdownMenuItem>
+            }
+          />
+        )}
         <DeleteConfirmationDialog
           trigger={
             <DropdownMenuItem

--- a/frontend/apps/web/app/invite/page.tsx
+++ b/frontend/apps/web/app/invite/page.tsx
@@ -56,6 +56,7 @@ export default function InvitePage(): ReactElement {
       acceptTeamInvite({ token })
         .then((res) => {
           if (res.account) {
+            toast.success('Invite accepted');
             setAccount(res.account);
             mutateUserAccount();
             router.replace(`/${res.account.name}`);

--- a/frontend/apps/web/components/providers/account-provider.tsx
+++ b/frontend/apps/web/components/providers/account-provider.tsx
@@ -36,10 +36,9 @@ const STORAGE_ACCOUNT_KEY = 'account';
 
 export default function AccountProvider(props: Props): ReactElement {
   const { children } = props;
-  const accountName = useGetAccountName();
   const { account } = useParams();
+  const accountName = useGetAccountName();
 
-  // Use both session and local storage
   const [, setLastSelectedAccountSession] = useSessionStorage<
     string | undefined
   >(STORAGE_ACCOUNT_KEY, undefined);
@@ -132,7 +131,7 @@ export default function AccountProvider(props: Props): ReactElement {
 
 function useGetAccountName(): string {
   const { account } = useParams();
-  console.log('account param value', account);
+
   const [sessionAccount] = useSessionStorage<string | undefined>(
     STORAGE_ACCOUNT_KEY,
     undefined

--- a/frontend/apps/web/components/providers/account-provider.tsx
+++ b/frontend/apps/web/components/providers/account-provider.tsx
@@ -1,4 +1,5 @@
 'use client';
+import { useNeosyncUser } from '@/libs/hooks/useNeosyncUser';
 import { getSingleOrUndefined } from '@/libs/utils';
 import { useQuery } from '@connectrpc/connect-query';
 import { UserAccount, UserAccountService } from '@neosync/sdk';
@@ -11,7 +12,7 @@ import {
   useEffect,
   useState,
 } from 'react';
-import { useLocalStorage } from 'usehooks-ts';
+import { useLocalStorage, useSessionStorage } from 'usehooks-ts';
 
 interface AccountContextType {
   account: UserAccount | undefined;
@@ -35,18 +36,28 @@ const STORAGE_ACCOUNT_KEY = 'account';
 
 export default function AccountProvider(props: Props): ReactElement {
   const { children } = props;
-  const { account } = useParams();
   const accountName = useGetAccountName();
-  const [, setLastSelectedAccount] = useLocalStorage(
+
+  // Use both session and local storage
+  const [, setLastSelectedAccountSession] = useSessionStorage(
     STORAGE_ACCOUNT_KEY,
     accountName ?? DEFAULT_ACCOUNT_NAME
   );
+  const [, setLastSelectedAccountLocal] = useLocalStorage(
+    STORAGE_ACCOUNT_KEY,
+    accountName ?? DEFAULT_ACCOUNT_NAME
+  );
+
+  const { isLoading: isUserLoading } = useNeosyncUser();
 
   const {
     data: accountsResponse,
     isLoading,
     refetch: mutate,
-  } = useQuery(UserAccountService.method.getUserAccounts);
+  } = useQuery(UserAccountService.method.getUserAccounts, undefined, {
+    enabled: !isUserLoading,
+  });
+
   const router = useRouter();
 
   const [userAccount, setUserAccount] = useState<UserAccount | undefined>(
@@ -68,14 +79,13 @@ export default function AccountProvider(props: Props): ReactElement {
     }
     if (foundAccount) {
       setUserAccount(foundAccount);
-      setLastSelectedAccount(foundAccount.name);
-      const accountParam = getSingleOrUndefined(account);
-      if (!accountParam || accountParam !== foundAccount.name) {
-        router.push(`/${foundAccount.name}/jobs`);
-      }
+      // Update both storages
+      setLastSelectedAccountSession(foundAccount.name);
+      setLastSelectedAccountLocal(foundAccount.name);
     } else if (accountName !== DEFAULT_ACCOUNT_NAME) {
-      setLastSelectedAccount(DEFAULT_ACCOUNT_NAME);
-      router.push(`/${DEFAULT_ACCOUNT_NAME}/jobs`);
+      // Update both storages
+      setLastSelectedAccountSession(DEFAULT_ACCOUNT_NAME);
+      setLastSelectedAccountLocal(DEFAULT_ACCOUNT_NAME);
     }
   }, [
     userAccount?.id,
@@ -88,10 +98,9 @@ export default function AccountProvider(props: Props): ReactElement {
 
   function setAccount(userAccount: UserAccount): void {
     if (userAccount.name !== accountName) {
-      // this order matters. Otherwise if we push first,
-      // when it routes to the page, there is no account param and it defaults to personal /shrug
-      // by setting this here, it finds the last selected account and is able to effectively route to the correct spot.
-      setLastSelectedAccount(userAccount.name);
+      // Update both storages before routing
+      setLastSelectedAccountSession(userAccount.name);
+      setLastSelectedAccountLocal(userAccount.name);
       setUserAccount(userAccount);
       router.push(`/${userAccount.name}`);
     }
@@ -113,7 +122,12 @@ export default function AccountProvider(props: Props): ReactElement {
 
 function useGetAccountName(): string {
   const { account } = useParams();
-  const [storedAccount] = useLocalStorage(
+  // Check session storage first, then fall back to local storage
+  const [sessionAccount] = useSessionStorage(
+    STORAGE_ACCOUNT_KEY,
+    account ?? DEFAULT_ACCOUNT_NAME
+  );
+  const [localAccount] = useLocalStorage(
     STORAGE_ACCOUNT_KEY,
     account ?? DEFAULT_ACCOUNT_NAME
   );
@@ -122,9 +136,14 @@ function useGetAccountName(): string {
   if (accountParam) {
     return accountParam;
   }
-  const singleStoredAccount = getSingleOrUndefined(storedAccount);
-  if (singleStoredAccount) {
-    return singleStoredAccount;
+  // Prefer session storage account over local storage
+  const singleSessionAccount = getSingleOrUndefined(sessionAccount);
+  if (singleSessionAccount) {
+    return singleSessionAccount;
+  }
+  const singleLocalAccount = getSingleOrUndefined(localAccount);
+  if (singleLocalAccount) {
+    return singleLocalAccount;
   }
   return DEFAULT_ACCOUNT_NAME;
 }

--- a/frontend/apps/web/components/providers/account-provider.tsx
+++ b/frontend/apps/web/components/providers/account-provider.tsx
@@ -37,6 +37,7 @@ const STORAGE_ACCOUNT_KEY = 'account';
 export default function AccountProvider(props: Props): ReactElement {
   const { children } = props;
   const accountName = useGetAccountName();
+  const { account } = useParams();
 
   // Use both session and local storage
   const [, setLastSelectedAccountSession] = useSessionStorage<
@@ -84,10 +85,16 @@ export default function AccountProvider(props: Props): ReactElement {
       // Update both storages
       setLastSelectedAccountSession(foundAccount.name);
       setLastSelectedAccountLocal(foundAccount.name);
+      const accountParam = getSingleOrUndefined(account);
+      // only want to push here if we actually have an account param. Otherwise we might push on a page like /invite or /hooks/slack
+      if (!!accountParam && accountParam !== foundAccount.name) {
+        router.push(`/${foundAccount.name}/jobs`);
+      }
     } else if (accountName !== DEFAULT_ACCOUNT_NAME) {
       // Update both storages
       setLastSelectedAccountSession(DEFAULT_ACCOUNT_NAME);
       setLastSelectedAccountLocal(DEFAULT_ACCOUNT_NAME);
+      router.push(`/${DEFAULT_ACCOUNT_NAME}/jobs`);
     }
   }, [
     userAccount?.id,
@@ -125,6 +132,7 @@ export default function AccountProvider(props: Props): ReactElement {
 
 function useGetAccountName(): string {
   const { account } = useParams();
+  console.log('account param value', account);
   const [sessionAccount] = useSessionStorage<string | undefined>(
     STORAGE_ACCOUNT_KEY,
     undefined

--- a/frontend/apps/web/components/site-header/AccountStatusHandler.tsx
+++ b/frontend/apps/web/components/site-header/AccountStatusHandler.tsx
@@ -49,7 +49,6 @@ export function AccountStatusHandler(props: Props) {
       )}
       <Upgrade
         calendlyLink={systemAppConfig.calendlyUpgradeLink}
-        isNeosyncCloud={systemAppConfig.isNeosyncCloud}
         isAccountStatusValidResp={data}
         isLoading={isLoading}
       />

--- a/frontend/apps/web/components/site-header/Upgrade.tsx
+++ b/frontend/apps/web/components/site-header/Upgrade.tsx
@@ -1,6 +1,11 @@
 'use client';
 import { Alert, AlertDescription, AlertTitle } from '@/components/ui/alert';
-import { AccountStatus, IsAccountStatusValidResponse } from '@neosync/sdk';
+import { useQuery } from '@connectrpc/connect-query';
+import {
+  AccountStatus,
+  IsAccountStatusValidResponse,
+  UserAccountService,
+} from '@neosync/sdk';
 import { ArrowUpIcon, ExclamationTriangleIcon } from '@radix-ui/react-icons';
 import { ReactElement, useState } from 'react';
 import { IoAlertCircleOutline } from 'react-icons/io5';
@@ -20,17 +25,18 @@ import UpgradeButton from './UpgradeButton';
 
 interface UpgradeProps {
   calendlyLink: string;
-  isNeosyncCloud: boolean;
   isAccountStatusValidResp: IsAccountStatusValidResponse | undefined;
   isLoading: boolean;
 }
 
 export default function Upgrade(props: UpgradeProps): ReactElement | null {
-  const { calendlyLink, isNeosyncCloud, isAccountStatusValidResp, isLoading } =
-    props;
+  const { calendlyLink, isAccountStatusValidResp, isLoading } = props;
   const { account } = useAccount();
+  const { data: systemInfo } = useQuery(
+    UserAccountService.method.getSystemInformation
+  );
   // always surface the upgrade button for non-neosynccloud users
-  if (!isNeosyncCloud) {
+  if (!systemInfo?.license?.isValid && !systemInfo?.license?.isNeosyncCloud) {
     return <UpgradeButton href={calendlyLink} target="_blank" />;
   }
 


### PR DESCRIPTION
- fixes upgrade button to not show for EE licensed installations
- adds local/session storage for account provider to handle tabs better
- slack and invite page no longer redirect away because there is no account in the url
- added more conditionals useAccount so that it ensures the user exists prior to retrieving the accounts.
- fixes bug on members page to conditionally show the update role only if rbac is enabled.