### PR TITLE
Fixes Postgres insert identity with OnConflict bug + fixes flaky postgres integration test

### DIFF
--- a/internal/integration-tests/worker/workflow/workflow-integration_test.go
+++ b/internal/integration-tests/worker/workflow/workflow-integration_test.go
@@ -112,7 +112,7 @@ func Test_Workflow(t *testing.T) {
 				t.Parallel()
 				test_postgres_schema_reconciliation(t, ctx, postgres, neosyncApi, dbManagers, accountId, sourceConn, destConn, true)
 			})
-			t.Run("no_truncate", func(t *testing.T) {
+			t.Run("retain_data", func(t *testing.T) {
 				t.Parallel()
 				test_postgres_schema_reconciliation(t, ctx, postgres, neosyncApi, dbManagers, accountId, sourceConn, destConn, false)
 			})

--- a/internal/testutil/testdata/postgres/schema-init/alter-job-mappings.go
+++ b/internal/testutil/testdata/postgres/schema-init/alter-job-mappings.go
@@ -24,8 +24,8 @@ func GetAlteredSyncJobMappings(schema string) []*mgmtv1alpha1.JobMapping {
 			Column: "region_number",
 			Transformer: &mgmtv1alpha1.JobMappingTransformer{
 				Config: &mgmtv1alpha1.TransformerConfig{
-					Config: &mgmtv1alpha1.TransformerConfig_GenerateDefaultConfig{
-						GenerateDefaultConfig: &mgmtv1alpha1.GenerateDefault{},
+					Config: &mgmtv1alpha1.TransformerConfig_PassthroughConfig{
+						PassthroughConfig: &mgmtv1alpha1.Passthrough{},
 					},
 				},
 			},


### PR DESCRIPTION
Not setting `OVERRIDING SYSTEM VALUE` when building postgres insert SQL with on conflict update set on a table with identity column was causing insert error