### PR TITLE
Fixes postgres sequence reset

### DIFF
--- a/backend/pkg/sqlmanager/postgres/postgres-manager.go
+++ b/backend/pkg/sqlmanager/postgres/postgres-manager.go
@@ -1063,8 +1063,8 @@ func BuildPgInsertIdentityAlwaysSql(
 	return sqlSplit[0] + ") OVERRIDING SYSTEM VALUE VALUES(" + sqlSplit[1]
 }
 
-func BuildPgResetSequenceSql(sequenceName string) string {
-	return fmt.Sprintf("ALTER SEQUENCE %q RESTART;", sequenceName)
+func BuildPgResetSequenceSql(schema, sequenceName string) string {
+	return fmt.Sprintf("ALTER SEQUENCE %q.%q RESTART;", schema, sequenceName)
 }
 
 func GetPostgresColumnOverrideAndResetProperties(columnInfo *sqlmanager_shared.DatabaseSchemaRow) (needsOverride, needsReset bool) {

--- a/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder.go
+++ b/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder.go
@@ -240,17 +240,15 @@ func (b *initStatementBuilder) RunSqlInitTableStatements(
 					schemaTableMap[schema] = append(schemaTableMap[schema], table)
 				}
 
-				resetSeqStmts := []string{}
 				for schema, tables := range schemaTableMap {
-					sequences, err := sourcedb.Db().GetSequencesByTables(ctx, schema, tables)
+					sequences, err := destdb.Db().GetSequencesByTables(ctx, schema, tables)
 					if err != nil {
 						return nil, err
 					}
+					resetSeqStmts := []string{}
 					for _, seq := range sequences {
-						resetSeqStmts = append(resetSeqStmts, sqlmanager_postgres.BuildPgResetSequenceSql(seq.Name))
+						resetSeqStmts = append(resetSeqStmts, sqlmanager_postgres.BuildPgResetSequenceSql(seq.Schema, seq.Name))
 					}
-				}
-				if len(resetSeqStmts) > 0 {
 					err = destdb.Db().BatchExec(ctx, 10, resetSeqStmts, &sqlmanager_shared.BatchExecOpts{})
 					if err != nil {
 						// handle not found errors

--- a/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder.go
+++ b/worker/pkg/workflows/datasync/activities/run-sql-init-table-stmts/init-statement-builder.go
@@ -249,11 +249,13 @@ func (b *initStatementBuilder) RunSqlInitTableStatements(
 					for _, seq := range sequences {
 						resetSeqStmts = append(resetSeqStmts, sqlmanager_postgres.BuildPgResetSequenceSql(seq.Schema, seq.Name))
 					}
-					err = destdb.Db().BatchExec(ctx, 10, resetSeqStmts, &sqlmanager_shared.BatchExecOpts{})
-					if err != nil {
-						// handle not found errors
-						if !strings.Contains(err.Error(), `does not exist`) {
-							return nil, fmt.Errorf("unable to exec postgres sequence reset statements: %w", err)
+					if len(resetSeqStmts) > 0 {
+						err = destdb.Db().BatchExec(ctx, 10, resetSeqStmts, &sqlmanager_shared.BatchExecOpts{})
+						if err != nil {
+							// handle not found errors
+							if !strings.Contains(err.Error(), `does not exist`) {
+								return nil, fmt.Errorf("unable to exec postgres sequence reset statements: %w", err)
+							}
 						}
 					}
 				}


### PR DESCRIPTION
Since we create sequences first then tables in init schema the sequence names don't match the source db. Update postgres sequence reset to query destination instead of source for sequences to reset