### PR TITLE
changes account hooks to not halt on first failure

### DIFF
--- a/worker/pkg/workflows/ee/account_hooks/workflow/workflow.go
+++ b/worker/pkg/workflows/ee/account_hooks/workflow/workflow.go
@@ -1,6 +1,7 @@
 package accounthook_workflow
 
 import (
+	"errors"
 	"fmt"
 	"time"
 
@@ -60,11 +61,15 @@ func ProcessAccountHook(wfctx workflow.Context, req *ProcessAccountHookRequest) 
 		)
 	}
 
+	errs := []error{}
 	for _, future := range futures {
 		var execResp *execute_hook_activity.ExecuteHookResponse
 		if err := future.Get(wfctx, &execResp); err != nil {
-			return nil, fmt.Errorf("error executing hook: %w", err)
+			errs = append(errs, fmt.Errorf("error executing hook: %w", err))
 		}
+	}
+	if len(errs) > 0 {
+		return nil, fmt.Errorf("error executing hooks: %w", errors.Join(errs...))
 	}
 
 	return &ProcessAccountHookResponse{}, nil

--- a/worker/pkg/workflows/ee/account_hooks/workflow/workflow_test.go
+++ b/worker/pkg/workflows/ee/account_hooks/workflow/workflow_test.go
@@ -1,6 +1,7 @@
 package accounthook_workflow
 
 import (
+	"errors"
 	"testing"
 
 	accounthook_events "github.com/nucleuscloud/neosync/internal/ee/events"
@@ -40,5 +41,30 @@ func Test_ProcessAccountHook(t *testing.T) {
 	require.NoError(t, err)
 	require.Equal(t, &ProcessAccountHookResponse{}, result)
 
+	env.AssertExpectations(t)
+}
+
+func Test_ProcessAccountHook_Error(t *testing.T) {
+	var ts testsuite.WorkflowTestSuite
+	env := ts.NewTestWorkflowEnvironment()
+
+	var hooksByEventActivity *hooks_by_event_activity.Activity
+	env.OnActivity(hooksByEventActivity.GetAccountHooksByEvent, mock.Anything, mock.Anything).
+		Return(&hooks_by_event_activity.RunHooksByEventResponse{
+			HookIds: []string{"hook1", "hook2"},
+		}, nil).Once()
+
+	var executeHookActivity *execute_hook_activity.Activity
+	env.OnActivity(executeHookActivity.ExecuteAccountHook, mock.Anything, mock.Anything).
+		Return(nil, errors.New("error"))
+
+	env.RegisterWorkflow(ProcessAccountHook)
+
+	env.ExecuteWorkflow(ProcessAccountHook, &ProcessAccountHookRequest{
+		Event: accounthook_events.NewEvent_JobRunCreated("123", "456", "789"),
+	})
+
+	require.True(t, env.IsWorkflowCompleted())
+	require.Error(t, env.GetWorkflowError())
 	env.AssertExpectations(t)
 }

--- a/worker/pkg/workflows/ee/account_hooks/workflow/workflow_test.go
+++ b/worker/pkg/workflows/ee/account_hooks/workflow/workflow_test.go
@@ -2,6 +2,7 @@ package accounthook_workflow
 
 import (
 	"errors"
+	"strings"
 	"testing"
 
 	accounthook_events "github.com/nucleuscloud/neosync/internal/ee/events"
@@ -64,7 +65,13 @@ func Test_ProcessAccountHook_Error(t *testing.T) {
 		Event: accounthook_events.NewEvent_JobRunCreated("123", "456", "789"),
 	})
 
-	require.True(t, env.IsWorkflowCompleted())
-	require.Error(t, env.GetWorkflowError())
 	env.AssertExpectations(t)
+
+	require.True(t, env.IsWorkflowCompleted())
+
+	workflowErr := env.GetWorkflowError()
+	require.Error(t, workflowErr)
+	require.Contains(t, workflowErr.Error(), "error executing hook:")
+	// The way temporal wraps these they show up more than the number of hooks
+	require.GreaterOrEqual(t, strings.Count(workflowErr.Error(), "error executing hook:"), 2)
 }


### PR DESCRIPTION
for multiple account hooks this would be bad if one of them is not working correctly.

This way each one gets to run to its fullest and we return all of the hook failures as a single joined error message.