### PR TITLE
NEOS-1583: Adds ability to remove missing source columns from the mappings table

### DIFF
--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataGenConnectionCard.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataGenConnectionCard.tsx
@@ -570,6 +570,8 @@ export default function DataGenConnectionCard({ jobId }: Props): ReactElement {
           }}
           onApplyDefaultClick={onApplyDefaultClick}
           onTransformerBulkUpdate={onTransformerBulkUpdate}
+          hasMissingSourceColumnMappings={false}
+          onRemoveMissingSourceColumnMappings={() => {}}
         />
 
         {form.formState.errors.mappings && (

--- a/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataSyncConnectionCard.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/jobs/[id]/source/components/DataSyncConnectionCard.tsx
@@ -912,6 +912,8 @@ export default function DataSyncConnectionCard({ jobId }: Props): ReactElement {
               }}
               onApplyDefaultClick={onApplyDefaultClick}
               onTransformerBulkUpdate={onTransformerBulkUpdate}
+              hasMissingSourceColumnMappings={missingSourceColumns.length > 0}
+              onRemoveMissingSourceColumnMappings={onRemoveMissingSourceColumns}
             />
           )}
 

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/schema/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/generate/single/schema/page.tsx
@@ -448,6 +448,8 @@ export default function Page(props: PageProps): ReactElement {
               }}
               onApplyDefaultClick={onApplyDefaultClick}
               onTransformerBulkUpdate={onTransformerBulkUpdate}
+              hasMissingSourceColumnMappings={false}
+              onRemoveMissingSourceColumnMappings={() => {}}
             />
           )}
           {form.formState.errors.root && (

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
@@ -762,6 +762,8 @@ export default function Page(props: PageProps): ReactElement {
               }}
               onApplyDefaultClick={onApplyDefaultClick}
               onTransformerBulkUpdate={onTransformerBulkUpdate}
+              hasMissingSourceColumnMappings={false}
+              onRemoveMissingSourceColumnMappings={() => {}}
             />
           )}
           <div className="flex flex-row gap-1 justify-between">

--- a/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
+++ b/frontend/apps/web/app/(mgmt)/[account]/new/job/schema/page.tsx
@@ -717,6 +717,8 @@ export default function Page(props: PageProps): ReactElement {
               }}
               onApplyDefaultClick={onApplyDefaultClick}
               onTransformerBulkUpdate={onTransformerBulkUpdate}
+              hasMissingSourceColumnMappings={false}
+              onRemoveMissingSourceColumnMappings={() => {}}
             />
           )}
 

--- a/frontend/apps/web/components/jobs/JobMappingTable/JobMappingTable.tsx
+++ b/frontend/apps/web/components/jobs/JobMappingTable/JobMappingTable.tsx
@@ -47,6 +47,8 @@ interface Props<TData, TValue> {
   canRenameColumn(index: number, newColumn: string): boolean;
   onRowUpdate(index: number, newValue: TData): void;
   getAvailableCollectionsByRow(index: number): string[];
+  hasMissingSourceColumnMappings: boolean;
+  onRemoveMissingSourceColumnMappings(): void;
 }
 
 declare module '@tanstack/react-table' {
@@ -91,6 +93,8 @@ export default function JobMappingTable<TData, TValue>(
     canRenameColumn,
     onRowUpdate,
     getAvailableCollectionsByRow,
+    hasMissingSourceColumnMappings,
+    onRemoveMissingSourceColumnMappings,
   } = props;
 
   const table = useReactTable({
@@ -142,6 +146,10 @@ export default function JobMappingTable<TData, TValue>(
             )
           }
           onImportMappingsClick={onImportMappingsClick}
+          hasMissingSourceColumnMappings={hasMissingSourceColumnMappings}
+          onRemoveMissingSourceColumnMappings={
+            onRemoveMissingSourceColumnMappings
+          }
         />
       </div>
 

--- a/frontend/apps/web/components/jobs/NosqlTable/NosqlTable.tsx
+++ b/frontend/apps/web/components/jobs/NosqlTable/NosqlTable.tsx
@@ -67,6 +67,8 @@ interface Props {
     indices: number[],
     config: JobMappingTransformerForm
   ): void;
+  hasMissingSourceColumnMappings: boolean;
+  onRemoveMissingSourceColumnMappings(): void;
 }
 
 export default function NosqlTable(props: Props): ReactElement {
@@ -90,6 +92,8 @@ export default function NosqlTable(props: Props): ReactElement {
     getAvailableTransformersForBulk,
     getTransformerFromFieldValue,
     onTransformerBulkUpdate,
+    hasMissingSourceColumnMappings,
+    onRemoveMissingSourceColumnMappings,
   } = props;
   const { account } = useAccount();
   const { handler, isValidating } = useGetTransformersHandler(
@@ -239,6 +243,10 @@ export default function NosqlTable(props: Props): ReactElement {
           );
         }}
         getAvailableCollectionsByRow={getAvailableCollectionsByRow}
+        hasMissingSourceColumnMappings={hasMissingSourceColumnMappings}
+        onRemoveMissingSourceColumnMappings={
+          onRemoveMissingSourceColumnMappings
+        }
       />
     </div>
   );

--- a/frontend/apps/web/components/jobs/SchemaTable/SchemaTable.tsx
+++ b/frontend/apps/web/components/jobs/SchemaTable/SchemaTable.tsx
@@ -77,6 +77,8 @@ interface Props {
   ): TransformerResult;
   getTransformerFromFieldValue(value: JobMappingTransformerForm): Transformer;
   onApplyDefaultClick(override: boolean): void;
+  hasMissingSourceColumnMappings: boolean;
+  onRemoveMissingSourceColumnMappings(): void;
 }
 
 export function SchemaTable(props: Props): ReactElement {
@@ -101,6 +103,8 @@ export function SchemaTable(props: Props): ReactElement {
     getTransformerFromFieldValue,
     onApplyDefaultClick,
     onTransformerBulkUpdate,
+    hasMissingSourceColumnMappings,
+    onRemoveMissingSourceColumnMappings,
   } = props;
   const tableData = useMemo((): JobMappingRow[] => {
     return data.map((d): JobMappingRow => {
@@ -256,6 +260,10 @@ export function SchemaTable(props: Props): ReactElement {
                 console.warn('getAvailableCollections is not implemented');
                 return [];
               }}
+              hasMissingSourceColumnMappings={hasMissingSourceColumnMappings}
+              onRemoveMissingSourceColumnMappings={
+                onRemoveMissingSourceColumnMappings
+              }
             />
           </TabsContent>
           <TabsContent value="virtualforeignkeys">
@@ -298,6 +306,10 @@ export function SchemaTable(props: Props): ReactElement {
             console.warn('getAvailableCollections is not implemented');
             return [];
           }}
+          hasMissingSourceColumnMappings={hasMissingSourceColumnMappings}
+          onRemoveMissingSourceColumnMappings={
+            onRemoveMissingSourceColumnMappings
+          }
         />
       )}
     </div>
@@ -369,14 +381,14 @@ export function getAllFormErrors(
   const colWarnings = validationErrors.columnWarnings.map((e) => {
     return {
       path: `${e.schema}.${e.table}.${e.column}`,
-      message: e.warnings.join('. '),
+      message: e.warningReports.map((w) => w.message).join('. '),
       level: 'warning' as ErrorLevel,
     };
   });
-  const dbErr = validationErrors.databaseErrors?.errors.map((e) => {
+  const dbErr = validationErrors.databaseErrors?.errorReports.map((e) => {
     return {
       path: '',
-      message: e,
+      message: e.message,
       level: 'error' as ErrorLevel,
     };
   });

--- a/frontend/apps/web/components/jobs/SchemaTable/SchemaTableToolBar.tsx
+++ b/frontend/apps/web/components/jobs/SchemaTable/SchemaTableToolBar.tsx
@@ -47,6 +47,9 @@ interface DataTableToolbarProps<TData> {
   displayApplyDefaultTransformersButton: boolean;
   isApplyDefaultButtonDisabled: boolean;
   onApplyDefaultClick(override: boolean): void;
+
+  hasMissingSourceColumnMappings: boolean;
+  onRemoveMissingSourceColumnMappings(): void;
 }
 
 const DEFAULT_TRANSFORMER_BUTTON_TEXT = 'Bulk set transformers';
@@ -61,6 +64,8 @@ export function SchemaTableToolbar<TData>({
   displayApplyDefaultTransformersButton,
   isApplyDefaultButtonDisabled,
   onApplyDefaultClick,
+  hasMissingSourceColumnMappings,
+  onRemoveMissingSourceColumnMappings,
 }: DataTableToolbarProps<TData>) {
   const tableState = table.getState();
   const isFiltered = tableState.columnFilters.length > 0;
@@ -156,6 +161,16 @@ export function SchemaTableToolbar<TData>({
                 leftIcon={<Cross2Icon className="h-3 w-3" />}
                 text="Clear filters"
               />
+            </Button>
+          )}
+          {hasMissingSourceColumnMappings && (
+            <Button
+              variant="outline"
+              type="button"
+              disabled={!hasMissingSourceColumnMappings}
+              onClick={onRemoveMissingSourceColumnMappings}
+            >
+              <ButtonText text="Remove Missing Source Column Mappings" />
             </Button>
           )}
           {displayApplyDefaultTransformersButton && (


### PR DESCRIPTION
![2025-03-19 14 27 18](https://github.com/user-attachments/assets/2e05c352-dc31-4f97-83fa-b8a2a891f3ac)

Conditionally surfaces a button that pops all job mappings that are missing from the source form the table.
Currently only works for sync jobs on the edit page.