### PR TITLE
NEOS-1800: fixes transformer sorts, adds tooltip for multi sorting

### DIFF
--- a/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
+++ b/frontend/apps/web/components/jobs/JobMappingTable/Columns.tsx
@@ -234,6 +234,7 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, any>[] {
         );
       },
       filterFn: transformerFilterFn,
+      sortingFn: transformerSortingFn,
     }
   );
 
@@ -248,6 +249,16 @@ function getJobMappingColumns(): ColumnDef<JobMappingRow, any>[] {
     attributeColumn,
     transformerColumn,
   ];
+}
+
+function transformerSortingFn(
+  rowA: Row<JobMappingRow>,
+  rowB: Row<JobMappingRow>,
+  _columnId: string
+): number {
+  return rowA.original.transformer.config.case.localeCompare(
+    rowB.original.transformer.config.case
+  );
 }
 
 function transformerFilterFn(


### PR DESCRIPTION
![2025-03-28 11 10 33](https://github.com/user-attachments/assets/c69faa4f-0609-4924-becb-26a993bb045f)

- Fixes transformer sorting
- Fixes transformer not being resettable back to unsorted state
- Adds multi sort (this is mostly relevant for sorting by table or schema, then by column.) not much will really happen the further right you go down the table due to not having any duplicates the lower you go.

Closes #3423 