### PR TITLE
adds in logic to handle abandoned child workflows in job run event history

### DIFF
--- a/backend/internal/dtomaps/job-runs.go
+++ b/backend/internal/dtomaps/job-runs.go
@@ -55,9 +55,9 @@ func GetJobIdFromWorkflow(logger *slog.Logger, searchAttributes *commonpb.Search
 
 func ToJobRunEventTaskDto(event *history.HistoryEvent, taskError *mgmtv1alpha1.JobRunEventTaskError) *mgmtv1alpha1.JobRunEventTask {
 	return &mgmtv1alpha1.JobRunEventTask{
-		Id:        event.EventId,
-		Type:      event.EventType.String(),
-		EventTime: event.EventTime,
+		Id:        event.GetEventId(),
+		Type:      event.GetEventType().String(),
+		EventTime: event.GetEventTime(),
 		Error:     taskError,
 	}
 }

--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -378,8 +378,9 @@ func (s *Service) getEventsByWorkflowId(ctx context.Context, accountId, workflow
 
 			switch info.GetStatus() {
 			case enums.WORKFLOW_EXECUTION_STATUS_COMPLETED:
+				highestEventId++
 				childEvent.Tasks = append(childEvent.Tasks, dtomaps.ToJobRunEventTaskDto(&history.HistoryEvent{
-					EventId:    childEvent.GetId() * 10,
+					EventId:    highestEventId,
 					EventTime:  info.GetCloseTime(),
 					EventType:  enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED,
 					Attributes: nil,
@@ -407,22 +408,25 @@ func (s *Service) getEventsByWorkflowId(ctx context.Context, accountId, workflow
 					Attributes: nil,
 				}, eventErr))
 			case enums.WORKFLOW_EXECUTION_STATUS_TIMED_OUT:
+				highestEventId++
 				childEvent.Tasks = append(childEvent.Tasks, dtomaps.ToJobRunEventTaskDto(&history.HistoryEvent{
-					EventId:    childEvent.GetId() * 10,
+					EventId:    highestEventId,
 					EventTime:  info.GetCloseTime(),
 					EventType:  enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT,
 					Attributes: nil,
 				}, nil))
 			case enums.WORKFLOW_EXECUTION_STATUS_CANCELED:
+				highestEventId++
 				childEvent.Tasks = append(childEvent.Tasks, dtomaps.ToJobRunEventTaskDto(&history.HistoryEvent{
-					EventId:    childEvent.GetId() * 10,
+					EventId:    highestEventId,
 					EventTime:  info.GetCloseTime(),
 					EventType:  enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED,
 					Attributes: nil,
 				}, nil))
 			case enums.WORKFLOW_EXECUTION_STATUS_TERMINATED:
+				highestEventId++
 				childEvent.Tasks = append(childEvent.Tasks, dtomaps.ToJobRunEventTaskDto(&history.HistoryEvent{
-					EventId:    childEvent.GetId() * 10,
+					EventId:    highestEventId,
 					EventTime:  info.GetCloseTime(),
 					EventType:  enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED,
 					Attributes: nil,

--- a/backend/services/mgmt/v1alpha1/job-service/runs.go
+++ b/backend/services/mgmt/v1alpha1/job-service/runs.go
@@ -26,6 +26,7 @@ import (
 	piidetect_table_activities "github.com/nucleuscloud/neosync/worker/pkg/workflows/ee/piidetect/workflows/table/activities"
 	tablesync_workflow "github.com/nucleuscloud/neosync/worker/pkg/workflows/tablesync/workflow"
 	"go.temporal.io/api/enums/v1"
+	"go.temporal.io/api/history/v1"
 	temporalclient "go.temporal.io/sdk/client"
 	"go.temporal.io/sdk/converter"
 	"google.golang.org/protobuf/types/known/timestamppb"
@@ -144,22 +145,36 @@ func (s *Service) GetJobRunEvents(
 
 	jobRun := jrResp.Msg.GetJobRun()
 
+	resp, err := s.getEventsByWorkflowId(ctx, req.Msg.GetAccountId(), jobRun.GetId(), logger)
+	if err != nil {
+		return nil, fmt.Errorf("unable to get events by workflow id: %w", err)
+	}
+
+	return connect.NewResponse(resp), nil
+}
+
+func (s *Service) getEventsByWorkflowId(ctx context.Context, accountId, workflowId string, logger *slog.Logger) (*mgmtv1alpha1.GetJobRunEventsResponse, error) {
 	isRunComplete := false
 	activityOrder := []int64{}
 	activityMap := map[int64]*mgmtv1alpha1.JobRunEvent{}
 	iter, err := s.temporalmgr.GetWorkflowHistory(
 		ctx,
-		req.Msg.GetAccountId(),
-		jobRun.GetId(),
+		accountId,
+		workflowId,
 		logger,
 	)
 	if err != nil {
-		return nil, err
+		return nil, fmt.Errorf("unable to get workflow history: %w", err)
 	}
+	childEvents := map[int64]string{} // eventId -> workflowId
+	highestEventId := int64(0)
 	for iter.HasNext() {
 		event, err := iter.Next()
 		if err != nil {
 			return nil, err
+		}
+		if event.GetEventId() > highestEventId {
+			highestEventId = event.GetEventId()
 		}
 
 		switch event.EventType {
@@ -243,6 +258,9 @@ func (s *Service) GetJobRunEvents(
 		case enums.EVENT_TYPE_START_CHILD_WORKFLOW_EXECUTION_INITIATED:
 			activityOrder = append(activityOrder, event.GetEventId())
 			attributes := event.GetStartChildWorkflowExecutionInitiatedEventAttributes()
+
+			childEvents[event.GetEventId()] = attributes.GetWorkflowId()
+
 			jobRunEvent := &mgmtv1alpha1.JobRunEvent{
 				Id:        event.EventId,
 				Type:      attributes.GetWorkflowType().GetName(),
@@ -330,16 +348,96 @@ func (s *Service) GetJobRunEvents(
 		}
 	}
 
+	if isRunComplete && len(childEvents) > 0 {
+		logger.Debug("checking if child workflows are complete")
+		for _, eventId := range activityOrder {
+			childWorkflowId, ok := childEvents[eventId]
+			if !ok {
+				continue
+			}
+
+			childEvent, ok := activityMap[eventId]
+			if !ok {
+				continue
+			}
+
+			if childEvent.GetCloseTime() != nil {
+				continue
+			}
+			logger.Debug("child workflow is not complete, checking if it is closed")
+			info, err := s.temporalmgr.GetWorkflowExecutionById(ctx, accountId, childWorkflowId, logger)
+			if err != nil {
+				logger.Warn(fmt.Sprintf("unable to get workflow execution info for %s: %s", childWorkflowId, err))
+				continue
+			}
+
+			if info.GetCloseTime() != nil {
+				logger.Debug("child workflow is closed, updating event")
+				childEvent.CloseTime = info.GetCloseTime()
+			}
+
+			switch info.GetStatus() {
+			case enums.WORKFLOW_EXECUTION_STATUS_COMPLETED:
+				childEvent.Tasks = append(childEvent.Tasks, dtomaps.ToJobRunEventTaskDto(&history.HistoryEvent{
+					EventId:    childEvent.GetId() * 10,
+					EventTime:  info.GetCloseTime(),
+					EventType:  enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_COMPLETED,
+					Attributes: nil,
+				}, nil))
+			case enums.WORKFLOW_EXECUTION_STATUS_FAILED:
+				resp, err := s.getEventsByWorkflowId(ctx, accountId, childWorkflowId, logger)
+				if err != nil {
+					logger.Warn(fmt.Sprintf("unable to get events by workflow id for %s: %s", childWorkflowId, err))
+					continue
+				}
+				var eventErr *mgmtv1alpha1.JobRunEventTaskError
+				for _, event := range resp.GetEvents() {
+					for _, task := range event.GetTasks() {
+						if task.GetError() != nil {
+							eventErr = task.GetError()
+							break
+						}
+					}
+				}
+				highestEventId++
+				childEvent.Tasks = append(childEvent.Tasks, dtomaps.ToJobRunEventTaskDto(&history.HistoryEvent{
+					EventId:    highestEventId,
+					EventTime:  info.GetCloseTime(),
+					EventType:  enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_FAILED,
+					Attributes: nil,
+				}, eventErr))
+			case enums.WORKFLOW_EXECUTION_STATUS_TIMED_OUT:
+				childEvent.Tasks = append(childEvent.Tasks, dtomaps.ToJobRunEventTaskDto(&history.HistoryEvent{
+					EventId:    childEvent.GetId() * 10,
+					EventTime:  info.GetCloseTime(),
+					EventType:  enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TIMED_OUT,
+					Attributes: nil,
+				}, nil))
+			case enums.WORKFLOW_EXECUTION_STATUS_CANCELED:
+				childEvent.Tasks = append(childEvent.Tasks, dtomaps.ToJobRunEventTaskDto(&history.HistoryEvent{
+					EventId:    childEvent.GetId() * 10,
+					EventTime:  info.GetCloseTime(),
+					EventType:  enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_CANCELED,
+					Attributes: nil,
+				}, nil))
+			case enums.WORKFLOW_EXECUTION_STATUS_TERMINATED:
+				childEvent.Tasks = append(childEvent.Tasks, dtomaps.ToJobRunEventTaskDto(&history.HistoryEvent{
+					EventId:    childEvent.GetId() * 10,
+					EventTime:  info.GetCloseTime(),
+					EventType:  enums.EVENT_TYPE_CHILD_WORKFLOW_EXECUTION_TERMINATED,
+					Attributes: nil,
+				}, nil))
+			}
+		}
+	}
+
 	events := []*mgmtv1alpha1.JobRunEvent{}
 	for _, index := range activityOrder {
 		value := activityMap[index]
 		events = append(events, value)
 	}
 
-	return connect.NewResponse(&mgmtv1alpha1.GetJobRunEventsResponse{
-		Events:        events,
-		IsRunComplete: isRunComplete,
-	}), nil
+	return &mgmtv1alpha1.GetJobRunEventsResponse{Events: events, IsRunComplete: isRunComplete}, nil
 }
 
 func (s *Service) CreateJobRun(

--- a/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/components/JobRunActivityTable.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/components/JobRunActivityTable.tsx
@@ -25,7 +25,7 @@ export default function JobRunActivityTable(
 
   return (
     <div className="flex flex-col gap-4">
-      <RunTimeline tasks={jobRunEvents} jobStatus={jobStatus} />
+      <RunTimeline jobRunEvents={jobRunEvents} jobStatus={jobStatus} />
       <div className="text-xl font-semibold">Activity Table</div>
       <DataTable
         columns={columns}

--- a/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/components/JobRunActivityTable/columns.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/runs/[id]/components/JobRunActivityTable/columns.tsx
@@ -72,19 +72,21 @@ export function getColumns(props: GetColumnsProps): ColumnDef<JobRunEvent>[] {
         <DataTableColumnHeader column={column} title="Completed" />
       ),
       cell: ({ row }) => {
-        const closeTime = row.original.tasks.find(
-          (item) =>
-            item.type === 'ActivityTaskCompleted' ||
-            item.type === 'ActivityTaskFailed' ||
-            item.type === 'ActivityTaskTerminated' ||
-            item.type === 'ActivityTaskCanceled' ||
-            item.type === 'ActivityTaskTimedOut' ||
-            item.type === 'ChildWorkflowExecutionCompleted' ||
-            item.type === 'ChildWorkflowExecutionFailed' ||
-            item.type === 'ChildWorkflowExecutionTerminated' ||
-            item.type === 'ChildWorkflowExecutionCanceled' ||
-            item.type === 'ChildWorkflowExecutionTimedOut'
-        )?.eventTime;
+        const closeTime =
+          row.original.closeTime ??
+          row.original.tasks.find(
+            (item) =>
+              item.type === 'ActivityTaskCompleted' ||
+              item.type === 'ActivityTaskFailed' ||
+              item.type === 'ActivityTaskTerminated' ||
+              item.type === 'ActivityTaskCanceled' ||
+              item.type === 'ActivityTaskTimedOut' ||
+              item.type === 'ChildWorkflowExecutionCompleted' ||
+              item.type === 'ChildWorkflowExecutionFailed' ||
+              item.type === 'ChildWorkflowExecutionTerminated' ||
+              item.type === 'ChildWorkflowExecutionCanceled' ||
+              item.type === 'ChildWorkflowExecutionTimedOut'
+          )?.eventTime;
 
         return (
           <div className="flex space-x-2">


### PR DESCRIPTION
<img width="1606" alt="image" src="https://github.com/user-attachments/assets/6bc8fe35-4bd2-4ade-8c36-edf607607815" />

For abandoned child workflows, this now handles retrieving the workflow history for that child to patch in synthetic event history for the main workflow.

This is only really useful right now for account hooks. But we could use it in the future to fully hydrate the child event history to surface all of it in the workflow.

Failed workflow now properly renders, even though it's a bit wonky:

<img width="1495" alt="image" src="https://github.com/user-attachments/assets/4559aee8-0bd2-4a67-a117-9874549d4222" />

<img width="1604" alt="image" src="https://github.com/user-attachments/assets/ba82390c-dc78-462a-b20d-4fe5bd10732c" />

